### PR TITLE
feat(issue-74): autosave audits and live directory updates

### DIFF
--- a/apps/api/prisma/migrations/20260422230000_issue74_audit_findings_hash/migration.sql
+++ b/apps/api/prisma/migrations/20260422230000_issue74_audit_findings_hash/migration.sql
@@ -1,0 +1,3 @@
+-- Issue #74: stable identity for an audit run's issue set so the web
+-- client can auto-save a version only when findings actually changed.
+ALTER TABLE "AuditRun" ADD COLUMN "findingsHash" TEXT NOT NULL DEFAULT '';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -327,6 +327,10 @@ model AuditRun {
   rulesSnapshot  Json
   scannedRows    Int         @default(0)
   flaggedRows    Int         @default(0)
+  /// Deterministic sha256 of the run's issue set (sorted keys).
+  /// Used by clients to skip auto-saving a version when nothing changed
+  /// between two back-to-back runs on the same unmodified file.
+  findingsHash   String      @default("")
   summary        Json
   ranById        String
   startedAt      DateTime    @default(now())

--- a/apps/api/src/audits.service.ts
+++ b/apps/api/src/audits.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import type { Prisma } from '@prisma/client';
 import type { AuditIssue, AuditResult, SessionUser, WorkbookFile as DomainWorkbookFile } from '@ses/domain';
 import {
@@ -21,6 +22,22 @@ import { requestContext } from './common/request-context';
 import { RealtimeGateway } from './realtime/realtime.gateway';
 import { StatusReconcilerService } from './status-reconciler.service';
 import { resolveIssueEmailsFromDirectory } from './directory/resolve-issue-emails';
+
+/**
+ * Stable sha256 over the sorted identity of each issue.
+ * Two runs with the same issues (any order) produce the same hash, so the
+ * web store can skip creating duplicate SavedVersion rows when an auditor
+ * re-runs against an unchanged file.
+ */
+function computeFindingsHash(
+  issues: Array<{ issueKey: string; ruleCode?: string | null; severity?: string | null }>,
+): string {
+  const normalized = issues
+    .map((i) => `${i.issueKey}|${i.ruleCode ?? ''}|${i.severity ?? ''}`)
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(`${issues.length}\n${normalized}`).digest('hex');
+}
 
 function serializeIssue(issue: {
   id: string;
@@ -78,6 +95,7 @@ function serializeRun(run: {
   source: string;
   scannedRows: number;
   flaggedRows: number;
+  findingsHash?: string;
   startedAt: Date;
   completedAt: Date | null;
   issues?: Array<{
@@ -114,6 +132,7 @@ function serializeRun(run: {
     runAt: (run.completedAt ?? run.startedAt).toISOString(),
     scannedRows: run.scannedRows,
     flaggedRows: run.flaggedRows,
+    findingsHash: run.findingsHash ?? '',
     issues,
     sheets: ((run.summary as { sheets?: AuditResult['sheets'] } | null)?.sheets ?? []),
     policySnapshot: run.policySnapshot,
@@ -313,12 +332,21 @@ export class AuditsService {
         });
       }
 
+      const findingsHash = computeFindingsHash(
+        issuesWithCodes.map((i) => ({
+          issueKey: i.issueKey!,
+          ruleCode: i.ruleCode ?? i.ruleId ?? '',
+          severity: i.severity,
+        })),
+      );
+
       const completedRun = await tx.auditRun.update({
         where: { id: createdRun.id },
         data: {
           status: 'completed',
           scannedRows: result.scannedRows,
           flaggedRows: result.flaggedRows,
+          findingsHash,
           // PRISMA-JSON: unavoidable until Prisma 6 supports typed JSON columns
           summary: summary as any,
           completedAt: new Date(result.runAt),

--- a/apps/api/src/directory/directory.service.ts
+++ b/apps/api/src/directory/directory.service.ts
@@ -20,6 +20,8 @@ import type { Prisma } from '@prisma/client';
 import { PrismaService } from '../common/prisma.service';
 import { IdentifierService } from '../common/identifier.service';
 import { ActivityLogService } from '../common/activity-log.service';
+import { RealtimeGateway } from '../realtime/realtime.gateway';
+import type { DirectoryUpdatedPayload } from '../realtime/realtime.types';
 import { matchRawNameToDirectoryEntries } from './directory-matching';
 
 function parseAliases(value: unknown): string[] {
@@ -47,7 +49,29 @@ export class DirectoryService {
     private readonly prisma: PrismaService,
     private readonly identifiers: IdentifierService,
     private readonly activity: ActivityLogService,
+    private readonly realtime: RealtimeGateway,
   ) {}
+
+  /**
+   * Directory mutations are tenant-scoped, but the realtime gateway rooms
+   * are per-process. Fan the notification out to every non-archived process
+   * in the tenant so any open EscalationCenter / Workspace tab re-derives
+   * its "unmapped manager" state without a reload. Cheap: one SELECT on
+   * PRIMARY-KEYed data plus N in-memory emits.
+   */
+  private async broadcastDirectoryUpdate(
+    tenantId: string,
+    payload: Omit<DirectoryUpdatedPayload, 'tenantId'>,
+  ): Promise<void> {
+    const processes = await this.prisma.process.findMany({
+      where: { tenantId, archivedAt: null },
+      select: { displayCode: true },
+    });
+    const envelope: DirectoryUpdatedPayload = { tenantId, ...payload };
+    for (const p of processes) {
+      this.realtime.emitToProcess(p.displayCode, 'directory.updated', envelope);
+    }
+  }
 
   private requireTenant(user: SessionUser): string {
     if (!user.tenantId) throw new ForbiddenException('Missing tenant');
@@ -244,6 +268,9 @@ export class DirectoryService {
         metadata: { created, updated, skipped, strategy: body.strategy, previewCounts: preview.counts },
       });
     });
+    if (created.length > 0 || updated.length > 0) {
+      await this.broadcastDirectoryUpdate(tenantId, { action: 'updated' });
+    }
     return { created, updated, skipped, previewCounts: preview.counts };
   }
 
@@ -295,6 +322,11 @@ export class DirectoryService {
         });
         return created;
       });
+      await this.broadcastDirectoryUpdate(tenantId, {
+        action: 'created',
+        entryId: row.id,
+        normalizedKeys: [row.normalizedKey],
+      });
       return this.serializeEntry(row);
     }
     if (!body.directoryEntryId) {
@@ -319,6 +351,11 @@ export class DirectoryService {
       entityId: entry.id,
       action: 'directory_resolve_alias',
       metadata: { rawName: raw },
+    });
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'updated',
+      entryId: updated.id,
+      normalizedKeys: [updated.normalizedKey],
     });
     return this.serializeEntry(updated);
   }
@@ -371,6 +408,11 @@ export class DirectoryService {
           createdById: user.id,
         },
       });
+    });
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'created',
+      entryId: created.id,
+      normalizedKeys: [created.normalizedKey],
     });
     return this.serializeEntry(created);
   }
@@ -445,6 +487,11 @@ export class DirectoryService {
       }
       throw error;
     }
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'created',
+      entryId: created.id,
+      normalizedKeys: [created.normalizedKey],
+    });
     return this.serializeEntry(created);
   }
 
@@ -502,6 +549,11 @@ export class DirectoryService {
         },
       });
     });
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'deleted',
+      entryId: entry.id,
+      normalizedKeys: [entry.normalizedKey],
+    });
   }
 
   async archiveBulk(user: SessionUser, body: { ids: string[] }) {
@@ -512,6 +564,9 @@ export class DirectoryService {
       where: { tenantId, id: { in: body.ids } },
       data: { active: false },
     });
+    if (res.count > 0) {
+      await this.broadcastDirectoryUpdate(tenantId, { action: 'archived' });
+    }
     return { archived: res.count };
   }
 
@@ -592,6 +647,11 @@ export class DirectoryService {
         metadata: { sourceId: source.id, targetId: target.id, repointed: n.count },
       });
       return n.count;
+    });
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'merged',
+      entryId: target.id,
+      normalizedKeys: [source.normalizedKey, target.normalizedKey],
     });
     return { repointed, targetId: target.id };
   }
@@ -755,6 +815,11 @@ export class DirectoryService {
         after: body as unknown as Record<string, unknown>,
       });
       return row;
+    });
+    await this.broadcastDirectoryUpdate(tenantId, {
+      action: 'updated',
+      entryId: updated.id,
+      normalizedKeys: [updated.normalizedKey],
     });
     return this.serializeEntry(updated);
   }

--- a/apps/api/src/realtime/realtime.types.ts
+++ b/apps/api/src/realtime/realtime.types.ts
@@ -29,6 +29,7 @@ export type RealtimeEventName =
   | 'conflict.row_version'
   | 'process.member_removed'
   | 'process.deleted'
+  | 'directory.updated'
   | 'function.audit_request_created';
 
 export interface RealtimeEnvelope<T = unknown> {
@@ -123,4 +124,17 @@ export interface ProcessMemberRemovedPayload {
 export interface ProcessDeletedPayload {
   processCode: string;
   processName: string;
+}
+
+/**
+ * Emitted after any Manager Directory mutation so that open EscalationCenter
+ * / Workspace sessions can re-derive their "unmapped manager" banners
+ * without a page reload. `normalizedKeys` lets clients filter their local
+ * re-computation, but any payload is a safe invalidation trigger.
+ */
+export interface DirectoryUpdatedPayload {
+  tenantId: string;
+  action: 'created' | 'updated' | 'deleted' | 'archived' | 'merged';
+  entryId?: string;
+  normalizedKeys?: string[];
 }

--- a/apps/api/test/directory.service.merge.test.ts
+++ b/apps/api/test/directory.service.merge.test.ts
@@ -73,6 +73,9 @@ describe('DirectoryService.merge', () => {
           return null;
         },
       },
+      process: {
+        findMany: async () => [] as Array<{ displayCode: string }>,
+      },
       $transaction: async (fn: (tx: typeof txStub) => Promise<number>) => fn(txStub),
     };
 
@@ -84,6 +87,7 @@ describe('DirectoryService.merge', () => {
           appendCalls.push(meta);
         },
       } as never,
+      { emitToProcess: () => {} } as never,
     );
 
     const out = await service.merge(admin, { sourceId: 'src', targetId: 'tgt' });

--- a/apps/web/src/components/escalations/Composer.tsx
+++ b/apps/web/src/components/escalations/Composer.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FunctionId, ProcessEscalationManagerRow } from '@ses/domain';
 import { FUNCTION_IDS } from '@ses/domain';
 import toast from 'react-hot-toast';
@@ -12,6 +12,7 @@ import {
   sendCompose,
   type ComposeDraftPayload,
 } from '../../lib/api/trackingComposeApi';
+import { useAutosaveOnLeave } from '../../hooks/useAutosaveOnLeave';
 import { Button } from '../shared/Button';
 import { PreviewPane } from './PreviewPane';
 
@@ -194,6 +195,27 @@ export function Composer({
     channel,
     ...(templateId ? { templateId } : {}),
   };
+
+  // Autosave-on-leave (Issue #74): silent flush of whatever the auditor has
+  // typed so far when the tab is hidden, the window unloads, or the route
+  // changes. Only fires when something has actually been edited (dirtyRef),
+  // and never when the drawer is read-only / locked by another user.
+  const dirtyRef = useRef(false);
+  useEffect(() => {
+    dirtyRef.current = true;
+  }, [subject, body, cc, removedEngines, channel, templateId]);
+  const latestPayloadRef = useRef(payload);
+  latestPayloadRef.current = payload;
+  useAutosaveOnLeave(async () => {
+    if (readOnly || !trackingRef || !dirtyRef.current) return;
+    if (!latestPayloadRef.current.body?.trim() && !latestPayloadRef.current.subject?.trim()) return;
+    try {
+      await saveComposeDraft(trackingRef, latestPayloadRef.current);
+      dirtyRef.current = false;
+    } catch {
+      // Autosave is best-effort — never interrupt the user's navigation.
+    }
+  }, Boolean(trackingRef));
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -134,7 +134,13 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
           {activeFile?.lastAuditedAt ? <div className="mt-0.5 text-[11px] text-gray-500">Last run: {new Date(activeFile.lastAuditedAt).toLocaleString()}</div> : null}
         </div>
         <Button
-          title={canSave ? '' : latestResult ? 'No new audit to save.' : 'Run an audit first to save a version.'}
+          title={
+            canSave
+              ? 'Manual save with a custom name — audits already auto-save a version on each new run.'
+              : latestResult
+              ? 'No new audit to save.'
+              : 'Run an audit first to save a version.'
+          }
           disabled={!canSave}
           onClick={() => setVersionModalOpen(true)}
           variant="secondary"

--- a/apps/web/src/hooks/useAutosaveOnLeave.ts
+++ b/apps/web/src/hooks/useAutosaveOnLeave.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Flushes an in-progress edit (compose draft, inline correction, note) any
+ * time the user is about to lose the current context: tab hide / switch,
+ * pagehide / beforeunload, or a client-side route change.
+ *
+ * The `flush` callback is read through a ref so callers can pass an inline
+ * arrow without re-registering the unload listeners on every render.
+ *
+ * Callers must keep the flush idempotent — it may fire more than once for a
+ * single navigation (e.g. visibilitychange + pagehide in the same flow).
+ */
+export function useAutosaveOnLeave(flush: () => void | Promise<void>, enabled: boolean = true): void {
+  const flushRef = useRef(flush);
+  flushRef.current = flush;
+  const location = useLocation();
+  const lastPath = useRef(location.pathname + location.search);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const run = () => {
+      try {
+        void flushRef.current();
+      } catch {
+        // Flush failures must never block navigation.
+      }
+    };
+    const onVis = () => {
+      if (document.hidden) run();
+    };
+    // pagehide fires on mobile Safari where beforeunload is unreliable; both
+    // together cover desktop and mobile.
+    window.addEventListener('pagehide', run);
+    window.addEventListener('beforeunload', run);
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      window.removeEventListener('pagehide', run);
+      window.removeEventListener('beforeunload', run);
+      document.removeEventListener('visibilitychange', onVis);
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const key = location.pathname + location.search;
+    if (lastPath.current !== key) {
+      try {
+        void flushRef.current();
+      } catch {
+        // Swallow — route transitions must still proceed.
+      }
+      lastPath.current = key;
+    }
+  }, [enabled, location.pathname, location.search]);
+}

--- a/apps/web/src/lib/api/auditsApi.ts
+++ b/apps/web/src/lib/api/auditsApi.ts
@@ -28,6 +28,11 @@ export interface ApiAuditRunSummary {
   status: string;
   scannedRows: number;
   flaggedRows: number;
+  /**
+   * Deterministic hash of the run's issue set (Issue #74). Empty string for
+   * legacy rows created before the column existed.
+   */
+  findingsHash?: string;
   summary: Record<string, unknown>;
   startedAt: string;
   completedAt: string | null;

--- a/apps/web/src/pages/EscalationCenter.tsx
+++ b/apps/web/src/pages/EscalationCenter.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { onRealtimeEvent } from '../realtime/socket';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, Megaphone } from 'lucide-react';
+import { ArrowLeft, Megaphone, RefreshCw } from 'lucide-react';
 import type { FunctionId, ProcessEscalationManagerRow } from '@ses/domain';
 import { FUNCTION_REGISTRY } from '@ses/domain';
 import { AppShell } from '../components/layout/AppShell';
@@ -117,6 +117,12 @@ export function EscalationCenter() {
         // Invalidate any open tracking-events queries too so the timeline
         // auto-advances when the SLA cron transitions a stage.
         void queryClient.invalidateQueries({ queryKey: ['tracking-events'] });
+      } else if (envelope.event === 'directory.updated') {
+        // Issue #74: a Manager Directory mutation (inline-add, alias,
+        // merge, archive, delete) invalidates the "unmapped manager"
+        // banner and may free a previously-blocked escalation for send.
+        void queryClient.invalidateQueries({ queryKey: ['escalations', processId] });
+        void queryClient.invalidateQueries({ queryKey: ['directory-suggestions'] });
       }
     });
     return off;
@@ -229,6 +235,18 @@ export function EscalationCenter() {
             </Link>
             <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Escalation Center</h1>
             <span className="flex-1" />
+            <button
+              type="button"
+              onClick={() => {
+                void q.refetch();
+                void queryClient.invalidateQueries({ queryKey: ['directory-suggestions'] });
+              }}
+              disabled={q.isFetching}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs text-gray-600 hover:border-gray-300 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300"
+              title="Force a refresh — only needed if the live feed has dropped"
+            >
+              <RefreshCw size={14} className={q.isFetching ? 'animate-spin' : ''} /> Refresh
+            </button>
             <button
               type="button"
               onClick={() => setBroadcastOpen(true)}

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -1,5 +1,6 @@
 import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Users } from 'lucide-react';
 import { DEFAULT_FUNCTION_ID, getFunctionLabel, isFunctionId, isValidEmail, type FunctionId } from '@ses/domain';
 import { FilesSidebar } from '../components/workspace/FilesSidebar';
@@ -19,6 +20,7 @@ import { useAppStore } from '../store/useAppStore';
 import { isLegacyTileTrackingTabEnabled } from '../lib/featureFlags';
 import { processDashboardPath } from '../lib/processRoutes';
 import { useRealtime } from '../realtime/useRealtime';
+import { onRealtimeEvent } from '../realtime/socket';
 import { directorySuggestions } from '../lib/api/directoryApi';
 import { ResolutionDrawer } from '../components/directory/ResolutionDrawer';
 
@@ -50,8 +52,8 @@ export function Workspace() {
   const tabFromUrl = searchParams.get('tab');
   const [membersOpen, setMembersOpen] = useState(false);
   const [resolutionOpen, setResolutionOpen] = useState(false);
-  const [unmappedCount, setUnmappedCount] = useState<number | null>(null);
   const hydrateAttemptedRef = useRef(false);
+  const queryClient = useQueryClient();
   const [hydrateFinished, setHydrateFinished] = useState(false);
   // hydrating is true only while we're waiting for hydrateProcesses() to complete.
   // Derived rather than stored so we never need setState in an effect's sync path.
@@ -70,26 +72,37 @@ export function Workspace() {
     return [...names];
   }, [process, functionId, result]);
 
+  // Issue #74: unmapped-manager banner is a React Query rather than a
+  // manual effect so any `directory.updated` realtime event or explicit
+  // invalidation from elsewhere re-runs the suggestion fetch automatically.
+  // The query key embeds the sorted name list so the cache buckets per
+  // distinct input and avoids double-fetches across remounts.
+  const directorySuggestionsKey = useMemo(
+    () => ['directory-suggestions', [...rawManagerNames].sort()] as const,
+    [rawManagerNames],
+  );
+  const suggestionsQ = useQuery({
+    queryKey: directorySuggestionsKey,
+    queryFn: () => directorySuggestions(rawManagerNames),
+    enabled: managerDirectoryOn && rawManagerNames.length > 0,
+    staleTime: 60_000,
+  });
+  const unmappedCount =
+    managerDirectoryOn && rawManagerNames.length > 0 && suggestionsQ.data
+      ? rawManagerNames.filter((name) => !suggestionsQ.data.results[name]?.autoMatch).length
+      : null;
+
+  // Realtime invalidation: directory mutations (resolve, inline add, merge,
+  // archive, delete) must flush the amber banner immediately without a
+  // browser refresh.
   useEffect(() => {
-    if (!managerDirectoryOn || rawManagerNames.length === 0) {
-      setUnmappedCount(null);
-      return;
-    }
-    let cancelled = false;
-    void (async () => {
-      try {
-        const sug = await directorySuggestions(rawManagerNames);
-        if (cancelled) return;
-        const n = rawManagerNames.filter((name) => !sug.results[name]?.autoMatch).length;
-        setUnmappedCount(n);
-      } catch {
-        if (!cancelled) setUnmappedCount(null);
+    const off = onRealtimeEvent((envelope) => {
+      if (envelope.event === 'directory.updated') {
+        void queryClient.invalidateQueries({ queryKey: ['directory-suggestions'] });
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [rawManagerNames, managerDirectoryOn]);
+    });
+    return off;
+  }, [queryClient]);
 
   // If the user hard-refreshed /workspace/<id> in a tab that has no cached
   // process (incognito, different logged-in user, cleared storage) the store

--- a/apps/web/src/realtime/types.ts
+++ b/apps/web/src/realtime/types.ts
@@ -27,7 +27,8 @@ export type RealtimeEventName =
   | 'activity.appended'
   | 'conflict.row_version'
   | 'process.member_removed'
-  | 'process.deleted';
+  | 'process.deleted'
+  | 'directory.updated';
 
 export interface RealtimeActor {
   id: string;

--- a/apps/web/src/store/useAppStore.ts
+++ b/apps/web/src/store/useAppStore.ts
@@ -190,6 +190,20 @@ function patchFile(process: AuditProcess, fileId: string, updater: (file: Workbo
  * The backend uses `ruleCode` / `displayCode`; the UI uses `ruleId` / `id`.
  * We map both directions so saved versions keep working.
  */
+/**
+ * Local fallback for AuditResult.findingsHash when the run came from the
+ * in-browser engine (no server hash). Same shape as the server hash so
+ * compare-by-equality works; uniqueness inside a session is enough for
+ * the auto-save dedup, no collision-resistance guarantee needed.
+ */
+function localFindingsSignature(issues: AuditResult['issues']): string {
+  const normalized = issues
+    .map((i) => `${i.issueKey ?? i.id}|${i.ruleCode ?? ''}|${i.severity ?? ''}`)
+    .sort()
+    .join('\n');
+  return `local:${issues.length}:${normalized.length}`;
+}
+
 function mapApiAuditToResult(
   fileId: string,
   run: ApiAuditRunSummary,
@@ -228,6 +242,7 @@ function mapApiAuditToResult(
     runAt: run.completedAt ?? run.startedAt,
     scannedRows: run.scannedRows,
     flaggedRows: run.flaggedRows,
+    findingsHash: run.findingsHash ?? '',
     issues: mapped,
     sheets: sheetSummary,
   };
@@ -598,6 +613,29 @@ export const useAppStore = create<AppStore>()(
 
         const fileDisplayCode = (file as { displayCode?: string }).displayCode;
         const useServer = Boolean(process.serverBacked && process.displayCode && fileDisplayCode);
+
+        // Issue #74: auto-save a SavedVersion after a successful run unless
+        // the new findings are identical to the most recent version for the
+        // same file (dedup by findingsHash — server-computed for server
+        // runs, falls back to issueKey-based signature for local runs).
+        const autoSaveAfterRun = (result: AuditResult) => {
+          const current = get().processes.find((p) => p.id === processId);
+          if (!current) return;
+          const sameFileVersion = current.versions.find((v) => v.result.fileId === result.fileId);
+          const prevHash = sameFileVersion?.result.findingsHash ?? '';
+          const nextHash =
+            result.findingsHash ??
+            localFindingsSignature(result.issues);
+          if (prevHash && nextHash && prevHash === nextHash) {
+            // Same findings — keep the existing version anchor; nothing to save.
+            return;
+          }
+          get().saveVersion(processId, {
+            versionName: `${current.name} - V${current.versions.length + 1}`,
+            notes: '',
+          });
+        };
+
         try {
           if (useServer) {
             const apiResult = await runAuditOnApi(process.displayCode!, fileDisplayCode!);
@@ -618,6 +656,7 @@ export const useAppStore = create<AppStore>()(
                 })),
               ),
             }));
+            autoSaveAfterRun(mapped);
             return;
           }
           // Local-only processes run the per-function dispatcher in-browser.
@@ -637,6 +676,7 @@ export const useAppStore = create<AppStore>()(
               })),
             ),
           }));
+          autoSaveAfterRun(result);
         } catch (err) {
           // Only clear the in-flight flag if this is still the active run;
           // otherwise we'd stomp a newer run's progress state.

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -144,6 +144,12 @@ export interface AuditResult {
   runAt: string;
   scannedRows: number;
   flaggedRows: number;
+  /**
+   * Deterministic identity of the issue set. Used client-side (Issue #74) to
+   * skip auto-saving a version when two consecutive runs produce the same
+   * findings.
+   */
+  findingsHash?: string;
   issues: AuditIssue[];
   sheets: SheetAuditResult[];
   policySnapshot?: AuditPolicy;


### PR DESCRIPTION
Closes #74

## Summary

Auditors no longer lose work: audits auto-save a version, compose drafts flush on tab-hide / unload / navigation, and directory resolves show up in the Escalation Center without a reload.

## Changes

- **Backend**
  - `AuditRun.findingsHash` column + migration; stable sha256 over sorted issue identity, computed inside `AuditsService.run`.
  - `DirectoryService` now emits a new `directory.updated` realtime event after every mutation (commit, inline resolve, alias resolve, create, delete, archive bulk, merge, patch). Fans out to every active process in the tenant — no schema changes needed to the gateway.
  - `realtime.types.ts` — new `directory.updated` event + `DirectoryUpdatedPayload`.
- **Frontend**
  - New `useAutosaveOnLeave` hook: flushes on `visibilitychange` (hidden), `pagehide`, `beforeunload`, and client-side route change.
  - `Composer.tsx` — wired to silently `saveComposeDraft` via the new hook; dirty-tracks subject/body/cc/removedEngines/channel/template.
  - `useAppStore.runAudit` — after success, auto-saves a `SavedVersion` unless `findingsHash` matches the latest version for the same file (dedup). Uses a local signature as fallback when audits run fully client-side.
  - `EscalationCenter.tsx` — listens for `directory.updated` and invalidates both the escalations list and directory-suggestions cache. Adds a **Refresh** icon button next to Broadcast.
  - `Workspace.tsx` — amber "unmapped manager" banner migrated from a manual `useEffect` to `useQuery` keyed on the sorted name list; invalidates on `directory.updated`.
  - `TopBar.tsx` — Save Version button tooltip now reads "Manual save with a custom name — audits already auto-save a version on each new run."
- **Database**
  - `20260422230000_issue74_audit_findings_hash`: `ALTER TABLE "AuditRun" ADD COLUMN "findingsHash" TEXT NOT NULL DEFAULT '';`

## Behavior

- Running an audit always leaves a version anchoring the findings. Re-running on the unchanged file → no duplicate version (toast-free, silent).
- Mid-compose tab-close or route change silently persists the draft via the existing `/tracking/compose/draft` endpoint.
- Resolving a manager in Master Data clears the "Missing email" chip on other open Escalation Center / Workspace tabs within one event round-trip.
- Refresh button is a recovery lever for websocket hiccups; live events are primary.

## Constraints Handled

- Autosave is best-effort; failures are swallowed so they never block navigation.
- `directory.updated` fan-out is bounded by the tenant's active process count (O(n) in-memory emits); keeps the gateway contract unchanged.
- `findingsHash` dedup is skipped on the first run (no prior version) and falls back gracefully for local/browser-only audits.
- Directory test was updated to construct `DirectoryService` with the new realtime gateway dependency.

## Testing

- `tsc --noEmit` clean for `apps/api` and `apps/web`.
- Existing directory merge test passes with the new constructor signature (stubbed gateway + `process.findMany`).
- Not verified in a browser — needs smoke test of (a) audit re-run dedup, (b) directory resolve → banner clears, (c) compose tab-close flush.

## Notes

- Migration is additive and non-breaking; existing runs carry `findingsHash = ''` and first-run dedup short-circuits on empty prevHash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)