### PR TITLE
feat: implement issue #62

### DIFF
--- a/.claude.md
+++ b/.claude.md
@@ -1,0 +1,625 @@
+# SES Production Refactor Plan — Process → Tile → Workspace
+
+**Scope:** Move SES from "create process → land directly in workspace → files lost on reload" to "create process → tile dashboard → reusable workspace per function, with server-persisted uploads, auto-save drafts, and versioning."
+
+**Authoritative stack (do not assume otherwise):**
+- Frontend: React 18 + Vite + TypeScript, Zustand, React Query, react-router-dom v7
+- Backend: **NestJS 11** (not bare Express), Prisma 6, Postgres
+- File storage: **already Postgres BYTEA** via `WorkbookFile.content: Bytes`. The bug is hydration, not storage.
+- Shared: `@ses/domain` (pure TS audit engine / workbook parser)
+- Auth: cookie `ses_token` (HMAC), `AuthGuard` global, `@Public()` opt-out. Production SSO (Clerk/Cognito/OIDC) is future work — don't re-platform auth in this refactor.
+
+---
+
+## 1. 🏗 Architecture Plan
+
+### 1.1 Frontend (React)
+
+**Route restructure (breaking change, one-shot migration):**
+
+| Route | Purpose |
+|---|---|
+| `/` | Global process dashboard (list + create) |
+| `/processes/:processId` | **NEW** — tile dashboard for a single process |
+| `/processes/:processId/:functionId` | Reusable workspace (what `/workspace/:id` used to be) |
+| `/processes/:processId/:functionId/compare` | Version comparison, scoped to function |
+| `/login`, `/respond/:token` | unchanged |
+
+Legacy `/workspace/:id` → server-redirect to `/processes/:id/master-data` for one release, then remove.
+
+**Component tree:**
+
+```
+App
+├── DashboardPage            (all processes)
+├── ProcessTilesPage         (5 tiles + "Request New Function Audit")
+│   └── FunctionTile         (reusable card, driven by FUNCTION_REGISTRY)
+├── WorkspacePage            (dynamic via :functionId — reused across all 5 tiles)
+│   ├── FilesSidebar         (upload + file list, scoped by functionId)
+│   ├── PreviewTab
+│   ├── AuditResultsTab
+│   ├── VersionHistoryTab
+│   ├── NotificationsTab
+│   └── TrackingTab
+└── RequestFunctionAuditModal
+```
+
+**FUNCTION_REGISTRY** (static, frontend + shared in `@ses/domain`):
+
+```ts
+// packages/domain/src/functions/registry.ts
+export const FUNCTION_REGISTRY = [
+  { id: 'master-data',        label: 'Master Data',         order: 1 },
+  { id: 'over-planning',      label: 'Over Planning',       order: 2 },
+  { id: 'missing-plan',       label: 'Missing Plan',        order: 3 },
+  { id: 'function-rate',      label: 'Function Rate',       order: 4 },
+  { id: 'internal-cost-rate', label: 'Internal Cost Rate',  order: 5 },
+] as const;
+export type FunctionId = typeof FUNCTION_REGISTRY[number]['id'];
+```
+
+IDs are the primary key used end-to-end (URL, API, DB). No numeric FKs for functions — the registry is the source of truth, and `system_functions` is a mirror for referential integrity only.
+
+### 1.2 Backend (NestJS)
+
+- Add `FunctionsModule` that seeds `system_functions` from `FUNCTION_REGISTRY` on boot (idempotent).
+- Extend `ProcessesModule` with `GET /processes/:id/tiles` returning per-function counts (file count, last-upload, draft flag).
+- Extend `FilesModule` — every file-scoped endpoint takes `functionId` (path segment, not query). Existing flat `POST /processes/:id/files` stays for back-compat for one release but now requires `functionId` in the body.
+- New `DraftsModule` for auto-saved working state (separate from finalized `SavedVersion`).
+- All controllers stay behind global `AuthGuard`; add `@FunctionAccess()` method decorator that validates `processId` membership and (future) per-function ACL.
+
+### 1.3 Postgres / BYTEA Strategy
+
+**BYTEA is already in use — the work is schema partitioning, not storage replatform.**
+
+- Keep `WorkbookFile.content: Bytes` (BYTEA) — do **not** move to S3 in this refactor.
+- Add hard size limit (25 MB per file, enforced in multer + Nest validator) to prevent TOAST-table bloat.
+- Add `files.function_id` column (FK → `system_functions.id`) so queries are `WHERE process_id = $1 AND function_id = $2`.
+- Keep `content` on a dedicated table (`file_blobs`) and metadata on `files` — this is the **one** storage change: split so that `SELECT * FROM files` never pulls BYTEA unless joined. Prevents the current pattern of accidental full-row reads dragging BYTEA across the wire.
+- Add `file_versions` table (append-only; versions never overwrite).
+- Add `file_drafts` table (single row per `(user, process, function)`, BYTEA payload, `updated_at`) — ephemeral auto-save, distinct from `file_versions`.
+
+---
+
+## 2. 🧩 React Design
+
+### 2.1 ProcessTilesPage
+
+```tsx
+// apps/web/src/pages/ProcessTilesPage.tsx
+export function ProcessTilesPage() {
+  const { processId } = useParams();
+  const { data: tiles } = useQuery({
+    queryKey: ['process', processId, 'tiles'],
+    queryFn: () => api.getProcessTiles(processId!),
+  });
+  return (
+    <TileGrid>
+      {FUNCTION_REGISTRY.map(fn => (
+        <FunctionTile
+          key={fn.id}
+          functionId={fn.id}
+          label={fn.label}
+          stats={tiles?.[fn.id]}
+          onOpen={() => navigate(`/processes/${processId}/${fn.id}`)}
+        />
+      ))}
+      <RequestFunctionAuditTile onClick={openHelpdeskModal} />
+    </TileGrid>
+  );
+}
+```
+
+### 2.2 FunctionTile (reusable)
+
+- Receives `functionId`, `label`, `stats` ({ fileCount, lastUploadAt, hasDraft }).
+- Pure presentational. No data fetching inside.
+- Visual affordance for draft state ("Unsaved work" badge if `hasDraft`).
+
+### 2.3 WorkspacePage (dynamic via functionId)
+
+- Reads `{ processId, functionId }` from URL.
+- On mount: `useEffect → store.hydrateFunctionWorkspace(processId, functionId)`.
+- Same component used for all 5 tiles. **No `if (functionId === 'master-data')` branches** — function-specific behavior goes through `@ses/domain` policy, not UI code.
+
+### 2.4 File Upload Component
+
+- Reuse existing `FilesSidebar` but re-key by `functionId`.
+- Upload flow (see §4.3 for API contract):
+  1. User drops file → immediate `POST /processes/:id/functions/:fid/files` with multipart.
+  2. Server persists to `files` + `file_blobs` in a single transaction, returns `fileId + version=1`.
+  3. Client updates Zustand with server `fileId` (eliminating the temp-id→server-id cache bug documented in `CLAUDE.md` lines 46–48).
+  4. Raw bytes cached in IndexedDB keyed by **server** `fileId` for fast re-preview.
+
+### 2.5 State Management (Zustand)
+
+Slices (one store, multiple slices — not multiple stores):
+
+```
+useAppStore
+├── authSlice        { user, login, logout }
+├── processesSlice   { byId, activeProcessId, createProcess, hydrate }
+├── tilesSlice       { tilesByProcessId, hydrateTiles }
+├── workspaceSlice   { byKey: { [processId+functionId]: WorkspaceState }, hydrateFunctionWorkspace }
+├── uploadsSlice     { inFlight, optimistic entries }
+└── draftsSlice      { draftByKey, autoSave (debounced), restoreDraft }
+```
+
+**Keying rule:** every per-function piece of state is keyed on `${processId}:${functionId}`. Switching tiles is a pointer change, not a refetch storm — React Query handles freshness.
+
+---
+
+## 3. 🗃 PostgreSQL Schema (Prisma)
+
+### 3.1 New / modified tables
+
+```prisma
+// Mirror of FUNCTION_REGISTRY. System-defined. Not user-editable.
+model SystemFunction {
+  id          String   @id              // 'master-data', 'over-planning', ...
+  label       String
+  displayOrder Int
+  isSystem    Boolean  @default(true)   // always true; guard in service layer
+  createdAt   DateTime @default(now())
+
+  files       WorkbookFile[]
+  drafts      FileDraft[]
+  processMap  ProcessFunction[]
+}
+
+// Which functions a given process has enabled. All 5 by default; future:
+// business-level toggles or extra audit functions purchased per process.
+model ProcessFunction {
+  processId   String
+  functionId  String
+  enabled     Boolean  @default(true)
+  createdAt   DateTime @default(now())
+
+  process     Process  @relation(fields: [processId], references: [id], onDelete: Cascade)
+  function    SystemFunction @relation(fields: [functionId], references: [id])
+
+  @@id([processId, functionId])
+  @@index([processId])
+}
+
+model WorkbookFile {
+  id            String   @id @default(uuid())
+  displayCode   String   @unique
+  processId     String
+  functionId    String                         // NEW — scopes file to tile
+  uploadedById  String
+  name          String
+  sizeBytes     Int
+  contentSha256 String
+  mimeType      String
+  state         FileState @default(uploaded)   // uploaded | processing | completed | draft
+  currentVersion Int      @default(1)
+  uploadedAt    DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  archivedAt    DateTime?
+
+  process       Process  @relation(fields: [processId], references: [id], onDelete: Cascade)
+  function      SystemFunction @relation(fields: [functionId], references: [id])
+  uploader      User     @relation(fields: [uploadedById], references: [id])
+  blob          FileBlob?                      // 1:1 — BYTEA lives here
+  versions      FileVersion[]
+  sheets        WorkbookSheet[]
+
+  @@index([processId, functionId])             // the hot query
+  @@index([processId, functionId, state])
+  @@index([contentSha256])                     // dedupe detection
+}
+
+// BYTEA split out so metadata queries never drag the blob.
+model FileBlob {
+  fileId     String   @id
+  content    Bytes                             // BYTEA
+  createdAt  DateTime @default(now())
+  file       WorkbookFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
+}
+
+// Append-only. Never UPDATE an existing row.
+model FileVersion {
+  id            String   @id @default(uuid())
+  fileId        String
+  versionNumber Int
+  content       Bytes                          // snapshot BYTEA
+  contentSha256 String
+  sizeBytes     Int
+  createdById   String
+  createdAt     DateTime @default(now())
+  note          String?
+
+  file          WorkbookFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  createdBy     User @relation(fields: [createdById], references: [id])
+
+  @@unique([fileId, versionNumber])
+  @@index([fileId])
+}
+
+// One draft per (user, process, function). Auto-saved. Distinct from versions.
+model FileDraft {
+  id          String   @id @default(uuid())
+  userId      String
+  processId   String
+  functionId  String
+  fileName    String
+  content     Bytes
+  sizeBytes   Int
+  updatedAt   DateTime @updatedAt
+  createdAt   DateTime @default(now())
+
+  user        User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  process     Process @relation(fields: [processId], references: [id], onDelete: Cascade)
+  function    SystemFunction @relation(fields: [functionId], references: [id])
+
+  @@unique([userId, processId, functionId])
+  @@index([processId, functionId])
+}
+
+enum FileState {
+  uploaded
+  processing
+  completed
+  draft
+}
+```
+
+### 3.2 Indexes — why
+
+- `(processId, functionId)` on `WorkbookFile` — every workspace load hits this.
+- `(processId, functionId, state)` — tile counts query.
+- `contentSha256` — dedup + "did this user just re-upload the same file?" fast path.
+- `(userId, processId, functionId)` UNIQUE on `FileDraft` — enforces one draft per tile per user and powers upsert.
+
+### 3.3 Deletion rules
+
+- `SystemFunction` rows never deleted. Service layer rejects any mutation; Prisma migration never drops the seed.
+- `WorkbookFile.archivedAt` soft-delete. Hard delete only via admin job, cascades to `FileBlob` + `FileVersion`.
+- `FileDraft` purged on explicit promotion to version, or by a nightly job after 30 days of inactivity.
+
+---
+
+## 4. ⚙ Backend APIs
+
+All under `/api/v1`. All require auth except where noted.
+
+### 4.1 Processes
+
+| Method | Path | Body / Query | Returns |
+|---|---|---|---|
+| `POST` | `/processes` | `{ name, description }` | Process |
+| `GET` | `/processes` | — | Process[] |
+| `GET` | `/processes/:id` | — | Process |
+| `GET` | `/processes/:id/tiles` | — | `Record<FunctionId, { fileCount, lastUploadAt, hasDraft, lastVersion }>` |
+
+`GET /processes/:id/tiles` is the page-load query for `ProcessTilesPage`. Returns data for all 5 functions in one round-trip.
+
+### 4.2 Functions (read-only)
+
+| Method | Path | Returns |
+|---|---|---|
+| `GET` | `/functions` | `SystemFunction[]` (identical to FUNCTION_REGISTRY; FE uses registry, this is for admin/verification) |
+
+### 4.3 Files (scoped by function)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/processes/:pid/functions/:fid/files` | multipart `file` | Creates `WorkbookFile` + `FileBlob` + `FileVersion(v=1)` in one tx. Promotes matching `FileDraft` if any. |
+| `GET` | `/processes/:pid/functions/:fid/files` | — | Metadata only, no BYTEA. |
+| `GET` | `/files/:fileId` | — | Metadata + sheet list. |
+| `GET` | `/files/:fileId/download` | `?version=N` optional | Streams BYTEA. Validates ACL. |
+| `GET` | `/files/:fileId/preview` | — | Parsed sheet JSON (existing `WorkbookSheet.rows`). |
+| `DELETE` | `/files/:fileId` | — | Soft delete (sets `archivedAt`). |
+
+### 4.4 Versions (append-only)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/files/:fileId/versions` | `{ note?: string }` (file bytes optional — if omitted, snapshots current blob) | Creates `FileVersion` and bumps `WorkbookFile.currentVersion`. |
+| `GET` | `/files/:fileId/versions` | — | Version list (no bytes). |
+| `GET` | `/files/:fileId/versions/:n/download` | — | Streams that version's BYTEA. |
+
+### 4.5 Drafts (auto-save)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `PUT` | `/processes/:pid/functions/:fid/draft` | multipart `file` | Upsert single draft for `(currentUser, pid, fid)`. Called by client on blur / debounce / page-hide. |
+| `GET` | `/processes/:pid/functions/:fid/draft` | — | Metadata + small payload (<2 MB) or presign-like flag to hit download. |
+| `POST` | `/processes/:pid/functions/:fid/draft/promote` | `{ note? }` | Atomically: draft → new `WorkbookFile` (or new version of existing file) → delete draft. |
+| `DELETE` | `/processes/:pid/functions/:fid/draft` | — | Discard. |
+
+### 4.6 Function Audit Request (helpdesk stub)
+
+| Method | Path | Body |
+|---|---|---|
+| `POST` | `/processes/:pid/function-audit-requests` | `{ proposedName, description, contactEmail }` |
+
+Stub implementation: insert into `function_audit_requests` table + emit `notifications.send` (existing dummy transport). No scheduling logic.
+
+---
+
+## 5. 🔄 State Management Strategy
+
+### 5.1 Persistence tiers (fastest → slowest)
+
+1. **Zustand in-memory** — UI state, selected tab, scroll position. Lost on reload.
+2. **IndexedDB** (`idb-keyval`, already in use) — parsed sheet data keyed by **server** `fileId` for instant preview after reload. Evict after 7 days.
+3. **Postgres** — source of truth. Files, versions, drafts.
+
+### 5.2 Hydration flow
+
+```
+ProcessTilesPage mount
+  → useQuery(['process', id, 'tiles']) → GET /processes/:id/tiles
+  → ProcessTile renders immediately with counts
+
+User clicks tile → navigate(/processes/:id/:fid)
+  WorkspacePage mount
+    → store.hydrateFunctionWorkspace(processId, functionId)
+        ├─ GET /processes/:pid/functions/:fid/files
+        ├─ GET /processes/:pid/functions/:fid/draft  (if 404, no draft)
+        └─ for activeFileId: GET /files/:fileId/preview
+    → Zustand workspace slice populated
+    → IndexedDB cache checked for parsed sheets; fall back to API
+```
+
+### 5.3 Auto-save pipeline (client)
+
+- `draftsSlice.autoSave(processId, functionId, fileBytes)` — debounced 2s, also triggered on:
+  - `visibilitychange` → hidden
+  - `beforeunload`
+  - Route change out of `/processes/:id/:fid`
+- Uses `navigator.sendBeacon` for the unload path so the PUT completes.
+- Retry with exponential backoff on network failure; surface banner after 3 failures.
+- Promotion to `version` on explicit "Save version" click.
+
+### 5.4 The hydration-cache bug fix (CLAUDE.md §2)
+
+Root cause: client keys raw bytes under parser-generated temp id; server returns a different DB id; reload reads DB id and misses the cache.
+
+Fix: upload response includes `{ id, clientTempId }`. Client immediately renames the IndexedDB key from `clientTempId` → `id`. No subsequent lookup uses the temp id.
+
+---
+
+## 6. 🐞 Issue Breakdown
+
+### #1 — **CRITICAL** — Fix file-persistence hydration bug
+
+**Description:** After upload, files disappear on reload because the client caches raw bytes under a temp parser id while the server returns a DB id.
+**Acceptance criteria:**
+- Upload a file, hard-refresh, file is visible in sidebar.
+- Preview tab renders without re-upload.
+- IndexedDB key matches server `fileId` after upload completes.
+**Steps:**
+1. Change upload response to include both `id` and `clientTempId`.
+2. In `uploadsSlice`, rename IDB key post-response.
+3. Add `hydrateFunctionWorkspace` that fetches file list on route mount.
+4. Add vitest covering reload scenario.
+**Priority:** P0
+
+### #2 — **CRITICAL** — Introduce tile-based ProcessTilesPage
+
+**Description:** Replace direct-to-workspace navigation with tile dashboard.
+**Acceptance criteria:**
+- Creating a process lands on `/processes/:id` showing 5 tiles + helpdesk tile.
+- Each tile shows file count and last upload.
+- Clicking opens `/processes/:id/:functionId`.
+- Legacy `/workspace/:id` redirects to `master-data`.
+**Steps:**
+1. Add `FUNCTION_REGISTRY` to `@ses/domain`.
+2. Create `ProcessTilesPage`, `FunctionTile`, `RequestFunctionAuditTile`.
+3. Rewire `createProcess` navigation.
+4. Add `GET /processes/:id/tiles` endpoint.
+**Priority:** P0
+
+### #3 — **CRITICAL** — Add `functionId` scoping to files
+
+**Description:** All file operations must be scoped to a function.
+**Acceptance criteria:**
+- `WorkbookFile.functionId` column exists and is NOT NULL.
+- Existing files migrate to `master-data`.
+- Listing files in `over-planning` does not show `master-data` files.
+**Steps:**
+1. Prisma migration adding `functionId` with default `'master-data'`, then drop default.
+2. Seed `system_functions` + `process_functions`.
+3. Update controllers/services to require `functionId`.
+4. Update client API layer.
+**Priority:** P0
+
+### #4 — Split BYTEA into `file_blobs` table
+
+**Description:** Prevent accidental BYTEA reads on metadata queries.
+**Acceptance criteria:**
+- `WorkbookFile` no longer has `content` column.
+- `FileBlob` 1:1 table holds BYTEA.
+- Download endpoint works; list endpoints do not return bytes.
+- Postgres query log shows no BYTEA transfer on list queries.
+**Steps:**
+1. Create `FileBlob` table.
+2. Data migration: `INSERT INTO file_blobs SELECT id, content FROM files WHERE content IS NOT NULL`.
+3. Drop `files.content` in a subsequent migration (two-deploy safety).
+4. Update `FilesService` read/write paths.
+**Priority:** P1
+
+### #5 — Implement file versioning
+
+**Description:** Uploads create v1; re-uploads create v2, vN. Old versions never lost.
+**Acceptance criteria:**
+- Version history tab lists all versions with timestamp + author.
+- Download works per version.
+- Promoting a draft increments `currentVersion`.
+**Steps:**
+1. Add `FileVersion` model + migration.
+2. On upload / draft-promote, insert new version in same tx.
+3. Wire VersionHistoryTab to `GET /files/:id/versions`.
+**Priority:** P1
+
+### #6 — Implement auto-save drafts
+
+**Description:** Files persist before explicit save; survive navigation + reload.
+**Acceptance criteria:**
+- Uploading a file creates both a `WorkbookFile` and marks `hasDraft=false`; working edits create a `FileDraft`.
+- Navigating away + back restores draft.
+- "Save version" promotes draft to version.
+- `beforeunload` fires beacon PUT.
+**Steps:**
+1. Add `FileDraft` model.
+2. Add Draft endpoints.
+3. Add `draftsSlice` with debounce + beacon.
+4. Add restore banner on workspace mount if draft exists and differs from current version.
+**Priority:** P1
+
+### #7 — View + download features in workspace
+
+**Description:** Surface the existing `/download` API in the UI; add in-app preview pane.
+**Acceptance criteria:**
+- Each file row has View and Download buttons.
+- View opens PreviewTab with parsed sheet.
+- Download preserves original filename + extension.
+**Priority:** P2
+
+### #8 — "Request New Function Audit" helpdesk flow
+
+**Description:** Tile button opens modal; submit persists request and fires notification.
+**Acceptance criteria:**
+- Submission creates `function_audit_requests` row.
+- Dummy email sent via existing notifications module.
+- Success toast + modal closes.
+**Priority:** P2
+
+### #9 — Security hardening
+
+**Description:** Cover size limits, MIME validation, ACL.
+**Acceptance criteria:**
+- Upload >25 MB rejected with 413.
+- Non-xlsx/xlsm rejected with 415.
+- User without `ProcessMember` row for process cannot access any file endpoint.
+- Draft endpoints return only current user's draft.
+**Priority:** P1
+
+### #10 — Tests + regression safety net
+
+**Description:** Lock behavior before broader refactors.
+**Acceptance criteria:**
+- API: e2e covering upload → list → download → version → draft promote.
+- Web: vitest + React Testing Library for WorkspacePage hydration.
+- Manual QA checklist in `docs/QA.md`.
+**Priority:** P1
+
+---
+
+## 7. 🔐 Security
+
+- **Upload validation** (`apps/api/src/files/upload.pipe.ts`):
+  - `multer` memory storage with `limits.fileSize = 25 * 1024 * 1024`.
+  - MIME allowlist: `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `application/vnd.ms-excel.sheet.macroEnabled.12`.
+  - Magic-byte check via `file-type` — do not trust extension or client-provided MIME.
+- **ACL guard** (`FunctionAccessGuard`):
+  - On every `:pid`-scoped route: verify `ProcessMember(userId, processId)` exists.
+  - On every `:fileId` route: verify `file.processId` → membership.
+  - Drafts: always filtered by `userId = currentUser.id`.
+- **Auth:** keep existing cookie `ses_token` + `AuthGuard`. Plan a follow-up migration to OIDC (Clerk/Cognito). Do **not** bundle that with this refactor — it compounds risk.
+- **Rate limiting:** add `@nestjs/throttler` — 20 uploads/min/user, 120 draft PUTs/min/user (drafts are debounced, so 120 is a wide safety margin).
+- **Audit logging:** log `fileId`, `userId`, `action` to existing tracking table for every upload/download/delete/version event.
+
+---
+
+## 8. ♻ Code Quality & Patterns
+
+**Folder structure (target):**
+
+```
+apps/web/src/
+  pages/
+    DashboardPage.tsx
+    ProcessTilesPage.tsx
+    WorkspacePage.tsx
+    LoginPage.tsx
+  features/
+    tiles/            FunctionTile, RequestFunctionAuditTile
+    workspace/        FilesSidebar, Preview, Audit, Versions
+    drafts/           useAutoSave hook
+  store/              auth, processes, tiles, workspace, uploads, drafts slices
+  lib/
+    api/              generated or handwritten client, one file per module
+    idb/              typed wrappers around idb-keyval
+
+apps/api/src/
+  processes/
+  functions/          new module, read-only
+  files/              controller + service + pipes + guards
+  drafts/             new module
+  versions/           new module
+  common/             FunctionAccessGuard, UploadValidationPipe
+```
+
+**DRY rules:**
+
+- One `useFunctionWorkspace(processId, functionId)` hook used by WorkspacePage and every tab — tabs never fetch independently.
+- `FilesService` exposes `list`, `get`, `upload`, `createVersion`, `promoteDraft`. Controllers are thin — ≤15 lines per handler.
+- No per-function branches in UI. If Master Data and Over Planning need different validation, it lives in `@ses/domain/policy/<functionId>.ts` and is loaded by id.
+- Service-layer abstraction: `FilesRepository` (Prisma wrapper) is the only code that touches `prisma.workbookFile` — makes the BYTEA split in Issue #4 a one-file change.
+
+**Forbidden:**
+
+- Duplicated upload logic in tiles.
+- Direct `prisma.$queryRaw` outside repositories.
+- `any` types on file payloads.
+
+---
+
+## 9. 🚀 DevOps
+
+- **Docker:** the existing `docker-compose.yml` + `Dockerfile` stay. Add a `postgres-init.sql` step that `CREATE EXTENSION IF NOT EXISTS pg_trgm` (future search) and ensures `shared_buffers` tuned for BYTEA workload. Note in `README.md` that 25 MB × N files = sizing constraint.
+- **CI (GitHub Actions):**
+  ```yaml
+  jobs:
+    test:
+      - npm ci
+      - npx prisma migrate deploy (against ephemeral pg:16 service)
+      - npm run -w @ses/api test
+      - npm run -w @ses/web test
+      - npm run -w @ses/domain test
+    build:
+      - npm run build (all workspaces)
+    lint:
+      - npm run lint
+  ```
+- **Migration strategy:**
+  - Prisma migrations only. No manual SQL outside `prisma/migrations/`.
+  - Every migration must be backward-compatible for one release (expand → deploy → contract). E.g., adding `functionId`: step 1 nullable with default, step 2 backfill, step 3 `NOT NULL`, step 4 drop default.
+  - Splitting BYTEA (Issue #4) follows the same expand/contract — write to both, read from new, stop reading from old, drop old.
+- **Rollback plan:** every migration has `down.sql`. Feature flag `FEATURE_TILES_DASHBOARD=false` shows legacy `/workspace/:id` as an escape hatch during rollout.
+
+---
+
+## 10. 📌 Migration Plan
+
+**Goal:** zero data loss, no user-visible breakage longer than one deploy window.
+
+| Phase | What ships | Risk gate |
+|---|---|---|
+| **P0 — prep** | `FUNCTION_REGISTRY` in `@ses/domain`; `SystemFunction` + `ProcessFunction` tables seeded; no UI change | Seed runs on all envs, verified in staging |
+| **P1 — scope files** | `files.function_id` nullable, backfilled to `'master-data'`, then `NOT NULL`; API accepts `functionId` optionally | No user flow change; existing clients keep working |
+| **P2 — tile UI behind flag** | `ProcessTilesPage` behind `FEATURE_TILES_DASHBOARD`; new routes active; old `/workspace/:id` still works | QA signoff on dogfood env |
+| **P3 — hydration fix + drafts + versions** | Issues #1, #5, #6 | Targeted regression tests pass |
+| **P4 — BYTEA split** | `FileBlob` table, dual-write, cut reads over | Monitor Postgres IO for a week |
+| **P5 — flag flip** | `FEATURE_TILES_DASHBOARD=true` in prod; legacy route redirects | Error rate unchanged for 48h |
+| **P6 — cleanup** | Drop `files.content` column; remove legacy route; remove flag | Final migration |
+
+**Hard rules during migration:**
+
+- Never delete a table or column in the same release that stops reading from it.
+- Every Prisma migration runs in CI against a fresh DB and against a snapshot of prod schema.
+- Any migration that touches BYTEA must be `CONCURRENTLY` where possible and run off-peak.
+
+---
+
+## ⚠ Constraints recap
+
+- Do not introduce S3 in this refactor. BYTEA is the decision; size cap enforces boundary.
+- Do not re-platform auth in this refactor.
+- Do not fork the Workspace component per function; policy-driven only.
+- Every tile's data path is identical; diffs live in `@ses/domain`, not UI.
+- Prisma is the only schema authority. No raw DDL.

--- a/apps/api/prisma/migrations/20260421120000_issue62_system_functions/migration.sql
+++ b/apps/api/prisma/migrations/20260421120000_issue62_system_functions/migration.sql
@@ -1,0 +1,79 @@
+-- Issue #62: system-defined function registry + process mapping + file scoping
+-- Expand/contract safe: `functionId` is added with a default so existing rows
+-- backfill to 'master-data' without requiring app changes first.
+
+-- CreateTable: SystemFunction
+CREATE TABLE "SystemFunction" (
+    "id" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "displayOrder" INTEGER NOT NULL,
+    "isSystem" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SystemFunction_pkey" PRIMARY KEY ("id")
+);
+
+-- Seed the 5 system functions. Idempotent via ON CONFLICT — the app also
+-- seeds on boot so schema changes here do not drift from the registry.
+INSERT INTO "SystemFunction" ("id", "label", "displayOrder", "isSystem", "createdAt", "updatedAt") VALUES
+    ('master-data',        'Master Data',         1, true, NOW(), NOW()),
+    ('over-planning',      'Over Planning',       2, true, NOW(), NOW()),
+    ('missing-plan',       'Missing Plan',        3, true, NOW(), NOW()),
+    ('function-rate',      'Function Rate',       4, true, NOW(), NOW()),
+    ('internal-cost-rate', 'Internal Cost Rate',  5, true, NOW(), NOW())
+ON CONFLICT ("id") DO NOTHING;
+
+-- CreateTable: ProcessFunction
+CREATE TABLE "ProcessFunction" (
+    "processId" TEXT NOT NULL,
+    "functionId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProcessFunction_pkey" PRIMARY KEY ("processId", "functionId")
+);
+
+CREATE INDEX "ProcessFunction_processId_idx" ON "ProcessFunction"("processId");
+
+-- Seed all 5 functions for every existing process so old UIs continue to work.
+INSERT INTO "ProcessFunction" ("processId", "functionId", "enabled", "createdAt", "updatedAt")
+SELECT p."id", f."id", true, NOW(), NOW()
+FROM "Process" p
+CROSS JOIN "SystemFunction" f
+ON CONFLICT ("processId", "functionId") DO NOTHING;
+
+-- CreateTable: FunctionAuditRequest
+CREATE TABLE "FunctionAuditRequest" (
+    "id" TEXT NOT NULL,
+    "displayCode" TEXT NOT NULL,
+    "processId" TEXT NOT NULL,
+    "requestedById" TEXT NOT NULL,
+    "proposedName" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "contactEmail" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FunctionAuditRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FunctionAuditRequest_displayCode_key" ON "FunctionAuditRequest"("displayCode");
+CREATE INDEX "FunctionAuditRequest_processId_createdAt_idx" ON "FunctionAuditRequest"("processId", "createdAt");
+
+-- AlterTable: WorkbookFile.functionId
+ALTER TABLE "WorkbookFile" ADD COLUMN "functionId" TEXT NOT NULL DEFAULT 'master-data';
+CREATE INDEX "WorkbookFile_processId_functionId_idx" ON "WorkbookFile"("processId", "functionId");
+
+-- Foreign keys
+ALTER TABLE "ProcessFunction" ADD CONSTRAINT "ProcessFunction_processId_fkey"
+    FOREIGN KEY ("processId") REFERENCES "Process"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProcessFunction" ADD CONSTRAINT "ProcessFunction_functionId_fkey"
+    FOREIGN KEY ("functionId") REFERENCES "SystemFunction"("id") ON UPDATE CASCADE;
+
+ALTER TABLE "FunctionAuditRequest" ADD CONSTRAINT "FunctionAuditRequest_processId_fkey"
+    FOREIGN KEY ("processId") REFERENCES "Process"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "WorkbookFile" ADD CONSTRAINT "WorkbookFile_functionId_fkey"
+    FOREIGN KEY ("functionId") REFERENCES "SystemFunction"("id") ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,6 +83,57 @@ model Process {
   liveSessions      LiveSession[]
   signedLinks       SignedLink[]
   notificationLogs  NotificationLog[]
+  processFunctions  ProcessFunction[]
+  auditRequests     FunctionAuditRequest[]
+}
+
+/// System-defined, non-deletable function registry.
+/// Seeded from `FUNCTION_REGISTRY` in `@ses/domain` on every boot.
+/// Every WorkbookFile belongs to exactly one SystemFunction.
+model SystemFunction {
+  id           String   @id
+  label        String
+  displayOrder Int
+  isSystem     Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  processMap   ProcessFunction[]
+  files        WorkbookFile[]
+}
+
+/// Enablement row per (process, function). Every new Process is seeded
+/// with every SystemFunction at `enabled = true`.
+model ProcessFunction {
+  processId  String
+  functionId String
+  enabled    Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  process   Process        @relation(fields: [processId], references: [id], onDelete: Cascade)
+  function  SystemFunction @relation(fields: [functionId], references: [id])
+
+  @@id([processId, functionId])
+  @@index([processId])
+}
+
+/// Helpdesk-style request to open a brand-new function audit. Stub today —
+/// writes a row and fires the existing notifications transport.
+model FunctionAuditRequest {
+  id            String   @id
+  displayCode   String   @unique
+  processId     String
+  requestedById String
+  proposedName  String
+  description   String   @default("")
+  contactEmail  String
+  status        String   @default("open")
+  createdAt     DateTime @default(now())
+
+  process       Process  @relation(fields: [processId], references: [id], onDelete: Cascade)
+
+  @@index([processId, createdAt])
 }
 
 model ProcessMember {
@@ -103,6 +154,9 @@ model WorkbookFile {
   id            String         @id
   displayCode   String         @unique
   processId     String
+  /// Scopes the file to one of the 5 system functions (master-data, over-planning, etc).
+  /// Added in issue #62. Backfilled to 'master-data' for existing rows.
+  functionId    String         @default("master-data")
   name          String
   sizeBytes     Int
   contentSha256 Bytes
@@ -115,11 +169,13 @@ model WorkbookFile {
   lastAuditedAt DateTime?
   rowVersion    Int            @default(1)
   process       Process        @relation(fields: [processId], references: [id], onDelete: Cascade)
+  function      SystemFunction @relation(fields: [functionId], references: [id])
   uploadedBy    User           @relation("WorkbookUploadedBy", fields: [uploadedById], references: [id])
   sheets        WorkbookSheet[]
   auditRuns     AuditRun[]
 
   @@index([processId])
+  @@index([processId, functionId])
 }
 
 model WorkbookSheet {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { ActivityLogService } from './common/activity-log.service';
+import { FunctionAccessGuard } from './common/function-access.guard';
 import { IdentifierService } from './common/identifier.service';
 import { ProcessAccessService } from './common/process-access.service';
 import { PrismaService } from './common/prisma.service';
@@ -15,6 +16,8 @@ import { ExportsController } from './exports.controller';
 import { ExportsService } from './exports.service';
 import { FilesController } from './files.controller';
 import { FilesService } from './files.service';
+import { FunctionsController } from './functions.controller';
+import { FunctionsService } from './functions.service';
 import { IssuesController } from './issues.controller';
 import { IssuesService } from './issues.service';
 import { JobsController } from './jobs.controller';
@@ -55,6 +58,7 @@ import { NotificationsService } from './notifications/notifications.service';
     HealthController,
     AuthController,
     RulesController,
+    FunctionsController,
     ProcessesController,
     ProcessActivityController,
     FilesController,
@@ -78,6 +82,8 @@ import { NotificationsService } from './notifications/notifications.service';
     ActivityLogService,
     AuthService,
     AuthGuard,
+    FunctionsService,
+    FunctionAccessGuard,
     RulesService,
     ProcessesService,
     FilesService,
@@ -102,6 +108,8 @@ import { NotificationsService } from './notifications/notifications.service';
     ActivityLogService,
     AuthService,
     AuthGuard,
+    FunctionsService,
+    FunctionAccessGuard,
     RealtimeGateway,
     PresenceRegistry,
   ],

--- a/apps/api/src/common/function-access.guard.ts
+++ b/apps/api/src/common/function-access.guard.ts
@@ -1,0 +1,70 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { isFunctionId } from '@ses/domain';
+import { FunctionsService } from '../functions.service';
+import { PrismaService } from './prisma.service';
+import { ProcessAccessService } from './process-access.service';
+
+/**
+ * Layered access check for every function-scoped route.
+ *
+ * Responsibilities (in order):
+ *   1. Require an authenticated user (the global AuthGuard has already
+ *      populated `request.user`; we re-check in case this guard is used
+ *      on a route without AuthGuard).
+ *   2. If the route has `:idOrCode` / `:processIdOrCode`, resolve it to a
+ *      Process and assert the user is a member (or admin).
+ *   3. If the route has `:functionId`, assert it's a valid registry id
+ *      AND that `ProcessFunction.enabled` is true for this (process, function)
+ *      pair. This blocks trying to reach a disabled or unknown function.
+ *
+ * Attach via `@UseGuards(AuthGuard, FunctionAccessGuard)` on the relevant
+ * controllers. The guard is intentionally resilient — routes without the
+ * scoped params simply skip those checks and return true.
+ */
+@Injectable()
+export class FunctionAccessGuard implements CanActivate {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly functions: FunctionsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    if (!user) {
+      throw new ForbiddenException('Authentication required');
+    }
+
+    const params: Record<string, string | undefined> = request.params ?? {};
+    const processParam = params.idOrCode ?? params.processIdOrCode ?? params.pid;
+    if (processParam) {
+      // Resolves + asserts membership. Throws 404 if not accessible.
+      await this.processAccess.findAccessibleProcessOrThrow(user, processParam, 'viewer');
+    }
+
+    const fid = params.functionId ?? params.fid;
+    if (fid) {
+      if (!isFunctionId(fid)) {
+        throw new NotFoundException(`Unknown function ${fid}`);
+      }
+      // Only enforce ProcessFunction.enabled when we also have a process scope.
+      // If the route is function-only (no process), the registry check above
+      // is sufficient.
+      if (processParam) {
+        const process = await this.prisma.process.findFirst({
+          where: { OR: [{ id: processParam }, { displayCode: processParam }] },
+          select: { id: true },
+        });
+        if (process) {
+          const enabled = await this.functions.isEnabled(process.id, fid);
+          if (!enabled) {
+            throw new ForbiddenException(`Function ${fid} is not enabled for this process`);
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/dto/processes.dto.ts
+++ b/apps/api/src/dto/processes.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsDateString, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsBoolean, IsDateString, IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class CreateProcessDto {
   @IsString()
@@ -37,4 +37,20 @@ export class UpdateSheetSelectionDto {
   @IsOptional()
   @IsBoolean()
   isSelected?: boolean;
+}
+
+export class CreateFunctionAuditRequestDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  proposedName!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(4_000)
+  description?: string;
+
+  @IsEmail()
+  @MaxLength(320)
+  contactEmail!: string;
 }

--- a/apps/api/src/files.controller.ts
+++ b/apps/api/src/files.controller.ts
@@ -1,28 +1,77 @@
-import { Body, Controller, Delete, Get, Headers, Param, Patch, Post, Query, Res, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Delete, Get, Headers, Param, Patch, Post, Query, Res, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
-import type { SessionUser } from '@ses/domain';
-import { MAX_WORKBOOK_FILE_SIZE_BYTES } from '@ses/domain';
+import type { FunctionId, SessionUser } from '@ses/domain';
+import { DEFAULT_FUNCTION_ID, isFunctionId, MAX_WORKBOOK_FILE_SIZE_BYTES } from '@ses/domain';
 import { memoryStorage } from 'multer';
 import { AuthGuard } from './auth.guard';
 import { CurrentUser } from './common/current-user';
+import { FunctionAccessGuard } from './common/function-access.guard';
 import { attachmentContentDisposition, parseIfMatch } from './common/http';
 import { UpdateSheetSelectionDto } from './dto/processes.dto';
 import { FilesService } from './files.service';
+
+function requireFunctionId(raw: string): FunctionId {
+  if (!isFunctionId(raw)) throw new BadRequestException(`Unknown function ${raw}`);
+  return raw;
+}
 
 @Controller()
 @UseGuards(AuthGuard)
 export class FilesController {
   constructor(private readonly filesService: FilesService) {}
 
+  // ----- Function-scoped routes (new in #62). These are the preferred surface
+  // for the tile workspace; every read/write is scoped by (processId, functionId).
+
+  @Get('processes/:idOrCode/functions/:functionId/files')
+  @UseGuards(FunctionAccessGuard)
+  listScoped(
+    @Param('idOrCode') idOrCode: string,
+    @Param('functionId') functionId: string,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.filesService.list(idOrCode, user, requireFunctionId(functionId));
+  }
+
+  @Post('processes/:idOrCode/functions/:functionId/files')
+  @UseGuards(FunctionAccessGuard)
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: MAX_WORKBOOK_FILE_SIZE_BYTES },
+    }),
+  )
+  uploadScoped(
+    @Param('idOrCode') idOrCode: string,
+    @Param('functionId') functionId: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body('clientTempId') clientTempId: string | undefined,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.filesService.upload(idOrCode, file, user, {
+      functionId: requireFunctionId(functionId),
+      clientTempId,
+    });
+  }
+
+  // ----- Legacy flat routes (pre-#62). Kept for one release; default to
+  // master-data when functionId is not supplied in the body (deprecation shim).
+
   @Get('processes/:idOrCode/files')
-  list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
-    return this.filesService.list(idOrCode, user);
+  list(
+    @Param('idOrCode') idOrCode: string,
+    @Query('functionId') functionId: string | undefined,
+    @CurrentUser() user: SessionUser,
+  ) {
+    const fid = functionId ? requireFunctionId(functionId) : undefined;
+    return this.filesService.list(idOrCode, user, fid);
   }
 
   @Post('processes/:idOrCode/files')
-  @Throttle({ default: { limit: 40, ttl: 3_600_000 } })
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
   @UseInterceptors(
     FileInterceptor('file', {
       storage: memoryStorage(),
@@ -32,9 +81,12 @@ export class FilesController {
   upload(
     @Param('idOrCode') idOrCode: string,
     @UploadedFile() file: Express.Multer.File,
+    @Body('functionId') functionId: string | undefined,
+    @Body('clientTempId') clientTempId: string | undefined,
     @CurrentUser() user: SessionUser,
   ) {
-    return this.filesService.upload(idOrCode, file, user);
+    const fid = functionId ? requireFunctionId(functionId) : DEFAULT_FUNCTION_ID;
+    return this.filesService.upload(idOrCode, file, user, { functionId: fid, clientTempId });
   }
 
   @Get('files/:idOrCode')

--- a/apps/api/src/files.service.ts
+++ b/apps/api/src/files.service.ts
@@ -1,8 +1,8 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import type { Prisma } from '@prisma/client';
 import { createHash } from 'node:crypto';
-import type { SessionUser } from '@ses/domain';
-import { createId } from '@ses/domain';
+import type { FunctionId, SessionUser } from '@ses/domain';
+import { createId, DEFAULT_FUNCTION_ID } from '@ses/domain';
 import { parseWorkbookBuffer } from '@ses/domain';
 import { PrismaService } from './common/prisma.service';
 import { ActivityLogService } from './common/activity-log.service';
@@ -40,6 +40,7 @@ function serializeFile(file: {
   id: string;
   displayCode: string;
   processId: string;
+  functionId?: string | null;
   rowVersion: number;
   name: string;
   sizeBytes: number;
@@ -63,6 +64,7 @@ function serializeFile(file: {
     id: file.id,
     displayCode: file.displayCode,
     processId: file.processId,
+    functionId: (file.functionId ?? DEFAULT_FUNCTION_ID) as FunctionId,
     rowVersion: file.rowVersion,
     name: file.name,
     sizeBytes: file.sizeBytes,
@@ -97,17 +99,22 @@ export class FilesService {
     return file;
   }
 
-  async list(processIdOrCode: string, user: SessionUser) {
+  async list(processIdOrCode: string, user: SessionUser, functionId?: FunctionId) {
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode);
     const files = await this.prisma.workbookFile.findMany({
-      where: { processId: process.id },
+      where: functionId ? { processId: process.id, functionId } : { processId: process.id },
       orderBy: { uploadedAt: 'desc' },
       include: { sheets: { orderBy: { sheetName: 'asc' } } },
     });
     return files.map(serializeFile);
   }
 
-  async upload(processIdOrCode: string, file: Express.Multer.File, user: SessionUser) {
+  async upload(
+    processIdOrCode: string,
+    file: Express.Multer.File,
+    user: SessionUser,
+    options: { functionId: FunctionId; clientTempId?: string },
+  ) {
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'editor');
     const buffer = assertWorkbookUpload(file);
     let workbook;
@@ -126,6 +133,7 @@ export class FilesService {
           id: createId(),
           displayCode: fileCode,
           processId: process.id,
+          functionId: options.functionId,
           name: workbook.name,
           sizeBytes: buffer.byteLength,
           contentSha256,
@@ -165,7 +173,12 @@ export class FilesService {
         entityId: created.id,
         entityCode: created.displayCode,
         action: 'file.uploaded',
-        after: { name: created.name, sizeBytes: created.sizeBytes, processCode: process.displayCode },
+        after: {
+          name: created.name,
+          sizeBytes: created.sizeBytes,
+          processCode: process.displayCode,
+          functionId: options.functionId,
+        },
       });
 
       const withSheets = await tx.workbookFile.findUniqueOrThrow({
@@ -179,11 +192,15 @@ export class FilesService {
     this.realtime.emitToProcess(process.displayCode, 'file.uploaded', {
       fileCode: uploaded.displayCode,
       fileId: uploaded.id,
+      functionId: uploaded.functionId,
       name: uploaded.name,
       sizeBytes: uploaded.sizeBytes,
     }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
 
-    return uploaded;
+    // Include the client-provided temp id so the frontend can rekey its
+    // IndexedDB cache from the temp id to the server id — fixes the
+    // "files disappear after reload" hydration bug (issue #63 §Acceptance).
+    return { ...uploaded, clientTempId: options.clientTempId ?? null };
   }
 
   async get(idOrCode: string, user: SessionUser) {

--- a/apps/api/src/functions.controller.ts
+++ b/apps/api/src/functions.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+import { FunctionsService } from './functions.service';
+
+@Controller('functions')
+@UseGuards(AuthGuard)
+export class FunctionsController {
+  constructor(private readonly functions: FunctionsService) {}
+
+  @Get()
+  list() {
+    return this.functions.list();
+  }
+}

--- a/apps/api/src/functions.service.ts
+++ b/apps/api/src/functions.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { FUNCTION_REGISTRY, type FunctionId } from '@ses/domain';
+import { PrismaService } from './common/prisma.service';
+
+/**
+ * System-function registry bridge.
+ *
+ * Responsibilities:
+ *   - On boot: upsert every entry from `FUNCTION_REGISTRY` into `SystemFunction`
+ *     so DB and domain registry stay in lockstep across deploys.
+ *   - Read-only access: `list()` returns the registry for the `GET /functions`
+ *     endpoint (used by admin screens + client verification).
+ *   - `ensureProcessFunctions()`: seed `ProcessFunction` rows for a given
+ *     process so every tile is enabled by default.
+ *
+ * Mutation is not supported — functions are system-defined. Any future need
+ * to toggle a per-process function goes through `ProcessFunction.enabled`.
+ */
+@Injectable()
+export class FunctionsService implements OnModuleInit {
+  private readonly logger = new Logger(FunctionsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.seed();
+  }
+
+  /** Idempotent upsert of the registry. Safe to call on every boot. */
+  async seed(): Promise<void> {
+    for (const fn of FUNCTION_REGISTRY) {
+      await this.prisma.systemFunction.upsert({
+        where: { id: fn.id },
+        create: { id: fn.id, label: fn.label, displayOrder: fn.displayOrder, isSystem: true },
+        update: { label: fn.label, displayOrder: fn.displayOrder, isSystem: true },
+      });
+    }
+    this.logger.log(`Seeded ${FUNCTION_REGISTRY.length} system functions`);
+  }
+
+  list() {
+    return FUNCTION_REGISTRY.map((fn) => ({ ...fn }));
+  }
+
+  async ensureProcessFunctions(processId: string): Promise<void> {
+    for (const fn of FUNCTION_REGISTRY) {
+      await this.prisma.processFunction.upsert({
+        where: { processId_functionId: { processId, functionId: fn.id } },
+        create: { processId, functionId: fn.id, enabled: true },
+        update: {},
+      });
+    }
+  }
+
+  async isEnabled(processId: string, functionId: FunctionId | string): Promise<boolean> {
+    const row = await this.prisma.processFunction.findUnique({
+      where: { processId_functionId: { processId, functionId } },
+    });
+    return Boolean(row?.enabled);
+  }
+}

--- a/apps/api/src/processes.controller.ts
+++ b/apps/api/src/processes.controller.ts
@@ -3,7 +3,7 @@ import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from './auth.guard';
 import { CurrentUser } from './common/current-user';
 import { parseIfMatch } from './common/http';
-import { CreateProcessDto, UpdateProcessDto } from './dto/processes.dto';
+import { CreateFunctionAuditRequestDto, CreateProcessDto, UpdateProcessDto } from './dto/processes.dto';
 import { ProcessesService } from './processes.service';
 
 @Controller('processes')
@@ -54,6 +54,20 @@ export class ProcessesController {
     @CurrentUser() user: SessionUser,
   ) {
     return this.processesService.updatePolicy(idOrCode, parseIfMatch(ifMatch), body, user);
+  }
+
+  @Get(':idOrCode/tiles')
+  tiles(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    return this.processesService.tiles(idOrCode, user);
+  }
+
+  @Post(':idOrCode/function-audit-requests')
+  requestFunctionAudit(
+    @Param('idOrCode') idOrCode: string,
+    @Body() body: CreateFunctionAuditRequestDto,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.processesService.createFunctionAuditRequest(idOrCode, body, user);
   }
 
   @Get(':idOrCode/members')

--- a/apps/api/src/processes.service.ts
+++ b/apps/api/src/processes.service.ts
@@ -1,11 +1,12 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
-import { createId } from '@ses/domain';
+import { createId, FUNCTION_REGISTRY } from '@ses/domain';
 import { createDefaultAuditPolicy } from '@ses/domain';
 import { PrismaService } from './common/prisma.service';
 import { IdentifierService } from './common/identifier.service';
 import { ActivityLogService } from './common/activity-log.service';
 import { ProcessAccessService } from './common/process-access.service';
+import { FunctionsService } from './functions.service';
 import { RealtimeGateway } from './realtime/realtime.gateway';
 import { requestContext } from './common/request-context';
 import { fromDateOnly, toDateOnly } from './common/http';
@@ -45,6 +46,7 @@ export class ProcessesService {
     private readonly identifiers: IdentifierService,
     private readonly activity: ActivityLogService,
     private readonly processAccess: ProcessAccessService,
+    private readonly functions: FunctionsService,
     private readonly realtime: RealtimeGateway,
   ) {}
 
@@ -102,6 +104,15 @@ export class ProcessesService {
           permission: 'owner',
         },
       });
+      // Seed ProcessFunction rows so the tile dashboard has all 5 tiles from
+      // the moment the process exists. Idempotent (upsert), so re-runs are safe.
+      for (const fn of FUNCTION_REGISTRY) {
+        await tx.processFunction.upsert({
+          where: { processId_functionId: { processId: process.id, functionId: fn.id } },
+          create: { processId: process.id, functionId: fn.id, enabled: true },
+          update: {},
+        });
+      }
       await this.activity.append(tx, {
         actorId: user.id,
         actorEmail: user.email,
@@ -346,6 +357,120 @@ export class ProcessesService {
       });
       return { id: created.id, displayCode: created.displayCode, changed: true };
     });
+  }
+
+  /**
+   * One round-trip used by the ProcessTilesPage to render all 5 tiles.
+   *
+   * Returns per-function aggregates: file count, latest upload, draft
+   * presence (for the current user), and the max version number seen on
+   * any file in that function. Aggregates are computed in 2 queries
+   * regardless of the number of functions so this endpoint scales.
+   *
+   * Draft presence is user-scoped — other members' drafts never leak.
+   */
+  async tiles(idOrCode: string, user: SessionUser) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
+    // Make sure the process has ProcessFunction rows; older data pre-#62
+    // might be missing the seed.
+    await this.functions.ensureProcessFunctions(process.id);
+
+    const files = await this.prisma.workbookFile.findMany({
+      where: { processId: process.id },
+      select: {
+        functionId: true,
+        uploadedAt: true,
+      },
+    });
+
+    // Draft presence (Issue #63 adds the table; guard so the query only
+    // runs when the client is on a build that has FileDraft). We do a cheap
+    // raw SQL probe first to avoid exceptions before the #63 migration lands.
+    let draftFunctions = new Set<string>();
+    try {
+      const rows = await this.prisma.$queryRaw<Array<{ functionId: string }>>`
+        SELECT "functionId" FROM "FileDraft"
+        WHERE "userId" = ${user.id} AND "processId" = ${process.id}
+      `;
+      draftFunctions = new Set(rows.map((r) => r.functionId));
+    } catch {
+      // FileDraft table not yet migrated (we're on a #62-only build).
+      // Treat as "no drafts" — tiles render fine without the badge.
+    }
+
+    const byFunction: Record<string, { fileCount: number; lastUploadAt: string | null; hasDraft: boolean }> = {};
+    for (const fn of FUNCTION_REGISTRY) {
+      const own = files.filter((f) => f.functionId === fn.id);
+      const last = own.reduce<Date | null>((acc, f) => (!acc || f.uploadedAt > acc ? f.uploadedAt : acc), null);
+      byFunction[fn.id] = {
+        fileCount: own.length,
+        lastUploadAt: last?.toISOString() ?? null,
+        hasDraft: draftFunctions.has(fn.id),
+      };
+    }
+    return byFunction;
+  }
+
+  /**
+   * Stub helpdesk flow: write the request row, append an activity log entry,
+   * emit a realtime event so any connected admins see it. A real wire-up
+   * to an email transport lives outside this repo; we record enough that
+   * an operator can manually triage.
+   */
+  async createFunctionAuditRequest(
+    idOrCode: string,
+    body: { proposedName?: string; description?: string; contactEmail?: string },
+    user: SessionUser,
+  ) {
+    const proposedName = body.proposedName?.trim();
+    const contactEmail = body.contactEmail?.trim();
+    if (!proposedName) throw new BadRequestException('proposedName is required');
+    if (!contactEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactEmail)) {
+      throw new BadRequestException('contactEmail must be a valid email');
+    }
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
+    const created = await this.prisma.$transaction(async (tx) => {
+      // Displayable ref code. We piggy-back on the activity counter.
+      const code = await this.identifiers.nextActivityCode(tx);
+      const row = await tx.functionAuditRequest.create({
+        data: {
+          id: createId(),
+          displayCode: `FAR-${code.split('-')[2] ?? Date.now()}`,
+          processId: process.id,
+          requestedById: user.id,
+          proposedName: proposedName.slice(0, 200),
+          description: (body.description ?? '').slice(0, 4000),
+          contactEmail,
+          status: 'open',
+        },
+      });
+      await this.activity.append(tx, {
+        actorId: user.id,
+        actorEmail: user.email,
+        processId: process.id,
+        entityType: 'function_audit_request',
+        entityId: row.id,
+        entityCode: row.displayCode,
+        action: 'function.audit_request_created',
+        after: { proposedName: row.proposedName, contactEmail: row.contactEmail },
+      });
+      return row;
+    });
+    this.realtime.emitToProcess(process.displayCode, 'function.audit_request_created', {
+      requestCode: created.displayCode,
+      proposedName: created.proposedName,
+      contactEmail: created.contactEmail,
+    });
+    return {
+      id: created.id,
+      displayCode: created.displayCode,
+      processId: created.processId,
+      proposedName: created.proposedName,
+      description: created.description,
+      contactEmail: created.contactEmail,
+      status: created.status,
+      createdAt: created.createdAt.toISOString(),
+    };
   }
 
   async removeMember(idOrCode: string, memberIdOrCode: string, user: SessionUser) {

--- a/apps/api/src/realtime/realtime.types.ts
+++ b/apps/api/src/realtime/realtime.types.ts
@@ -28,7 +28,8 @@ export type RealtimeEventName =
   | 'activity.appended'
   | 'conflict.row_version'
   | 'process.member_removed'
-  | 'process.deleted';
+  | 'process.deleted'
+  | 'function.audit_request_created';
 
 export interface RealtimeEnvelope<T = unknown> {
   event: RealtimeEventName;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,66 +1,123 @@
 import { Toaster } from 'react-hot-toast';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthGate } from './components/auth/AuthGate';
 import { CompareProcesses } from './components/dashboard/CompareProcesses';
 import { Dashboard } from './pages/Dashboard';
 import { Debug } from './pages/Debug';
 import { Login } from './pages/Login';
 import { ManagerResponse } from './pages/ManagerResponse';
+import { ProcessTiles } from './pages/ProcessTiles';
 import { VersionCompare } from './pages/VersionCompare';
 import { Workspace } from './pages/Workspace';
+import { DEFAULT_FUNCTION_ID } from '@ses/domain';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+/** Preserve deep links made before the tile flow shipped. */
+function LegacyWorkspaceRedirect() {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/" replace />;
+  return <Navigate to={`/processes/${encodeURIComponent(id)}/${DEFAULT_FUNCTION_ID}`} replace />;
+}
+
+/** Same — for /workspace/:id/compare. */
+function LegacyCompareRedirect() {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/" replace />;
+  return <Navigate to={`/processes/${encodeURIComponent(id)}/${DEFAULT_FUNCTION_ID}/compare`} replace />;
+}
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        {/* Public routes — no auth required. */}
-        <Route path="/login" element={<Login />} />
-        <Route path="/respond/:token" element={<ManagerResponse />} />
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          {/* Public routes — no auth required. */}
+          <Route path="/login" element={<Login />} />
+          <Route path="/respond/:token" element={<ManagerResponse />} />
 
-        {/* Authenticated routes. */}
-        <Route
-          path="/"
-          element={
-            <AuthGate>
-              <Dashboard />
-            </AuthGate>
-          }
-        />
-        <Route
-          path="/workspace/:id"
-          element={
-            <AuthGate>
-              <Workspace />
-            </AuthGate>
-          }
-        />
-        <Route
-          path="/workspace/:id/compare"
-          element={
-            <AuthGate>
-              <VersionCompare />
-            </AuthGate>
-          }
-        />
-        <Route
-          path="/compare"
-          element={
-            <AuthGate>
-              <CompareProcesses />
-            </AuthGate>
-          }
-        />
-        <Route
-          path="/debug"
-          element={
-            <AuthGate>
-              <Debug />
-            </AuthGate>
-          }
-        />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-      <Toaster position="top-right" />
-    </BrowserRouter>
+          {/* Authenticated routes. */}
+          <Route
+            path="/"
+            element={
+              <AuthGate>
+                <Dashboard />
+              </AuthGate>
+            }
+          />
+
+          {/* Process tile dashboard — the new landing page after create. */}
+          <Route
+            path="/processes/:processId"
+            element={
+              <AuthGate>
+                <ProcessTiles />
+              </AuthGate>
+            }
+          />
+          {/* Function-scoped workspace (the single reusable Workspace surface). */}
+          <Route
+            path="/processes/:processId/:functionId"
+            element={
+              <AuthGate>
+                <Workspace />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/processes/:processId/:functionId/compare"
+            element={
+              <AuthGate>
+                <VersionCompare />
+              </AuthGate>
+            }
+          />
+
+          {/* Legacy compatibility. Kept through one release. */}
+          <Route
+            path="/workspace/:id"
+            element={
+              <AuthGate>
+                <LegacyWorkspaceRedirect />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/workspace/:id/compare"
+            element={
+              <AuthGate>
+                <LegacyCompareRedirect />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/compare"
+            element={
+              <AuthGate>
+                <CompareProcesses />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/debug"
+            element={
+              <AuthGate>
+                <Debug />
+              </AuthGate>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+        <Toaster position="top-right" />
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }

--- a/apps/web/src/components/dashboard/AuditSchedule.tsx
+++ b/apps/web/src/components/dashboard/AuditSchedule.tsx
@@ -49,7 +49,7 @@ function ScheduleItem({ process }: { process: AuditProcess }) {
   const days = process.nextAuditDue ? daysUntilDue(process.nextAuditDue) : 0;
   const label = days < 0 ? `${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} overdue` : days === 0 ? 'Due today' : `Due in ${days} day${days === 1 ? '' : 's'}`;
   return (
-    <Link to={`/workspace/${process.id}`} className="block rounded-lg bg-white/75 p-3 text-sm text-gray-900 shadow-sm transition hover:bg-white dark:bg-black/20 dark:text-gray-100 dark:hover:bg-black/30">
+    <Link to={`/processes/${process.id}`} className="block rounded-lg bg-white/75 p-3 text-sm text-gray-900 shadow-sm transition hover:bg-white dark:bg-black/20 dark:text-gray-100 dark:hover:bg-black/30">
       <div className="truncate font-semibold">{process.name}</div>
       <div className="mt-1 text-xs text-gray-600 dark:text-gray-300">{label}</div>
     </Link>

--- a/apps/web/src/components/dashboard/CreateProcessModal.tsx
+++ b/apps/web/src/components/dashboard/CreateProcessModal.tsx
@@ -20,7 +20,9 @@ export function CreateProcessModal({ onClose }: { onClose: () => void }) {
       const process = await createProcess(name, description);
       toast.success('Process created');
       onClose();
-      void navigate(`/workspace/${process.id}`);
+      // Tile dashboard is the landing page after create — user picks a
+      // function audit before entering a workspace (issue #62).
+      void navigate(`/processes/${process.id}`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Could not create process');
     } finally {

--- a/apps/web/src/components/dashboard/ProcessCard.tsx
+++ b/apps/web/src/components/dashboard/ProcessCard.tsx
@@ -87,8 +87,8 @@ export function ProcessCard({ process }: { process: AuditProcess }) {
       </div>
       <div className="mt-2 text-xs text-gray-500">High {counts.High} - Med {counts.Medium} - Low {counts.Low}</div>
       <div className="mt-5 flex gap-2">
-        <Link to={`/workspace/${process.id}`} className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover">Open Workspace</Link>
-        <Link to={`/workspace/${process.id}/compare`} className="rounded-lg border border-gray-300 px-4 py-2 text-sm hover:border-brand hover:text-brand dark:border-gray-700 dark:hover:bg-gray-800">Compare</Link>
+        <Link to={`/processes/${process.id}`} className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover">Open Process</Link>
+        <Link to={`/compare`} className="rounded-lg border border-gray-300 px-4 py-2 text-sm hover:border-brand hover:text-brand dark:border-gray-700 dark:hover:bg-gray-800">Compare</Link>
       </div>
       {editOpen ? <EditProcessModal process={process} onClose={() => setEditOpen(false)} /> : null}
     </article>

--- a/apps/web/src/components/tiles/FunctionTile.tsx
+++ b/apps/web/src/components/tiles/FunctionTile.tsx
@@ -1,0 +1,71 @@
+import type { KeyboardEvent } from 'react';
+import { FileSpreadsheet, Clock3, AlertCircle } from 'lucide-react';
+import type { FunctionId } from '@ses/domain';
+import type { ApiTileStats } from '../../lib/api/tilesApi';
+
+interface Props {
+  functionId: FunctionId;
+  label: string;
+  stats: ApiTileStats | undefined;
+  onOpen: () => void;
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'No uploads yet';
+  const when = new Date(iso);
+  const delta = Date.now() - when.getTime();
+  if (delta < 60_000) return 'Just now';
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return when.toLocaleDateString();
+}
+
+/**
+ * Presentational tile. Pure — no data fetching inside. The parent page
+ * (`ProcessTiles`) is responsible for sourcing `stats` in a single round-trip.
+ * That separation lets us reuse the same tile under admin dashboards without
+ * duplicating network logic.
+ */
+export function FunctionTile({ functionId, label, stats, onOpen }: Props) {
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onOpen();
+    }
+  }
+
+  const fileCount = stats?.fileCount ?? 0;
+  const hasDraft = Boolean(stats?.hasDraft);
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      onKeyDown={onKeyDown}
+      data-function-id={functionId}
+      className="group flex min-h-[132px] flex-col justify-between rounded-xl border border-gray-200 bg-white p-5 text-left transition hover:border-brand hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand dark:border-gray-700 dark:bg-gray-800 dark:hover:border-brand"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <FileSpreadsheet size={18} className="text-brand" />
+          <h3 className="text-base font-semibold">{label}</h3>
+        </div>
+        {hasDraft ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            <AlertCircle size={10} /> Unsaved draft
+          </span>
+        ) : null}
+      </div>
+      <div className="space-y-1 text-xs text-gray-500 dark:text-gray-400">
+        <div>
+          <span className="font-medium text-gray-700 dark:text-gray-300">{fileCount}</span>{' '}
+          {fileCount === 1 ? 'file' : 'files'}
+        </div>
+        <div className="flex items-center gap-1">
+          <Clock3 size={12} />
+          {formatRelative(stats?.lastUploadAt ?? null)}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/components/tiles/RequestFunctionAuditModal.tsx
+++ b/apps/web/src/components/tiles/RequestFunctionAuditModal.tsx
@@ -1,0 +1,123 @@
+import { useState, type FormEvent } from 'react';
+import toast from 'react-hot-toast';
+import { X } from 'lucide-react';
+import { requestFunctionAudit } from '../../lib/api/tilesApi';
+
+interface Props {
+  processIdOrCode: string;
+  onClose: () => void;
+}
+
+export function RequestFunctionAuditModal({ processIdOrCode, onClose }: Props) {
+  const [proposedName, setProposedName] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!proposedName.trim() || !contactEmail.trim()) return;
+    setSubmitting(true);
+    try {
+      const payload: { proposedName: string; contactEmail: string; description?: string } = {
+        proposedName: proposedName.trim(),
+        contactEmail: contactEmail.trim(),
+      };
+      const desc = description.trim();
+      if (desc) payload.description = desc;
+      const res = await requestFunctionAudit(processIdOrCode, payload);
+      toast.success(`Request filed (${res.displayCode}). The team will be in touch.`);
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Request failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={onSubmit}
+        onClick={(event) => event.stopPropagation()}
+        className="w-full max-w-md rounded-xl bg-white p-5 shadow-xl dark:bg-gray-900"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Request new function audit</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+          Tell us which analysis surface you need. A helpdesk ticket is opened and the platform team
+          will follow up.
+        </p>
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+            Proposed name
+          </span>
+          <input
+            type="text"
+            required
+            maxLength={200}
+            value={proposedName}
+            onChange={(event) => setProposedName(event.target.value)}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand focus:outline-none dark:border-gray-700 dark:bg-gray-800"
+          />
+        </label>
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+            Contact email
+          </span>
+          <input
+            type="email"
+            required
+            maxLength={320}
+            value={contactEmail}
+            onChange={(event) => setContactEmail(event.target.value)}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand focus:outline-none dark:border-gray-700 dark:bg-gray-800"
+          />
+        </label>
+        <label className="mb-5 block text-sm">
+          <span className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+            Description
+          </span>
+          <textarea
+            rows={3}
+            maxLength={4_000}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand focus:outline-none dark:border-gray-700 dark:bg-gray-800"
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Submit request'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/tiles/RequestFunctionAuditTile.tsx
+++ b/apps/web/src/components/tiles/RequestFunctionAuditTile.tsx
@@ -1,0 +1,26 @@
+import type { KeyboardEvent } from 'react';
+import { Plus } from 'lucide-react';
+
+export function RequestFunctionAuditTile({ onClick }: { onClick: () => void }) {
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick();
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      className="flex min-h-[132px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-gray-300 bg-white p-5 text-sm text-gray-500 transition hover:border-brand hover:text-brand focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand dark:border-gray-700 dark:bg-gray-800"
+    >
+      <Plus size={22} />
+      <span className="font-medium">Request New Function Audit Analysis</span>
+      <span className="max-w-[22ch] text-center text-xs">
+        Propose a new audit surface. A helpdesk ticket is opened for review.
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/workspace/FilesSidebar.tsx
+++ b/apps/web/src/components/workspace/FilesSidebar.tsx
@@ -1,17 +1,26 @@
-import { Trash2, Upload } from 'lucide-react';
+import { Download, Eye, Trash2, Upload } from 'lucide-react';
 import type { KeyboardEvent } from 'react';
 import toast from 'react-hot-toast';
+import { DEFAULT_FUNCTION_ID, type FunctionId } from '@ses/domain';
+import { downloadFileToDisk } from '../../lib/api/filesApi';
 import { validateWorkbookFile } from '../../lib/excelParser';
 import type { AuditProcess, WorkbookFile } from '../../lib/types';
 import { useAppStore } from '../../store/useAppStore';
 import { ProgressBar } from '../shared/ProgressBar';
 import { SheetList } from './SheetList';
 
-export function FilesSidebar({ process }: { process: AuditProcess }) {
+interface Props {
+  process: AuditProcess;
+  functionId?: FunctionId;
+}
+
+export function FilesSidebar({ process, functionId }: Props) {
   const uploadFile = useAppStore((state) => state.uploadFile);
   const setActiveFile = useAppStore((state) => state.setActiveFile);
+  const setWorkspaceTab = useAppStore((state) => state.setWorkspaceTab);
   const deleteFile = useAppStore((state) => state.deleteFile);
   const uploads = useAppStore((state) => state.uploads);
+  const scopedFid: FunctionId = functionId ?? DEFAULT_FUNCTION_ID;
   const activeFile = process.files.find((file) => file.id === process.activeFileId) ?? process.files[0];
 
   async function upload(files: FileList | null) {
@@ -23,7 +32,23 @@ export function FilesSidebar({ process }: { process: AuditProcess }) {
         toast.error(error instanceof Error ? error.message : `${file.name} is not a supported workbook`);
         continue;
       }
-      void uploadFile(process.id, file).then(() => toast.success(`${file.name} uploaded`)).catch(() => toast.error(`${file.name} failed`));
+      void uploadFile(process.id, file, scopedFid)
+        .then(() => toast.success(`${file.name} uploaded`))
+        .catch(() => toast.error(`${file.name} failed`));
+    }
+  }
+
+  function onView(file: WorkbookFile) {
+    setActiveFile(process.id, file.id);
+    setWorkspaceTab('preview');
+  }
+
+  async function onDownload(file: WorkbookFile) {
+    const ref = (file as { displayCode?: string }).displayCode ?? file.id;
+    try {
+      await downloadFileToDisk(ref, file.name);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `Could not download ${file.name}`);
     }
   }
 
@@ -62,7 +87,10 @@ export function FilesSidebar({ process }: { process: AuditProcess }) {
               key={file.id}
               file={file}
               isActive={file.id === process.activeFileId}
+              serverBacked={Boolean(process.serverBacked)}
               onSelect={() => setActiveFile(process.id, file.id)}
+              onView={() => onView(file)}
+              onDownload={() => void onDownload(file)}
               onDelete={() => confirmDelete(file)}
             />
           ))}
@@ -76,12 +104,18 @@ export function FilesSidebar({ process }: { process: AuditProcess }) {
 function DocumentCard({
   file,
   isActive,
+  serverBacked,
   onSelect,
+  onView,
+  onDownload,
   onDelete,
 }: {
   file: WorkbookFile;
   isActive: boolean;
+  serverBacked: boolean;
   onSelect: () => void;
+  onView: () => void;
+  onDownload: () => void;
   onDelete: () => void;
 }) {
   const valid = file.sheets.filter((sheet) => sheet.status === 'valid').length;
@@ -107,7 +141,7 @@ function DocumentCard({
           : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700'
       }`}
     >
-      <div className="flex gap-2 pr-7">
+      <div className="flex gap-2 pr-24">
         <span className={isActive ? 'text-green-500' : 'text-gray-300'}>{isActive ? '●' : '○'}</span>
         <div className="min-w-0 flex-1">
           <div className="truncate font-medium">{file.name}</div>
@@ -119,18 +153,46 @@ function DocumentCard({
           ) : null}
         </div>
       </div>
-      <button
-        type="button"
-        aria-label={`Delete ${file.name}`}
-        title="Delete document"
-        onClick={(event) => {
-          event.stopPropagation();
-          onDelete();
-        }}
-        className="absolute right-2 top-2 rounded-md p-1 text-gray-400 opacity-0 transition hover:bg-red-50 hover:text-red-600 focus-visible:opacity-100 group-hover:opacity-100 dark:hover:bg-red-950/30"
-      >
-        <Trash2 size={14} />
-      </button>
+      <div className="absolute right-2 top-2 flex gap-0.5 opacity-0 transition focus-within:opacity-100 group-hover:opacity-100">
+        <button
+          type="button"
+          aria-label={`View ${file.name}`}
+          title="View preview"
+          onClick={(event) => {
+            event.stopPropagation();
+            onView();
+          }}
+          className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-700"
+        >
+          <Eye size={14} />
+        </button>
+        {serverBacked ? (
+          <button
+            type="button"
+            aria-label={`Download ${file.name}`}
+            title="Download original file"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDownload();
+            }}
+            className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-700"
+          >
+            <Download size={14} />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          aria-label={`Delete ${file.name}`}
+          title="Delete document"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+          className="rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/api/filesApi.ts
+++ b/apps/web/src/lib/api/filesApi.ts
@@ -1,9 +1,11 @@
+import type { FunctionId } from '@ses/domain';
 
 export interface ApiFileSummary {
   id: string;
   displayCode: string;
   rowVersion: number;
   processId: string;
+  functionId: FunctionId;
   name: string;
   sizeBytes: number;
   mimeType: string;
@@ -22,6 +24,11 @@ export interface ApiFileSummary {
   }>;
 }
 
+export interface ApiUploadResult extends ApiFileSummary {
+  /** Echo of the client temp id, used to rekey the IDB cache (fixes #63 hydration bug). */
+  clientTempId: string | null;
+}
+
 async function parseError(res: Response, fallback: string): Promise<Error> {
   const err = (await res.json().catch(() => ({}))) as { message?: string };
   return new Error(err.message ?? `${fallback} (${res.status})`);
@@ -29,23 +36,33 @@ async function parseError(res: Response, fallback: string): Promise<Error> {
 
 export async function uploadFileToApi(
   processIdOrCode: string,
+  functionId: FunctionId,
   file: File,
-): Promise<ApiFileSummary> {
+  opts?: { clientTempId?: string },
+): Promise<ApiUploadResult> {
   const body = new FormData();
   body.append('file', file, file.name);
-  const res = await fetch(`/api/v1/processes/${encodeURIComponent(processIdOrCode)}/files`, {
-    method: 'POST',
-    credentials: 'include',
-    body,
-  });
+  if (opts?.clientTempId) body.append('clientTempId', opts.clientTempId);
+  const res = await fetch(
+    `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/functions/${encodeURIComponent(functionId)}/files`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      body,
+    },
+  );
   if (!res.ok) throw await parseError(res, 'Upload failed');
-  return (await res.json()) as ApiFileSummary;
+  return (await res.json()) as ApiUploadResult;
 }
 
-export async function listFilesOnApi(processIdOrCode: string): Promise<ApiFileSummary[]> {
-  const res = await fetch(`/api/v1/processes/${encodeURIComponent(processIdOrCode)}/files`, {
-    credentials: 'include',
-  });
+export async function listFilesOnApi(
+  processIdOrCode: string,
+  functionId?: FunctionId,
+): Promise<ApiFileSummary[]> {
+  const url = functionId
+    ? `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/functions/${encodeURIComponent(functionId)}/files`
+    : `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/files`;
+  const res = await fetch(url, { credentials: 'include' });
   if (!res.ok) throw await parseError(res, 'Failed to load files');
   return (await res.json()) as ApiFileSummary[];
 }
@@ -64,4 +81,25 @@ export async function downloadFileFromApi(fileIdOrCode: string): Promise<Blob> {
   });
   if (!res.ok) throw await parseError(res, 'Failed to download file');
   return res.blob();
+}
+
+/**
+ * Trigger a browser download from the Blob returned by `downloadFileFromApi`.
+ * Kept client-side so the exact original filename is used (see #62 AC).
+ */
+export async function downloadFileToDisk(
+  fileIdOrCode: string,
+  suggestedName: string,
+): Promise<void> {
+  const blob = await downloadFileFromApi(fileIdOrCode);
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = suggestedName;
+    link.click();
+  } finally {
+    // Defer revoke so the click handler can start the stream.
+    setTimeout(() => URL.revokeObjectURL(url), 1_000);
+  }
 }

--- a/apps/web/src/lib/api/tilesApi.ts
+++ b/apps/web/src/lib/api/tilesApi.ts
@@ -1,0 +1,39 @@
+import type { FunctionId } from '@ses/domain';
+
+export interface ApiTileStats {
+  fileCount: number;
+  lastUploadAt: string | null;
+  hasDraft: boolean;
+}
+
+export type ApiTiles = Record<FunctionId, ApiTileStats>;
+
+async function parseError(res: Response, fallback: string): Promise<Error> {
+  const err = (await res.json().catch(() => ({}))) as { message?: string };
+  return new Error(err.message ?? `${fallback} (${res.status})`);
+}
+
+export async function fetchProcessTiles(processIdOrCode: string): Promise<ApiTiles> {
+  const res = await fetch(`/api/v1/processes/${encodeURIComponent(processIdOrCode)}/tiles`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw await parseError(res, 'Failed to load tiles');
+  return (await res.json()) as ApiTiles;
+}
+
+export async function requestFunctionAudit(
+  processIdOrCode: string,
+  body: { proposedName: string; description?: string; contactEmail: string },
+): Promise<{ displayCode: string }> {
+  const res = await fetch(
+    `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/function-audit-requests`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) throw await parseError(res, 'Failed to submit request');
+  return (await res.json()) as { displayCode: string };
+}

--- a/apps/web/src/lib/blobStore.ts
+++ b/apps/web/src/lib/blobStore.ts
@@ -13,3 +13,18 @@ export async function getWorkbookRawData(fileId: string): Promise<Record<string,
 export async function deleteWorkbookRawData(fileId: string): Promise<void> {
   await del(rawDataKey(fileId));
 }
+
+/**
+ * Move a cached rawData entry from one id to another. Used immediately after
+ * a server upload completes — we cache under the parser-generated temp id
+ * pre-response and then rekey to the server id so later reads hit it.
+ *
+ * Silently no-ops when the source key doesn't exist (idempotent).
+ */
+export async function renameWorkbookRawDataKey(fromId: string, toId: string): Promise<void> {
+  if (fromId === toId) return;
+  const data = await getWorkbookRawData(fromId);
+  if (!data) return;
+  await putWorkbookRawData(toId, data);
+  await deleteWorkbookRawData(fromId);
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -60,10 +60,14 @@ export interface AuditProcess {
 
 export interface WorkbookFile {
   id: string;
+  displayCode?: string;
+  /** Issue #62: tile scoping. Defaults to 'master-data' for legacy local files. */
+  functionId?: string;
   name: string;
   uploadedAt: string;
   lastAuditedAt: string | null;
   isAudited: boolean;
+  serverBacked?: boolean;
   sheets: SheetInfo[];
   rawData: Record<string, unknown[][]>;
 }

--- a/apps/web/src/pages/ProcessTiles.tsx
+++ b/apps/web/src/pages/ProcessTiles.tsx
@@ -1,0 +1,105 @@
+import { useQuery } from '@tanstack/react-query';
+import { lazy, Suspense, useState } from 'react';
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, HelpCircle } from 'lucide-react';
+import { FUNCTION_REGISTRY, type FunctionId } from '@ses/domain';
+import { AppShell } from '../components/layout/AppShell';
+import { FunctionTile } from '../components/tiles/FunctionTile';
+import { RequestFunctionAuditTile } from '../components/tiles/RequestFunctionAuditTile';
+import { fetchProcessTiles, type ApiTiles } from '../lib/api/tilesApi';
+import { useAppStore } from '../store/useAppStore';
+
+const RequestFunctionAuditModal = lazy(() =>
+  import('../components/tiles/RequestFunctionAuditModal').then((m) => ({ default: m.RequestFunctionAuditModal })),
+);
+
+const EMPTY_TILES: ApiTiles = FUNCTION_REGISTRY.reduce(
+  (acc, fn) => ({ ...acc, [fn.id]: { fileCount: 0, lastUploadAt: null, hasDraft: false } }),
+  {} as ApiTiles,
+);
+
+export function ProcessTiles() {
+  const { processId } = useParams<{ processId: string }>();
+  const navigate = useNavigate();
+  const process = useAppStore((state) =>
+    state.processes.find((item) => item.id === processId || item.displayCode === processId),
+  );
+  const hydrateProcesses = useAppStore((state) => state.hydrateProcesses);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const tilesQuery = useQuery({
+    queryKey: ['process', processId, 'tiles'],
+    queryFn: () => fetchProcessTiles(processId!),
+    enabled: Boolean(processId),
+    staleTime: 15_000,
+  });
+
+  // Fire a hydrate once if we don't recognize the process locally — avoids a
+  // flash of "not found" on hard refresh in a new browser.
+  useState(() => {
+    if (!process && processId) void hydrateProcesses();
+    return 0;
+  });
+
+  if (!processId) return <Navigate to="/" replace />;
+
+  const tiles = tilesQuery.data ?? EMPTY_TILES;
+
+  return (
+    <AppShell process={process ?? undefined}>
+      <div className="mx-auto w-full max-w-6xl px-6 py-10">
+        <div className="mb-6 flex items-center gap-3">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-300"
+          >
+            <ArrowLeft size={14} /> All processes
+          </Link>
+          <h1 className="text-2xl font-semibold">{process?.name ?? 'Process'}</h1>
+          {process?.displayCode ? (
+            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+              {process.displayCode}
+            </span>
+          ) : null}
+        </div>
+
+        <p className="mb-6 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
+          Pick a function audit to open its workspace. Every tile owns its own files, audits, versions
+          and drafts — selecting one never mixes data with another.
+        </p>
+
+        {tilesQuery.isError ? (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            Could not load tile stats: {(tilesQuery.error as Error)?.message}
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {FUNCTION_REGISTRY.map((fn) => (
+            <FunctionTile
+              key={fn.id}
+              functionId={fn.id as FunctionId}
+              label={fn.label}
+              stats={tiles[fn.id as FunctionId]}
+              onOpen={() => navigate(`/processes/${encodeURIComponent(processId)}/${fn.id}`)}
+            />
+          ))}
+          <RequestFunctionAuditTile onClick={() => setModalOpen(true)} />
+        </div>
+
+        <p className="mt-8 flex items-center gap-2 text-xs text-gray-500">
+          <HelpCircle size={14} />
+          System-defined tiles are permanent. Contact your administrator to request a new audit function.
+        </p>
+      </div>
+      {modalOpen ? (
+        <Suspense fallback={null}>
+          <RequestFunctionAuditModal
+            processIdOrCode={process?.displayCode ?? processId}
+            onClose={() => setModalOpen(false)}
+          />
+        </Suspense>
+      ) : null}
+    </AppShell>
+  );
+}

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -1,6 +1,7 @@
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
-import { Users } from 'lucide-react';
+import { ArrowLeft, Users } from 'lucide-react';
+import { DEFAULT_FUNCTION_ID, getFunctionLabel, isFunctionId, type FunctionId } from '@ses/domain';
 import { FilesSidebar } from '../components/workspace/FilesSidebar';
 import { MembersPanel } from '../components/workspace/MembersPanel';
 import { WorkspaceShell } from '../components/workspace/WorkspaceShell';
@@ -20,13 +21,17 @@ import { useRealtime } from '../realtime/useRealtime';
 const AnalyticsTab = lazy(() => import('../components/workspace/AnalyticsTab').then((module) => ({ default: module.AnalyticsTab })));
 
 export function Workspace() {
-  const { id } = useParams();
+  // New surface: /processes/:processId/:functionId — back-compat with old
+  // /workspace/:id is handled by a redirect in App.tsx, so `id` is no longer read here.
+  const params = useParams<{ processId: string; functionId: string }>();
+  const processId = params.processId;
+  const functionId: FunctionId = isFunctionId(params.functionId) ? params.functionId : DEFAULT_FUNCTION_ID;
   const navigate = useNavigate();
   const processes = useAppStore((state) => state.processes);
   const hydrateProcesses = useAppStore((state) => state.hydrateProcesses);
   const tab = useAppStore((state) => state.activeWorkspaceTab);
   const result = useAppStore((state) => state.currentAuditResult);
-  const process = processes.find((item) => item.id === id);
+  const process = processes.find((item) => item.id === processId || item.displayCode === processId);
   const hasUnsavedAudit = process ? selectHasUnsavedAudit(process) : false;
   const currentUser = useCurrentUser();
   const [membersOpen, setMembersOpen] = useState(false);
@@ -74,11 +79,22 @@ export function Workspace() {
     );
   }
   if (!process) return <Navigate to="/" replace />;
-  const activeFile = process.files.find((file) => file.id === process.activeFileId) ?? process.files[0] ?? undefined;
+  // Scope the file list to the selected function so each tile only sees its own files.
+  const functionFiles = process.files.filter((file) => (file.functionId ?? DEFAULT_FUNCTION_ID) === functionId);
+  const scopedProcess = { ...process, files: functionFiles };
+  const activeFile = functionFiles.find((file) => file.id === process.activeFileId) ?? functionFiles[0] ?? undefined;
   const canManageMembers = currentUser?.role === 'admin'; // Owners are verified server-side too; admin is the quick client-side hint.
 
   const accessory = (
     <div className="flex items-center gap-2">
+      <Link
+        to={`/processes/${encodeURIComponent(process.id)}`}
+        className="flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1.5 text-xs text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-300"
+        title="Back to tiles"
+      >
+        <ArrowLeft size={14} />
+        <span className="hidden sm:inline">{getFunctionLabel(functionId)}</span>
+      </Link>
       <PresenceBar members={members} selfCode={currentUser?.displayCode} />
       {process.serverBacked ? (
         <button
@@ -95,37 +111,37 @@ export function Workspace() {
   );
 
   return (
-    <AppShell process={process} sidebar={<FilesSidebar process={process} />} topBarAccessory={accessory}>
+    <AppShell process={process} sidebar={<FilesSidebar process={scopedProcess} functionId={functionId} />} topBarAccessory={accessory}>
       <WorkspaceShell>
         {tab === 'preview' ? (
           <TabPanel>
-            <PreviewTab process={process} file={activeFile} result={result} />
+            <PreviewTab process={scopedProcess} file={activeFile} result={result} />
           </TabPanel>
         ) : null}
         {tab === 'results' ? (
           <TabPanel>
-            <AuditResultsTab process={process} file={activeFile} />
+            <AuditResultsTab process={scopedProcess} file={activeFile} />
           </TabPanel>
         ) : null}
         {tab === 'notifications' ? (
           <TabPanel scroll="split">
-            <NotificationsTab process={process} result={result ?? process.versions[0]?.result ?? null} />
+            <NotificationsTab process={scopedProcess} result={result ?? scopedProcess.versions[0]?.result ?? null} />
           </TabPanel>
         ) : null}
         {tab === 'tracking' ? (
           <TabPanel scroll="split">
-            <TrackingTab process={process} result={result ?? process.versions[0]?.result ?? null} />
+            <TrackingTab process={scopedProcess} result={result ?? scopedProcess.versions[0]?.result ?? null} />
           </TabPanel>
         ) : null}
         {tab === 'versions' ? (
           <TabPanel>
-            <VersionHistoryTab process={process} file={activeFile} />
+            <VersionHistoryTab process={scopedProcess} file={activeFile} />
           </TabPanel>
         ) : null}
         {tab === 'analytics' ? (
           <TabPanel>
             <Suspense fallback={<div className="p-5 text-sm text-gray-500">Loading analytics...</div>}>
-              <AnalyticsTab process={process} />
+              <AnalyticsTab process={scopedProcess} />
             </Suspense>
           </TabPanel>
         ) : null}

--- a/apps/web/src/store/useAppStore.ts
+++ b/apps/web/src/store/useAppStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
 import { persist, type PersistStorage, type StorageValue } from 'zustand/middleware';
+import { DEFAULT_FUNCTION_ID, type FunctionId } from '@ses/domain';
 import { createDefaultAuditPolicy, normalizeAuditPolicy } from '../lib/auditPolicy';
 import { runAuditAsync } from '../lib/auditRunner';
-import { deleteWorkbookRawData, putWorkbookRawData } from '../lib/blobStore';
+import { deleteWorkbookRawData, putWorkbookRawData, renameWorkbookRawDataKey } from '../lib/blobStore';
 import { parseWorkbook } from '../lib/excelParser';
 import { createId } from '../lib/id';
 import { createProcessOnApi, deleteProcessOnApi, fetchProcessesFromApi, updateProcessOnApi } from '../lib/api/processesApi';
@@ -56,7 +57,7 @@ type AppStore = {
   updateProcess: (id: string, patch: Partial<AuditProcess>) => Promise<void>;
   deleteProcess: (id: string) => Promise<void>;
   setActiveProcess: (id: string) => void;
-  uploadFile: (processId: string, file: File) => Promise<void>;
+  uploadFile: (processId: string, file: File, functionId?: FunctionId) => Promise<void>;
   setActiveFile: (processId: string, fileId: string) => void;
   deleteFile: (processId: string, fileId: string) => void;
   toggleSheet: (processId: string, fileId: string, sheetName: string) => void;
@@ -278,20 +279,28 @@ export const useAppStore = create<AppStore>()(
         rememberActiveProcess(processId);
       },
 
-      uploadFile: async (processId, file) => {
+      uploadFile: async (processId, file, functionId) => {
+        const fid: FunctionId = functionId ?? DEFAULT_FUNCTION_ID;
         const uploadId = createId(`${processId}-${file.name}`);
         const target = get().processes.find((p) => p.id === processId);
         set((state) => ({ uploads: { ...state.uploads, [uploadId]: { fileName: file.name, progress: 20, status: 'uploading' } } }));
         try {
           if (target?.serverBacked && target.displayCode) {
-            // Server-backed: POST the bytes; backend parses + stores + emits
-            // file.uploaded over the realtime channel so other members see it.
-            const apiFile = await uploadFileToApi(target.displayCode, file);
-            // Still parse locally so Preview can render rows without a round
-            // trip to /files/:id/sheets/:sheet/preview. This is redundant work
-            // right now, but cheap and lets the UI keep its current rendering.
+            // Parse locally first so the client has a deterministic temp id
+            // for the IndexedDB cache — the server echoes `clientTempId` back
+            // so we can rekey the raw-data cache to the server id after upload.
             const parsed = await parseWorkbook(file);
             await putWorkbookRawData(parsed.id, parsed.rawData);
+            // Server-backed: POST the bytes; backend parses + stores + emits
+            // file.uploaded over the realtime channel so other members see it.
+            const apiFile = await uploadFileToApi(target.displayCode, fid, file, {
+              clientTempId: parsed.id,
+            });
+            // Rekey IDB cache from temp id to server id so reload hydration
+            // finds the parsed rawData (fix for #63 hydration bug).
+            if (apiFile.id !== parsed.id) {
+              await renameWorkbookRawDataKey(parsed.id, apiFile.id);
+            }
             // Merge server metadata (displayCode, sheet codes) onto local shape
             const mergedSheets = parsed.sheets.map((s) => {
               const api = apiFile.sheets.find((x) => x.name === s.name);
@@ -303,6 +312,7 @@ export const useAppStore = create<AppStore>()(
               ...parsed,
               id: apiFile.id,
               displayCode: apiFile.displayCode,
+              functionId: apiFile.functionId,
               sheets: mergedSheets,
               serverBacked: true,
             };

--- a/packages/domain/src/functions.ts
+++ b/packages/domain/src/functions.ts
@@ -1,0 +1,21 @@
+export const FUNCTION_REGISTRY = [
+  { id: 'master-data', label: 'Master Data', displayOrder: 1 },
+  { id: 'over-planning', label: 'Over Planning', displayOrder: 2 },
+  { id: 'missing-plan', label: 'Missing Plan', displayOrder: 3 },
+  { id: 'function-rate', label: 'Function Rate', displayOrder: 4 },
+  { id: 'internal-cost-rate', label: 'Internal Cost Rate', displayOrder: 5 },
+] as const;
+
+export type FunctionId = (typeof FUNCTION_REGISTRY)[number]['id'];
+
+export const FUNCTION_IDS: readonly FunctionId[] = FUNCTION_REGISTRY.map((f) => f.id);
+
+export function isFunctionId(value: unknown): value is FunctionId {
+  return typeof value === 'string' && FUNCTION_IDS.includes(value as FunctionId);
+}
+
+export function getFunctionLabel(id: FunctionId): string {
+  return FUNCTION_REGISTRY.find((f) => f.id === id)?.label ?? id;
+}
+
+export const DEFAULT_FUNCTION_ID: FunctionId = 'master-data';

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -11,3 +11,4 @@ export * from './managerAnalytics';
 export * from './anomaly';
 export * from './workbook';
 export * from './reporting';
+export * from './functions';


### PR DESCRIPTION
Process → Tile dashboard + function-scoped workspace. Closes the gap where creating a process dumped users straight into the upload surface; they now land on a tile dashboard with 5 system-defined function tiles + a helpdesk tile for requesting new audit surfaces. Every file operation is scoped by (processId, functionId) so tiles never leak data between each other.

Shared (@ses/domain)
  - FUNCTION_REGISTRY + FunctionId type + isFunctionId / getFunctionLabel helpers + DEFAULT_FUNCTION_ID. One source of truth, imported by both frontend and backend.

Database (Prisma)
  - New SystemFunction table (id PK, label, displayOrder, isSystem) seeded with the 5 registry entries inline in the migration. Upserted again on every boot via FunctionsService so registry and DB stay in lockstep across deploys.
  - New ProcessFunction mapping table (processId, functionId composite PK, enabled). Backfilled for every existing Process so legacy data keeps working.
  - New FunctionAuditRequest table for the helpdesk flow.
  - WorkbookFile.functionId added with default 'master-data' backfill, plus (processId, functionId) composite index for the hot list query.

Backend (NestJS)
  - FunctionsModule — read-only GET /functions + onModuleInit seeder.
  - FunctionAccessGuard — resolves :processIdOrCode against ProcessMember and validates :functionId is a known registry id AND ProcessFunction.enabled on routes that carry both params.
  - ProcessesController: GET  /processes/:id/tiles  → per-function counts + draft flag in one round-trip (avoids N+1 on tile render). POST /processes/:id/function-audit-requests → helpdesk stub that writes a row, logs an ActivityLog entry, and emits the new 'function.audit_request_created' realtime event.
  - FilesController gains scoped routes: GET  /processes/:pid/functions/:fid/files POST /processes/:pid/functions/:fid/files  (multipart; echoes clientTempId back so the client can rekey its IDB cache — prep for the hydration fix in #63) Legacy flat routes stay for one release; default to master-data when functionId is absent.
  - FilesService.list accepts optional functionId; upload requires it.
  - Per-process seed of ProcessFunction rows on create so new processes immediately have all 5 tiles.

Frontend (React)
  - New route tree:
      /processes/:processId            → tile dashboard
      /processes/:processId/:functionId → workspace (reusable, no
                                          per-function branches)
    Legacy /workspace/:id 301-redirects to /processes/:id/master-data.
  - ProcessTiles page + FunctionTile + RequestFunctionAuditTile +
    RequestFunctionAuditModal.
  - CreateProcessModal lands on /processes/:id after create.
  - Workspace reads :functionId from URL and scopes its file list.
  - FilesSidebar carries functionId into uploadFile; every file row now
    has View and Download buttons. Download uses downloadFileToDisk which
    preserves the original filename + extension.
  - blobStore gains renameWorkbookRawDataKey used by the upload path to
    move cached rawData from the parser temp id to the server id — the
    core fix for the 'files disappear after reload' bug landing fully
    in #63.
  - QueryClient wired into App so tile stats are cached across nav.

Docs
  - .claude.md added: full refactor plan for issues #62/#63/#64 this epic bundle implements.