### PR TITLE
feat(issue-75): mailto/Teams handoff with channel gating

### DIFF
--- a/apps/api/prisma/migrations/20260422231500_issue75_notification_log_note_deadline/migration.sql
+++ b/apps/api/prisma/migrations/20260422231500_issue75_notification_log_note_deadline/migration.sql
@@ -1,0 +1,6 @@
+-- Issue #75: the auditor's own mail/Teams client now does the send. The
+-- server records intent and counts; these two columns capture context that
+-- was previously only communicated in the body of the email.
+ALTER TABLE "notification_log"
+  ADD COLUMN "authorNote" TEXT NOT NULL DEFAULT '',
+  ADD COLUMN "deadlineAt" TIMESTAMPTZ NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -711,6 +711,11 @@ model NotificationLog {
   sources      Json?
   severity     String?
   issueCount   Int      @default(0)
+  /// Auditor-only freeform note captured alongside a handoff (Issue #75).
+  /// Not shown to the manager; used for post-hoc explanation in the activity feed.
+  authorNote   String   @default("")
+  /// Due date surfaced to the recipient via the {{dueDate}} slot (Issue #75).
+  deadlineAt   DateTime?
   sentAt       DateTime @default(now())
 
   process Process @relation(fields: [processId], references: [id], onDelete: Cascade)

--- a/apps/api/src/escalations-aggregator.ts
+++ b/apps/api/src/escalations-aggregator.ts
@@ -29,6 +29,8 @@ export type AggregatorTrackingRow = {
   slaDueAt: Date | null;
   id: string;
   displayCode: string;
+  outlookCount: number;
+  teamsCount: number;
 };
 
 function issueManagerKey(row: AggregatorIssueRow): string {
@@ -140,6 +142,8 @@ export function aggregateEscalations(
       slaDueAt: tr?.slaDueAt?.toISOString() ?? null,
       trackingId: tr?.id ?? null,
       trackingDisplayCode: tr?.displayCode ?? null,
+      outlookCount: tr?.outlookCount ?? 0,
+      teamsCount: tr?.teamsCount ?? 0,
     });
   }
 

--- a/apps/api/src/escalations.service.ts
+++ b/apps/api/src/escalations.service.ts
@@ -68,6 +68,8 @@ export class EscalationsService {
         resolved: true,
         lastContactAt: true,
         slaDueAt: true,
+        outlookCount: true,
+        teamsCount: true,
         draftLockExpiresAt: true,
         draftLockUser: { select: { displayName: true } },
       },
@@ -83,6 +85,8 @@ export class EscalationsService {
       slaDueAt: t.slaDueAt,
       id: t.id,
       displayCode: t.displayCode,
+      outlookCount: t.outlookCount,
+      teamsCount: t.teamsCount,
     }));
 
     const payload = aggregateEscalations(process.id, issues, tracking);

--- a/apps/api/src/outbound/outbound-delivery.service.ts
+++ b/apps/api/src/outbound/outbound-delivery.service.ts
@@ -1,59 +1,25 @@
-import { Injectable, ServiceUnavailableException } from '@nestjs/common';
-import nodemailer from 'nodemailer';
+import { Injectable } from '@nestjs/common';
 
 export type EscalationSendChannel = 'email' | 'teams' | 'both';
 
+/**
+ * Issue #75: server-side SMTP / Teams webhook delivery was removed. The web
+ * client now opens the user's own mail client (`mailto:`) or Teams deep-link
+ * with the prefilled content after the server records the handoff. This
+ * class survives as a no-op to keep the module graph intact for any code
+ * path that still DI-injects it; it no longer reads env vars and no longer
+ * talks to nodemailer or Teams.
+ */
 @Injectable()
 export class OutboundDeliveryService {
-  async sendEscalation(opts: {
+  async sendEscalation(_opts: {
     channel: EscalationSendChannel;
     to: string;
     cc: string[];
     subject: string;
     bodyText: string;
   }): Promise<void> {
-    const needEmail = opts.channel === 'email' || opts.channel === 'both';
-    const needTeams = opts.channel === 'teams' || opts.channel === 'both';
-    const smtpUrl = process.env.SES_SMTP_URL?.trim();
-    const teamsWebhook = process.env.SES_TEAMS_INCOMING_WEBHOOK_URL?.trim();
-
-    if (needEmail && !smtpUrl) {
-      throw new ServiceUnavailableException('Outbound email is not configured (set SES_SMTP_URL).');
-    }
-    if (needTeams && !teamsWebhook) {
-      throw new ServiceUnavailableException('Teams webhook is not configured (set SES_TEAMS_INCOMING_WEBHOOK_URL).');
-    }
-
-    if (needEmail) {
-      const transport = nodemailer.createTransport(smtpUrl);
-      const from = process.env.SES_MAIL_FROM?.trim() || 'noreply@ses.local';
-      await transport.sendMail({
-        from,
-        to: opts.to,
-        cc: opts.cc.length ? opts.cc.join(', ') : undefined,
-        subject: opts.subject,
-        text: opts.bodyText,
-      });
-    }
-
-    if (needTeams) {
-      const card = {
-        '@type': 'MessageCard',
-        '@context': 'https://schema.org/extensions',
-        summary: opts.subject,
-        themeColor: '0078D4',
-        title: opts.subject,
-        text: opts.bodyText.replace(/\n+/g, '\n\n'),
-      };
-      const res = await fetch(teamsWebhook!, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(card),
-      });
-      if (!res.ok) {
-        const t = await res.text().catch(() => '');
-        throw new ServiceUnavailableException(`Teams webhook failed: ${res.status} ${t}`.slice(0, 500));
-      }
-    }
+    // Intentionally empty — the client-handoff path in the web app does
+    // the actual send via the auditor's own mail / Teams application.
   }
 }

--- a/apps/api/src/tracking-compose/tracking-compose.controller.ts
+++ b/apps/api/src/tracking-compose/tracking-compose.controller.ts
@@ -45,4 +45,14 @@ export class TrackingComposeController {
   ) {
     return this.composeService.send(idOrCode, user, body);
   }
+
+  // Issue #75: admin-only cycle reset. Zeroes outlookCount / teamsCount
+  // so the channel gate re-opens at Outlook #1.
+  @Post('tracking/:idOrCode/force-reescalate')
+  forceReescalate(
+    @Param('idOrCode') idOrCode: string,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.composeService.forceReescalate(idOrCode, user);
+  }
 }

--- a/apps/api/src/tracking-compose/tracking-compose.service.ts
+++ b/apps/api/src/tracking-compose/tracking-compose.service.ts
@@ -33,7 +33,36 @@ export type ComposeDraftPayload = {
   cc: string[];
   removedEngineIds?: string[];
   channel?: EscalationSendChannel;
+  /** Auditor-only note persisted alongside the send. Not shown to the manager. */
+  authorNote?: string;
+  /** ISO-8601 date for the {{dueDate}} slot. */
+  deadlineAt?: string | null;
 };
+
+/**
+ * Issue #75: escalation cycle is outlook → outlook → teams, then the cycle
+ * is complete. The server is the source of truth for the gate; the UI
+ * mirrors it from `outlookCount` / `teamsCount` on the tracking entry.
+ * Admin-only `forceReescalate` zeroes the counters to start a new cycle.
+ */
+function assertChannelAllowed(
+  entry: { outlookCount: number; teamsCount: number },
+  channel: EscalationSendChannel,
+): void {
+  const effective: 'outlook' | 'teams' = channel === 'teams' ? 'teams' : 'outlook';
+  if (effective === 'outlook') {
+    if (entry.outlookCount >= 2) {
+      throw new ConflictException('Outlook limit reached for this cycle — escalate via Teams next.');
+    }
+    return;
+  }
+  if (entry.outlookCount < 2) {
+    throw new ConflictException('Send two Outlook reminders before escalating to Teams.');
+  }
+  if (entry.teamsCount >= 1) {
+    throw new ConflictException('Cycle complete — resolve or force re-escalate before sending again.');
+  }
+}
 
 function stageKeyForLevel(level: number): string {
   if (level >= 2) return 'ESCALATED_L2';
@@ -182,30 +211,53 @@ export class TrackingComposeService {
     ) {
       throw new ForbiddenException('Another user holds the compose lock.');
     }
-    if (entry.stage !== EscalationStage.NEW && entry.stage !== EscalationStage.DRAFTED) {
-      throw new BadRequestException('Send is only allowed from NEW or DRAFTED.');
+    // The ladder may be at any stage the cycle allows: NEW/DRAFTED for the
+    // first Outlook, AWAITING_RESPONSE for the second Outlook, and
+    // AWAITING_RESPONSE / ESCALATED_L1 / NO_RESPONSE for the Teams leg. Any
+    // other stage is a bug in the client: refuse loudly.
+    if (
+      entry.stage !== EscalationStage.NEW &&
+      entry.stage !== EscalationStage.DRAFTED &&
+      entry.stage !== EscalationStage.AWAITING_RESPONSE &&
+      entry.stage !== EscalationStage.ESCALATED_L1 &&
+      entry.stage !== EscalationStage.NO_RESPONSE
+    ) {
+      throw new BadRequestException(`Send is not allowed from stage ${entry.stage}.`);
     }
-    assertTransition(entry.stage as DomainEscalationStage, EscalationStage.SENT);
-    assertTransition(EscalationStage.SENT, EscalationStage.AWAITING_RESPONSE);
 
     const { subject, text, channel } = await this.resolveContent(entry, user, body);
     const sendChannel: EscalationSendChannel = channel ?? 'email';
+    // Channel gate (Issue #75): the 2-Outlooks-then-1-Teams cycle is
+    // enforced here so race conditions between multiple auditors can't
+    // punch through the counter.
+    assertChannelAllowed({ outlookCount: entry.outlookCount, teamsCount: entry.teamsCount }, sendChannel);
+    if (sendChannel === 'both') {
+      // The client-handoff path opens one window per channel; mailto and
+      // the Teams deep-link can't be atomically composed anyway. Force the
+      // auditor to pick one explicitly.
+      throw new BadRequestException('Channel "both" is no longer supported — pick Outlook or Teams.');
+    }
+
     const to = (entry.managerEmail ?? '').trim();
     if (!to) {
       throw new BadRequestException('Manager email is required before send.');
     }
 
-    await this.outbound.sendEscalation({
-      channel: sendChannel,
-      to,
-      cc: (body.cc ?? []).map((c) => c.trim()).filter(Boolean),
-      subject,
-      bodyText: text,
-    });
+    // Issue #75: no SMTP, no Teams webhook. The web client opens mailto: /
+    // teams deep-link with the prefilled content after this endpoint
+    // returns. We only RECORD the handoff here so the ladder advances and
+    // the activity timeline reflects what happened.
 
     const slaHours = entry.process.slaInitialHours ?? 120;
     const slaDueAt = new Date(Date.now() + slaHours * 60 * 60 * 1000);
     const issueCount = body.sources?.length ? body.sources.length : 0;
+    const deadlineAt = body.deadlineAt ? new Date(body.deadlineAt) : null;
+    const authorNote = (body.authorNote ?? '').slice(0, 2000);
+
+    // The Teams leg transitions to ESCALATED_L1 so the timeline clearly
+    // distinguishes an Outlook reminder from a Teams escalation.
+    const nextStage: EscalationStage =
+      sendChannel === 'teams' ? EscalationStage.ESCALATED_L1 : EscalationStage.AWAITING_RESPONSE;
 
     const logRow = await this.prisma.$transaction(async (tx) => {
       const log = await tx.notificationLog.create({
@@ -216,12 +268,14 @@ export class TrackingComposeService {
           trackingEntryId: entry.id,
           managerEmail: to.toLowerCase(),
           managerName: entry.managerName,
-          channel: sendChannel === 'both' ? 'both' : sendChannel,
+          channel: sendChannel,
           subject,
           bodyPreview: text.slice(0, 2000),
           resolvedBody: text,
           sources: body.sources as object,
           issueCount,
+          authorNote,
+          deadlineAt,
         },
       });
       await tx.trackingEvent.create({
@@ -230,20 +284,24 @@ export class TrackingComposeService {
           displayCode: await this.identifiers.nextTrackingEventCode(tx),
           trackingId: entry.id,
           kind: 'escalation_sent',
-          channel: sendChannel === 'both' ? 'sendAll' : sendChannel === 'teams' ? 'teams' : 'outlook',
+          channel: sendChannel === 'teams' ? 'teams' : 'outlook',
           note: subject.slice(0, 200),
           reason: 'escalation_send',
-          payload: { sources: body.sources, notificationLogId: log.id } as object,
+          payload: {
+            sources: body.sources,
+            notificationLogId: log.id,
+            deadlineAt: deadlineAt?.toISOString() ?? null,
+            authorNote,
+          } as object,
           triggeredById: user.id,
         },
       });
-      const outlookInc =
-        sendChannel === 'email' || sendChannel === 'both' ? 1 : 0;
-      const teamsInc = sendChannel === 'teams' || sendChannel === 'both' ? 1 : 0;
+      const outlookInc = sendChannel === 'email' ? 1 : 0;
+      const teamsInc = sendChannel === 'teams' ? 1 : 0;
       await tx.trackingEntry.update({
         where: { id: entry.id },
         data: {
-          stage: EscalationStage.AWAITING_RESPONSE,
+          stage: nextStage,
           outlookCount: outlookInc ? { increment: outlookInc } : undefined,
           teamsCount: teamsInc ? { increment: teamsInc } : undefined,
           lastContactAt: new Date(),
@@ -272,7 +330,69 @@ export class TrackingComposeService {
       issueCount: logRow.issueCount,
     }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
 
-    return { ok: true, notificationLogId: logRow.id };
+    // Return the resolved content so the client can hand it to the user's
+    // mail / Teams app immediately — no second round-trip for preview.
+    return {
+      ok: true,
+      notificationLogId: logRow.id,
+      channel: sendChannel,
+      subject,
+      body: text,
+      to: to.toLowerCase(),
+      cc: (body.cc ?? []).map((c) => c.trim()).filter(Boolean),
+    };
+  }
+
+  /**
+   * Admin-only cycle reset (Issue #75). Zeroes the Outlook / Teams
+   * counters and stamps a `cycle_reset` TrackingEvent so the activity
+   * feed explains why a manager is seeing a fresh round of reminders.
+   * Transitions back to NEW so the gate reopens at Outlook #1.
+   */
+  async forceReescalate(idOrCode: string, user: SessionUser) {
+    if (user.role !== 'admin') {
+      throw new ForbiddenException('Admin role required to force a new cycle.');
+    }
+    const entry = await this.loadEntry(idOrCode, user);
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const row = await tx.trackingEntry.update({
+        where: { id: entry.id },
+        data: {
+          outlookCount: 0,
+          teamsCount: 0,
+          stage: EscalationStage.NEW,
+          slaDueAt: null,
+          rowVersion: { increment: 1 },
+        },
+      });
+      await tx.trackingEvent.create({
+        data: {
+          id: createId(),
+          displayCode: await this.identifiers.nextTrackingEventCode(tx),
+          trackingId: entry.id,
+          kind: 'cycle_reset',
+          channel: 'manual',
+          note: 'Cycle reset — Outlook and Teams counters zeroed.',
+          reason: 'force_reescalate',
+          triggeredById: user.id,
+        },
+      });
+      await this.activity.append(tx, {
+        actorId: user.id,
+        actorEmail: user.email,
+        processId: entry.processId,
+        entityType: 'tracking_entry',
+        entityId: entry.id,
+        entityCode: entry.displayCode,
+        action: 'tracking.cycle_reset',
+      });
+      return row;
+    });
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: updated.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+    return { ok: true, stage: updated.stage };
   }
 
   private async pickTemplate(tenantId: string, stageKey: string, templateId?: string) {

--- a/apps/api/test/escalations-aggregator.test.ts
+++ b/apps/api/test/escalations-aggregator.test.ts
@@ -33,6 +33,8 @@ describe('aggregateEscalations', () => {
         slaDueAt: null,
         id: 't1',
         displayCode: 'TRK-1',
+        outlookCount: 1,
+        teamsCount: 0,
       },
     ];
     const payload = aggregateEscalations('proc-1', issues, tracking);

--- a/apps/web/src/components/escalations/BroadcastDialog.tsx
+++ b/apps/web/src/components/escalations/BroadcastDialog.tsx
@@ -4,16 +4,37 @@ import { Megaphone, Send } from 'lucide-react';
 import { broadcastNotification } from '../../lib/api/bulkTrackingApi';
 import { Modal } from '../shared/Modal';
 import { Button } from '../shared/Button';
+import { PreviewPane } from './PreviewPane';
 
-type Channel = 'email' | 'teams' | 'both';
+// Issue #75: 'both' was supported when the server did the sending via SMTP
+// + Teams webhook. The client-handoff model opens the user's own app, one
+// channel at a time; 'both' would require two tabs per recipient which is
+// not a useful broadcast UX. Channel is pick-one.
+type Channel = 'email' | 'teams';
 
-// A no-frills "tell everyone at once" dialog. The heavy lifting lives on
-// the server; the UI just owns the message, the channel, and the scope
-// toggle (all open findings vs. only a specific function's findings).
-//
-// Deliberately simple: the per-recipient render already happens in the
-// Composer; Broadcast is the "send one thing to many" path and should
-// feel like it.
+function addBusinessDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  let added = 0;
+  while (added < days) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    const wd = d.getUTCDay();
+    if (wd !== 0 && wd !== 6) added += 1;
+  }
+  return d;
+}
+
+function toDateInputValue(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// A no-frills "tell everyone at once" dialog. Issue #75 keeps the bulk
+// broadcast API (one server-side round-trip for the whole audience), but
+// the dialog now opens preview-first and carries a due date + auditor note
+// so the auditor reviews the copy against a representative recipient before
+// firing.
 export function BroadcastDialog({
   processIdOrCode,
   open,
@@ -29,17 +50,23 @@ export function BroadcastDialog({
   estimatedAudience: number;
   functionOptions?: Array<{ id: string; label: string }>;
 }) {
-  const [subject, setSubject] = useState('Reminder: open master-data findings');
+  const [view, setView] = useState<'preview' | 'edit'>('preview');
+  const [subject, setSubject] = useState('Reminder: open findings for your review');
   const [body, setBody] = useState(
     'Hi {{managerName}},\n\nYou have {{projectCount}} open findings that need attention. Please review and respond by {{dueDate}}.\n\nThanks.',
   );
   const [channel, setChannel] = useState<Channel>('email');
   const [functionId, setFunctionId] = useState<string>('');
+  const [authorNote, setAuthorNote] = useState('');
+  const [deadlineAt, setDeadlineAt] = useState<string>(() =>
+    toDateInputValue(addBusinessDays(new Date(), 5)),
+  );
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     setBusy(false);
+    setView('preview');
   }, [open]);
 
   async function submit(event: FormEvent) {
@@ -54,23 +81,27 @@ export function BroadcastDialog({
     }
     setBusy(true);
     try {
+      const payload: Parameters<typeof broadcastNotification>[0]['payload'] = {
+        subject: subject.trim(),
+        body: body.trim(),
+        cc: [],
+        sources: [],
+        channel,
+        deadlineAt: deadlineAt || null,
+      };
+      const note = authorNote.trim();
+      if (note) payload.authorNote = note;
       const res = await broadcastNotification({
         processIdOrCode,
-        payload: {
-          subject: subject.trim(),
-          body: body.trim(),
-          cc: [],
-          sources: [],
-          channel,
-        },
+        payload,
         filter: functionId ? { functionId } : {},
       });
       if (res.skipped > 0 || res.failed > 0) {
-        toast(`Sent ${res.success}/${res.audience} · skipped ${res.skipped} · failed ${res.failed}.`, {
+        toast(`Recorded ${res.success}/${res.audience} · skipped ${res.skipped} · failed ${res.failed}.`, {
           icon: '⚠️',
         });
       } else {
-        toast.success(`Broadcast sent to ${res.success} manager${res.success === 1 ? '' : 's'}.`);
+        toast.success(`Broadcast recorded for ${res.success} manager${res.success === 1 ? '' : 's'}.`);
       }
       onDone();
       onClose();
@@ -80,6 +111,20 @@ export function BroadcastDialog({
       setBusy(false);
     }
   }
+
+  // Cheap per-recipient substitution for the preview. The server does the
+  // authoritative substitution at send time — this is a readability aid so
+  // the auditor sees what a manager will receive.
+  const previewSubject = subject
+    .replace(/\{\{managerName\}\}/g, '<first manager>')
+    .replace(/\{\{projectCount\}\}/g, '3')
+    .replace(/\{\{dueDate\}\}/g, deadlineAt ? new Date(deadlineAt).toLocaleDateString() : '—')
+    .replace(/\{\{auditRunCode\}\}/g, 'ARN-…');
+  const previewBody = body
+    .replace(/\{\{managerName\}\}/g, '<first manager>')
+    .replace(/\{\{projectCount\}\}/g, '3')
+    .replace(/\{\{dueDate\}\}/g, deadlineAt ? new Date(deadlineAt).toLocaleDateString() : '—')
+    .replace(/\{\{auditRunCode\}\}/g, 'ARN-…');
 
   return (
     <Modal
@@ -102,6 +147,14 @@ export function BroadcastDialog({
             Cancel
           </Button>
           <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setView(view === 'preview' ? 'edit' : 'preview')}
+            disabled={busy}
+          >
+            {view === 'preview' ? 'Edit' : 'Preview'}
+          </Button>
+          <Button
             type="submit"
             form="broadcast-form"
             disabled={busy || estimatedAudience === 0}
@@ -118,7 +171,7 @@ export function BroadcastDialog({
           manager{estimatedAudience === 1 ? '' : 's'} currently selected as audience.
         </div>
 
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid gap-3 md:grid-cols-3">
           <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
             Channel
             <select
@@ -126,9 +179,8 @@ export function BroadcastDialog({
               onChange={(event) => setChannel(event.target.value as Channel)}
               className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
             >
-              <option value="email">Email only</option>
-              <option value="teams">Teams only</option>
-              <option value="both">Email + Teams</option>
+              <option value="email">Email</option>
+              <option value="teams">Teams</option>
             </select>
           </label>
           {functionOptions.length > 0 ? (
@@ -148,31 +200,61 @@ export function BroadcastDialog({
               </select>
             </label>
           ) : null}
+          <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+            Due date
+            <input
+              type="date"
+              value={deadlineAt}
+              onChange={(event) => setDeadlineAt(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+            />
+          </label>
         </div>
 
-        <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-          Subject
-          <input
-            value={subject}
-            onChange={(event) => setSubject(event.target.value)}
-            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
-            required
-          />
-        </label>
+        {view === 'edit' ? (
+          <>
+            <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+              Subject
+              <input
+                value={subject}
+                onChange={(event) => setSubject(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+                required
+              />
+            </label>
+
+            <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+              Body
+              <textarea
+                value={body}
+                onChange={(event) => setBody(event.target.value)}
+                rows={8}
+                required
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-xs leading-relaxed dark:border-gray-700 dark:bg-gray-900"
+              />
+              <span className="mt-1 block text-[10px] text-gray-500">
+                Tokens: {`{{managerName}}`}, {`{{projectCount}}`}, {`{{dueDate}}`}, {`{{auditRunCode}}`} —
+                substituted per-recipient at send time.
+              </span>
+            </label>
+          </>
+        ) : (
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wide text-gray-500">
+              Preview (representative recipient — tokens are rendered per-manager at send time)
+            </div>
+            <PreviewPane subject={previewSubject} body={previewBody} deadlineAt={deadlineAt || null} />
+          </div>
+        )}
 
         <label className="block text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-          Body
+          Auditor note (internal — not shown to recipients)
           <textarea
-            value={body}
-            onChange={(event) => setBody(event.target.value)}
-            rows={8}
-            required
-            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-xs leading-relaxed dark:border-gray-700 dark:bg-gray-900"
+            value={authorNote}
+            onChange={(event) => setAuthorNote(event.target.value)}
+            rows={2}
+            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
-          <span className="mt-1 block text-[10px] text-gray-500">
-            Tokens: {`{{managerName}}`}, {`{{projectCount}}`}, {`{{dueDate}}`}, {`{{auditRunCode}}`} —
-            substituted per-recipient at send time.
-          </span>
         </label>
       </form>
     </Modal>

--- a/apps/web/src/components/escalations/Composer.tsx
+++ b/apps/web/src/components/escalations/Composer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FunctionId, ProcessEscalationManagerRow } from '@ses/domain';
 import { FUNCTION_IDS } from '@ses/domain';
 import toast from 'react-hot-toast';
+import { Mail, MessageSquare } from 'lucide-react';
 import { fetchEscalationTemplates } from '../../lib/api/escalationTemplatesApi';
 import {
   discardComposeDraft,
@@ -12,15 +13,37 @@ import {
   sendCompose,
   type ComposeDraftPayload,
 } from '../../lib/api/trackingComposeApi';
+import { openMailto, openTeamsChat } from '../../lib/outbound/clientHandoff';
 import { useAutosaveOnLeave } from '../../hooks/useAutosaveOnLeave';
 import { Button } from '../shared/Button';
 import { PreviewPane } from './PreviewPane';
+
+type SendChannel = 'email' | 'teams';
 
 function stageKeyForRow(row: ProcessEscalationManagerRow): string {
   const lv = row.escalationLevel ?? 0;
   if (lv >= 2) return 'ESCALATED_L2';
   if (lv >= 1) return 'ESCALATED_L1';
   return 'NEW';
+}
+
+function addBusinessDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  let added = 0;
+  while (added < days) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    const wd = d.getUTCDay();
+    if (wd !== 0 && wd !== 6) added += 1;
+  }
+  return d;
+}
+
+function toDateInputValue(d: Date): string {
+  // yyyy-mm-dd for <input type="date">
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 export function Composer({
@@ -34,17 +57,29 @@ export function Composer({
 }) {
   const qc = useQueryClient();
   const trackingRef = row.trackingId ?? row.trackingDisplayCode;
-  const [previewMode, setPreviewMode] = useState(false);
+
+  // Issue #75 — Composer defaults to Preview so the auditor reviews before
+  // sending. Edit is a toggle-back; send actions live in the preview footer.
+  const [viewMode, setViewMode] = useState<'preview' | 'edit'>('preview');
   const [templateId, setTemplateId] = useState<string | undefined>();
   const [subject, setSubject] = useState('');
   const [body, setBody] = useState('');
   const [cc, setCc] = useState<string[]>([]);
   const [ccInput, setCcInput] = useState('');
-  const [channel, setChannel] = useState<'email' | 'teams' | 'both'>('email');
   const [removedEngines, setRemovedEngines] = useState<Set<string>>(new Set());
   const [resolvedPreview, setResolvedPreview] = useState<{ subject: string; body: string } | null>(null);
   const [dirtyWarn, setDirtyWarn] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [authorNote, setAuthorNote] = useState('');
+  const [deadlineAt, setDeadlineAt] = useState<string>(() =>
+    toDateInputValue(addBusinessDays(new Date(), 5)),
+  );
+
+  const outlookCount = row.outlookCount ?? 0;
+  const teamsCount = row.teamsCount ?? 0;
+  const outlookAllowed = outlookCount < 2;
+  const teamsAllowed = outlookCount >= 2 && teamsCount < 1;
+  const cycleComplete = outlookCount >= 2 && teamsCount >= 1;
 
   const statusQ = useQuery({
     queryKey: ['compose-status', trackingRef],
@@ -79,33 +114,40 @@ export function Composer({
     setTemplateId(t.id);
     setSubject(t.subject);
     setBody(t.body);
-    setChannel((t.channel as 'email' | 'teams' | 'both') || 'email');
   }, [templatesQ.data]);
 
-  async function togglePreview() {
-    if (previewMode) {
-      setPreviewMode(false);
-      return;
-    }
+  // Refresh the resolved preview whenever we enter preview mode so the
+  // auditor sees the actual substituted copy, not the raw template.
+  useEffect(() => {
+    if (viewMode !== 'preview' || !trackingRef) return;
+    let cancelled = false;
     setPreviewLoading(true);
-    try {
-      const previewBody: Partial<ComposeDraftPayload> = {
-        subject,
-        body,
-        cc,
-        removedEngineIds: [...removedEngines],
-        channel,
-      };
-      if (templateId) previewBody.templateId = templateId;
-      const data = await previewCompose(trackingRef!, previewBody);
-      setResolvedPreview(data);
-      setPreviewMode(true);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Preview failed');
-    } finally {
-      setPreviewLoading(false);
-    }
-  }
+    const previewBody: Partial<ComposeDraftPayload> = {
+      subject,
+      body,
+      cc,
+      removedEngineIds: [...removedEngines],
+      authorNote,
+      deadlineAt: deadlineAt || null,
+    };
+    if (templateId) previewBody.templateId = templateId;
+    void previewCompose(trackingRef, previewBody)
+      .then((data) => {
+        if (cancelled) return;
+        setResolvedPreview(data);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        toast.error(e instanceof Error ? e.message : 'Preview failed');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [viewMode, trackingRef, templateId, subject, body, cc, removedEngines, authorNote, deadlineAt]);
 
   const draftMut = useMutation({
     mutationFn: (payload: ComposeDraftPayload) => saveComposeDraft(trackingRef!, payload),
@@ -127,18 +169,38 @@ export function Composer({
   });
 
   const sendMut = useMutation({
-    mutationFn: () =>
+    mutationFn: (channel: SendChannel) =>
       sendCompose(trackingRef!, {
         subject,
         body,
         cc,
         removedEngineIds: [...removedEngines],
         channel,
-        sources: FUNCTION_IDS.filter((id) => (row.countsByEngine[id] ?? 0) > 0 && !removedEngines.has(id)) as string[],
+        authorNote,
+        deadlineAt: deadlineAt || null,
+        sources: FUNCTION_IDS.filter(
+          (id) => (row.countsByEngine[id] ?? 0) > 0 && !removedEngines.has(id),
+        ) as string[],
         ...(templateId ? { templateId } : {}),
       }),
-    onSuccess: () => {
-      toast.success('Sent');
+    onSuccess: (result) => {
+      // Issue #75: the server only records intent; the user's own app does
+      // the actual send. Try to open it; fall back to a copy-hint when the
+      // browser's popup blocker kills the window.open.
+      const handoffOk =
+        result.channel === 'teams'
+          ? openTeamsChat({ to: result.to, message: `${result.subject}\n\n${result.body}` })
+          : openMailto({ to: result.to, cc: result.cc, subject: result.subject, body: result.body });
+      if (handoffOk) {
+        toast.success(
+          result.channel === 'teams' ? 'Recorded — Teams opening…' : 'Recorded — mail client opening…',
+        );
+      } else {
+        toast(
+          `Recorded on server. Your browser blocked the ${result.channel === 'teams' ? 'Teams' : 'mail'} window — open it manually.`,
+          { icon: '⚠️' },
+        );
+      }
       void qc.invalidateQueries({ queryKey: ['escalations'] });
       onDone();
     },
@@ -160,7 +222,6 @@ export function Composer({
     if (t) {
       setSubject(t.subject);
       setBody(t.body);
-      setChannel((t.channel as 'email' | 'teams' | 'both') || 'email');
     }
   }
 
@@ -192,7 +253,8 @@ export function Composer({
     body,
     cc,
     removedEngineIds: [...removedEngines],
-    channel,
+    authorNote,
+    deadlineAt: deadlineAt || null,
     ...(templateId ? { templateId } : {}),
   };
 
@@ -203,7 +265,7 @@ export function Composer({
   const dirtyRef = useRef(false);
   useEffect(() => {
     dirtyRef.current = true;
-  }, [subject, body, cc, removedEngines, channel, templateId]);
+  }, [subject, body, cc, removedEngines, templateId, authorNote, deadlineAt]);
   const latestPayloadRef = useRef(payload);
   latestPayloadRef.current = payload;
   useAutosaveOnLeave(async () => {
@@ -216,6 +278,19 @@ export function Composer({
       // Autosave is best-effort — never interrupt the user's navigation.
     }
   }, Boolean(trackingRef));
+
+  const outlookGateReason = cycleComplete
+    ? 'Cycle complete — resolve or force re-escalate.'
+    : outlookAllowed
+    ? ''
+    : 'Outlook limit reached — escalate via Teams next.';
+  const teamsGateReason = cycleComplete
+    ? 'Cycle complete — resolve or force re-escalate.'
+    : teamsAllowed
+    ? ''
+    : outlookCount < 2
+    ? `Send ${2 - outlookCount} more Outlook reminder${2 - outlookCount === 1 ? '' : 's'} before Teams.`
+    : 'Teams already used this cycle.';
 
   return (
     <div className="space-y-4">
@@ -232,6 +307,19 @@ export function Composer({
           </button>
         </div>
       ) : null}
+
+      <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+        <span className="font-medium">Ladder:</span>
+        <span className={`rounded-full px-2 py-0.5 ${outlookCount >= 1 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' : 'bg-gray-100 dark:bg-gray-800'}`}>
+          Outlook #1 {outlookCount >= 1 ? '✓' : ''}
+        </span>
+        <span className={`rounded-full px-2 py-0.5 ${outlookCount >= 2 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' : 'bg-gray-100 dark:bg-gray-800'}`}>
+          Outlook #2 {outlookCount >= 2 ? '✓' : ''}
+        </span>
+        <span className={`rounded-full px-2 py-0.5 ${teamsCount >= 1 ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' : 'bg-gray-100 dark:bg-gray-800'}`}>
+          Teams {teamsCount >= 1 ? '✓' : ''}
+        </span>
+      </div>
 
       <div>
         <div className="text-xs font-medium text-gray-500">To</div>
@@ -269,34 +357,32 @@ export function Composer({
         ) : null}
       </div>
 
-      <div>
-        <label className="text-xs font-medium text-gray-500">Template</label>
-        <select
-          disabled={readOnly}
-          value={templateId ?? ''}
-          onChange={(e) => onTemplateChange(e.target.value)}
-          className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-900"
-        >
-          {(templatesQ.data ?? []).map((t) => (
-            <option key={t.id} value={t.id}>
-              {t.stage} v{t.version} ({t.channel})
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <label className="text-xs font-medium text-gray-500">Channel</label>
-        <select
-          disabled={readOnly}
-          value={channel}
-          onChange={(e) => setChannel(e.target.value as 'email' | 'teams' | 'both')}
-          className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-900"
-        >
-          <option value="email">Email</option>
-          <option value="teams">Teams</option>
-          <option value="both">Both</option>
-        </select>
+      <div className="grid gap-3 md:grid-cols-2">
+        <div>
+          <label className="text-xs font-medium text-gray-500">Template</label>
+          <select
+            disabled={readOnly}
+            value={templateId ?? ''}
+            onChange={(e) => onTemplateChange(e.target.value)}
+            className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-900"
+          >
+            {(templatesQ.data ?? []).map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.stage} v{t.version} ({t.channel})
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-xs font-medium text-gray-500">Due date (shown to manager as {'{{dueDate}}'})</label>
+          <input
+            type="date"
+            disabled={readOnly}
+            value={deadlineAt}
+            onChange={(e) => setDeadlineAt(e.target.value)}
+            className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-900"
+          />
+        </div>
       </div>
 
       <div>
@@ -334,7 +420,7 @@ export function Composer({
         </div>
       </div>
 
-      {!previewMode ? (
+      {viewMode === 'edit' ? (
         <>
           <div>
             <label className="text-xs font-medium text-gray-500">Subject</label>
@@ -357,22 +443,65 @@ export function Composer({
           </div>
         </>
       ) : (
-        <PreviewPane subject={resolvedPreview?.subject ?? ''} body={resolvedPreview?.body ?? ''} />
+        <div className="space-y-2">
+          <div className="text-[11px] uppercase tracking-wide text-gray-500">
+            Preview (what the manager will see)
+          </div>
+          <PreviewPane
+            subject={resolvedPreview?.subject ?? (previewLoading ? 'Loading…' : subject)}
+            body={resolvedPreview?.body ?? (previewLoading ? 'Loading…' : body)}
+          />
+        </div>
       )}
 
+      <div>
+        <label className="text-xs font-medium text-gray-500">
+          Auditor note (internal — not shown to the manager)
+        </label>
+        <textarea
+          disabled={readOnly}
+          value={authorNote}
+          onChange={(e) => setAuthorNote(e.target.value)}
+          rows={2}
+          placeholder="Why are you sending this now? e.g. 'tried calling twice, no answer'"
+          className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-900"
+        />
+      </div>
+
       <div className="flex flex-wrap items-center gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
-        <Button type="button" variant="secondary" onClick={() => void togglePreview()} disabled={previewLoading}>
-          {previewMode ? 'Edit' : 'Preview'}
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => setViewMode(viewMode === 'preview' ? 'edit' : 'preview')}
+        >
+          {viewMode === 'preview' ? 'Edit' : 'Preview'}
         </Button>
-        <div className="flex-1" />
         <Button type="button" variant="secondary" onClick={() => discardMut.mutate()} disabled={readOnly || discardMut.isPending}>
           Discard
         </Button>
         <Button type="button" variant="secondary" onClick={() => draftMut.mutate(payload)} disabled={readOnly || draftMut.isPending}>
           Save draft
         </Button>
-        <Button type="button" onClick={() => sendMut.mutate()} disabled={readOnly || sendMut.isPending}>
-          Send
+        <div className="flex-1" />
+        <Button
+          type="button"
+          variant={outlookAllowed ? 'primary' : 'secondary'}
+          leading={<Mail size={14} />}
+          title={outlookGateReason || 'Open Outlook with this message prefilled'}
+          disabled={readOnly || !outlookAllowed || sendMut.isPending}
+          onClick={() => sendMut.mutate('email')}
+        >
+          Outlook ({outlookCount}/2)
+        </Button>
+        <Button
+          type="button"
+          variant={teamsAllowed ? 'primary' : 'secondary'}
+          leading={<MessageSquare size={14} />}
+          title={teamsGateReason || 'Open Teams chat with this message prefilled'}
+          disabled={readOnly || !teamsAllowed || sendMut.isPending}
+          onClick={() => sendMut.mutate('teams')}
+        >
+          Teams ({teamsCount}/1)
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/escalations/PreviewPane.tsx
+++ b/apps/web/src/components/escalations/PreviewPane.tsx
@@ -1,8 +1,24 @@
-export function PreviewPane({ subject, body }: { subject: string; body: string }) {
+export function PreviewPane({
+  subject,
+  body,
+  deadlineAt,
+}: {
+  subject: string;
+  body: string;
+  deadlineAt?: string | null;
+}) {
   return (
     <div className="rounded border border-gray-200 bg-white p-3 text-sm dark:border-gray-700 dark:bg-gray-900">
       <div className="text-xs font-medium text-gray-500">Subject</div>
       <div className="mt-1 font-medium text-gray-900 dark:text-white">{subject || '(empty)'}</div>
+      {deadlineAt ? (
+        <>
+          <div className="mt-3 text-xs font-medium text-gray-500">Due date</div>
+          <div className="mt-1 text-gray-900 dark:text-white">
+            {new Date(deadlineAt).toLocaleDateString()}
+          </div>
+        </>
+      ) : null}
       <div className="mt-3 text-xs font-medium text-gray-500">Body</div>
       <pre className="mt-1 whitespace-pre-wrap font-sans text-gray-800 dark:text-gray-200">{body || '(empty)'}</pre>
     </div>

--- a/apps/web/src/lib/api/trackingComposeApi.ts
+++ b/apps/web/src/lib/api/trackingComposeApi.ts
@@ -9,7 +9,25 @@ export type ComposeDraftPayload = {
   cc: string[];
   removedEngineIds?: string[];
   channel?: 'email' | 'teams' | 'both';
+  /** Issue #75: auditor-only note captured with the handoff. */
+  authorNote?: string;
+  /** Issue #75: ISO-8601 date for the {{dueDate}} slot. */
+  deadlineAt?: string | null;
 };
+
+/**
+ * Issue #75: what the server returns after recording a send. The client
+ * uses these to drive the mailto / Teams handoff — no extra preview call.
+ */
+export interface SendComposeResult {
+  ok: boolean;
+  notificationLogId: string;
+  channel: 'email' | 'teams' | 'both';
+  subject: string;
+  body: string;
+  to: string;
+  cc: string[];
+}
 
 export async function fetchComposeStatus(trackingIdOrCode: string) {
   const res = await fetch(`/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/compose-status`, {
@@ -51,7 +69,10 @@ export async function discardComposeDraft(trackingIdOrCode: string) {
   return (await res.json()) as { ok: boolean; stage: string };
 }
 
-export async function sendCompose(trackingIdOrCode: string, body: ComposeDraftPayload & { sources: string[] }) {
+export async function sendCompose(
+  trackingIdOrCode: string,
+  body: ComposeDraftPayload & { sources: string[] },
+): Promise<SendComposeResult> {
   const res = await fetch(`/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/send`, {
     method: 'POST',
     credentials: 'include',
@@ -59,5 +80,15 @@ export async function sendCompose(trackingIdOrCode: string, body: ComposeDraftPa
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await parseApiError(res, 'Send failed');
-  return (await res.json()) as { ok: boolean; notificationLogId: string };
+  return (await res.json()) as SendComposeResult;
+}
+
+export async function forceReescalate(trackingIdOrCode: string) {
+  const res = await fetch(`/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/force-reescalate`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: JSON_HEADERS,
+  });
+  if (!res.ok) throw await parseApiError(res, 'Force re-escalate failed');
+  return (await res.json()) as { ok: boolean; stage: string };
 }

--- a/apps/web/src/lib/outbound/clientHandoff.ts
+++ b/apps/web/src/lib/outbound/clientHandoff.ts
@@ -1,0 +1,54 @@
+/**
+ * Issue #75: server-side SMTP and Teams webhooks were removed. The auditor's
+ * own mail / Teams app performs the actual send after the server records
+ * intent, so replies thread back to the auditor and no outbound config is
+ * needed on the API.
+ *
+ * Keep these helpers tiny and self-contained — they're the full surface
+ * the Composer and BroadcastDialog rely on for delivery.
+ */
+
+export interface MailtoHandoff {
+  to: string;
+  cc?: string[];
+  subject: string;
+  body: string;
+}
+
+export interface TeamsHandoff {
+  to: string; // recipient's email (Teams accepts email as a user identifier)
+  message: string;
+}
+
+const WINDOW_FEATURES = 'noopener,noreferrer';
+
+/**
+ * Opens the user's default mail client with subject / body / cc prefilled.
+ * Returns `true` if the window.open was accepted, `false` if the browser's
+ * popup blocker silently swallowed it — the caller can fall back to a
+ * copy-to-clipboard flow when that happens.
+ */
+export function openMailto(opts: MailtoHandoff): boolean {
+  const qs = new URLSearchParams();
+  qs.set('subject', opts.subject);
+  qs.set('body', opts.body);
+  if (opts.cc && opts.cc.length > 0) qs.set('cc', opts.cc.join(','));
+  const url = `mailto:${encodeURIComponent(opts.to)}?${qs.toString()}`;
+  const w = window.open(url, '_blank', WINDOW_FEATURES);
+  return Boolean(w);
+}
+
+/**
+ * Opens Teams (desktop if installed, otherwise web) on the 1:1 chat with
+ * the supplied user, prefilled with the message body. Teams truncates long
+ * deep-links silently; body is capped at 4 KB to stay safely inside the
+ * documented limit.
+ */
+export function openTeamsChat(opts: TeamsHandoff): boolean {
+  const message = opts.message.length > 4000 ? opts.message.slice(0, 4000) : opts.message;
+  const url =
+    `https://teams.microsoft.com/l/chat/0/0?users=${encodeURIComponent(opts.to)}` +
+    `&message=${encodeURIComponent(message)}`;
+  const w = window.open(url, '_blank', WINDOW_FEATURES);
+  return Boolean(w);
+}

--- a/packages/domain/src/escalations.ts
+++ b/packages/domain/src/escalations.ts
@@ -33,6 +33,13 @@ export interface ProcessEscalationManagerRow {
   slaDueAt: string | null;
   trackingId: string | null;
   trackingDisplayCode: string | null;
+  /**
+   * Current counters on the tracking entry (Issue #75). The UI uses these
+   * to render the `Outlook N/2` / `Teams N/1` pills and to mirror the
+   * server-side channel gate.
+   */
+  outlookCount?: number;
+  teamsCount?: number;
   escalationLevel?: number;
   draftLockExpiresAt?: string | null;
   draftLockUserDisplayName?: string | null;


### PR DESCRIPTION
Closes #75

## Summary

Removes the server-side SMTP / Teams webhook dependency (zero outbound config needed on the API) and moves delivery to the auditor's own mail / Teams app via `mailto:` and Teams deep-links. Enforces the 2-Outlooks-then-1-Teams cycle server-side, mirrors it in the UI with gated buttons, and adds deadline + auditor-note metadata to every handoff.

## Changes

- **Backend**
  - `TrackingComposeService.send` — enforces the cycle gate (`outlookCount < 2` → Outlook; then `outlookCount >= 2 && teamsCount < 1` → Teams; then complete). Rejects `channel: 'both'` (not atomic for client handoff). Accepts `authorNote` + `deadlineAt`. Persists both on `NotificationLog` and stashes them on the `TrackingEvent.payload`. Teams leg transitions to `ESCALATED_L1`, Outlook to `AWAITING_RESPONSE`.
  - `TrackingComposeService.forceReescalate` + new `POST /tracking/:id/force-reescalate` — admin-only cycle reset. Zeroes counters, writes a `cycle_reset` tracking event, transitions back to `NEW`, emits `tracking.updated`.
  - `OutboundDeliveryService.sendEscalation` — stubbed to a no-op. No `nodemailer`, no env vars required at boot.
  - `TrackingComposeService.send` now returns `{ channel, subject, body, to, cc }` so the client does the handoff with zero extra round-trip.
  - `escalationsAggregator` / `ProcessEscalationManagerRow` — carry `outlookCount` + `teamsCount` so the UI mirrors the server gate.
- **Frontend**
  - New `apps/web/src/lib/outbound/clientHandoff.ts` — `openMailto` + `openTeamsChat`. Both detect popup-blocker swallowing and return false so the caller can hint at a manual fallback.
  - `Composer.tsx` rewritten preview-first. Two gated send buttons (`Outlook N/2`, `Teams N/1`) in the footer; disabled tooltips explain why. Added inline deadline picker (defaults to +5 business days) and auditor note field. Pull-to-preview autoruns on enter so the auditor always sees substituted copy.
  - `BroadcastDialog.tsx` gets the same preview/edit toggle, deadline, and auditor-note. `both` removed (client handoff can't open two tabs atomically; Broadcast records intent server-side in bulk).
  - `PreviewPane.tsx` extended to render the deadline.
  - `trackingComposeApi.ts` — `SendComposeResult` exposes what the client needs to drive the handoff.
- **Database**
  - `20260422231500_issue75_notification_log_note_deadline`: adds `authorNote TEXT NOT NULL DEFAULT ''` and `deadlineAt TIMESTAMPTZ NULL` to `notification_log`.

## Behavior

- Sending Outlook opens the auditor's default mail client with subject/body/cc prefilled. Sending Teams opens the 1:1 deep-link with the message body. The server increments counters and writes the log before the handoff runs, so the ladder advances even if the popup is blocked (toast explains the fallback).
- Channel buttons reflect live counter state and gate per the spec. Once `outlookCount === 2 && teamsCount === 1`, both buttons disable with "Cycle complete — resolve or force re-escalate."
- Force-re-escalate (admin) clears counters and stage.

## Constraints Handled

- Gate enforced server-side too (race-safe across concurrent auditors).
- `channel: 'both'` is explicitly rejected (400) to prevent silent divergence.
- Boot no longer reads `SES_SMTP_URL` / `SES_TEAMS_INCOMING_WEBHOOK_URL`.
- Popup blockers → toast warning instead of a silent failure.
- Deadline defaults to +5 business days; `{{dueDate}}` slot is available to templates.

## Testing

- `tsc --noEmit` clean for `apps/api` and `apps/web`.
- `escalationsAggregator` test updated for the new counter fields.
- Not verified in a browser — needs smoke test of (a) Outlook→Outlook→Teams cycle, (b) gate rejection at each boundary, (c) `mailto:` actually opens on a fresh OS profile.

## Notes

- Migration is additive. Existing `channel: 'both'` rows keep their value — but no new ones can be created.
- The old SMTP code path is gone; env config for delivery is no longer required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)