### PR TITLE
feat(issue-76): stage graph and auditor verification gate

### DIFF
--- a/apps/api/prisma/migrations/20260422233000_issue76_verification_and_stage_comments/migration.sql
+++ b/apps/api/prisma/migrations/20260422233000_issue76_verification_and_stage_comments/migration.sql
@@ -1,0 +1,28 @@
+-- Issue #76: auditor verification gate + per-stage commentary.
+
+ALTER TABLE "TrackingEntry"
+  ADD COLUMN "verifiedById" TEXT NULL,
+  ADD COLUMN "verifiedAt" TIMESTAMPTZ NULL;
+
+ALTER TABLE "TrackingEntry"
+  ADD CONSTRAINT "TrackingEntry_verifiedById_fkey"
+  FOREIGN KEY ("verifiedById") REFERENCES "User"("id") ON DELETE SET NULL;
+
+CREATE INDEX "TrackingEntry_verifiedAt_idx" ON "TrackingEntry" ("verifiedAt");
+
+CREATE TABLE "TrackingStageComment" (
+  "id"              TEXT NOT NULL PRIMARY KEY,
+  "displayCode"     TEXT NOT NULL UNIQUE,
+  "trackingEntryId" TEXT NOT NULL REFERENCES "TrackingEntry"("id") ON DELETE CASCADE,
+  "stage"           TEXT NOT NULL,
+  "authorId"        TEXT NOT NULL REFERENCES "User"("id"),
+  "authorName"      TEXT NOT NULL,
+  "body"            TEXT NOT NULL,
+  "createdAt"       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "TrackingStageComment_trackingEntryId_stage_idx"
+  ON "TrackingStageComment" ("trackingEntryId", "stage");
+
+CREATE INDEX "TrackingStageComment_trackingEntryId_createdAt_idx"
+  ON "TrackingStageComment" ("trackingEntryId", "createdAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -76,6 +76,8 @@ model User {
   fileDrafts     FileDraft[]       @relation("FileDraftBy")
   managerDirectoriesCreated ManagerDirectory[] @relation("ManagerDirectoryCreatedBy")
   trackingDraftLocks TrackingEntry[] @relation("TrackingDraftLock")
+  trackingVerifications TrackingEntry[] @relation("TrackingVerifier")
+  trackingStageComments TrackingStageComment[] @relation("TrackingStageCommentBy")
 }
 
 model Process {
@@ -457,17 +459,46 @@ model TrackingEntry {
   composeDraft   Json?
   draftLockUserId String?
   draftLockExpiresAt DateTime?
+  /// Issue #76: an auditor must explicitly click "Verified — Resolve"
+  /// before a RESOLVED-stage entry leaves the active list. Null means the
+  /// row is "resolved per manager" but still awaiting auditor sign-off.
+  verifiedById   String?
+  verifiedAt     DateTime?
   rowVersion     Int      @default(1)
   updatedAt      DateTime @updatedAt
   process        Process  @relation(fields: [processId], references: [id], onDelete: Cascade)
   events         TrackingEvent[]
   notifications  Notification[]
   draftLockUser  User?    @relation("TrackingDraftLock", fields: [draftLockUserId], references: [id], onDelete: SetNull)
+  verifiedBy     User?    @relation("TrackingVerifier", fields: [verifiedById], references: [id], onDelete: SetNull)
   notificationLogs NotificationLog[]
+  stageComments  TrackingStageComment[]
 
   @@unique([processId, managerKey])
   @@index([processId, stage, slaDueAt])
   @@index([processId, managerEmail])
+}
+
+/// Per-stage commentary on a tracking entry (Issue #76). Auditors drop
+/// notes like "tried calling, no answer" or "manager asked for extension"
+/// attached to a specific ladder step; each click on a StageGraph node
+/// opens a thread scoped to (trackingEntryId, stage).
+model TrackingStageComment {
+  id              String        @id
+  displayCode     String        @unique
+  trackingEntryId String
+  stage           String
+  authorId        String
+  /// Denormalised for display when the author is later deleted.
+  authorName      String
+  body            String
+  createdAt       DateTime      @default(now())
+
+  trackingEntry   TrackingEntry @relation(fields: [trackingEntryId], references: [id], onDelete: Cascade)
+  author          User          @relation("TrackingStageCommentBy", fields: [authorId], references: [id])
+
+  @@index([trackingEntryId, stage])
+  @@index([trackingEntryId, createdAt])
 }
 
 model TrackingEvent {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -57,6 +57,8 @@ import { EscalationTemplatesController } from './escalation-templates/escalation
 import { EscalationTemplatesService } from './escalation-templates/escalation-templates.service';
 import { TrackingComposeController } from './tracking-compose/tracking-compose.controller';
 import { TrackingComposeService } from './tracking-compose/tracking-compose.service';
+import { TrackingStageController } from './tracking-stage/tracking-stage.controller';
+import { TrackingStageService } from './tracking-stage/tracking-stage.service';
 import { OutboundDeliveryService } from './outbound/outbound-delivery.service';
 import { TrackingBulkController } from './tracking-bulk.controller';
 import { TrackingBulkService } from './tracking-bulk.service';
@@ -100,6 +102,7 @@ import { SlaEngineService } from './sla-engine.service';
     DirectoryController,
     EscalationTemplatesController,
     TrackingComposeController,
+    TrackingStageController,
     TrackingBulkController,
     InAppNotificationsController,
     SavedViewsController,
@@ -140,6 +143,7 @@ import { SlaEngineService } from './sla-engine.service';
     OutboundDeliveryService,
     EscalationTemplatesService,
     TrackingComposeService,
+    TrackingStageService,
     TrackingBulkService,
     InAppNotificationsService,
     SavedViewsService,

--- a/apps/api/src/common/identifier.service.ts
+++ b/apps/api/src/common/identifier.service.ts
@@ -123,4 +123,9 @@ export class IdentifierService {
     const value = await this.nextSequence(tx, 'MDR', 'tenant');
     return `MDR-${pad(value, 6)}`;
   }
+
+  async nextStageCommentCode(tx: TxLike): Promise<string> {
+    const value = await this.nextSequence(tx, 'TSC');
+    return `TSC-${pad(value, 9)}`;
+  }
 }

--- a/apps/api/src/escalations.service.ts
+++ b/apps/api/src/escalations.service.ts
@@ -68,6 +68,8 @@ export class EscalationsService {
         resolved: true,
         lastContactAt: true,
         slaDueAt: true,
+        verifiedAt: true,
+        verifiedBy: { select: { displayName: true } },
         outlookCount: true,
         teamsCount: true,
         draftLockExpiresAt: true,
@@ -106,6 +108,8 @@ export class EscalationsService {
           escalationLevel: t.escalationLevel,
           draftLockExpiresAt: t.draftLockExpiresAt?.toISOString() ?? null,
           draftLockUserDisplayName: t.draftLockUser?.displayName ?? null,
+          verifiedAt: t.verifiedAt?.toISOString() ?? null,
+          verifiedByName: t.verifiedBy?.displayName ?? null,
         },
       ]),
     );
@@ -121,6 +125,8 @@ export class EscalationsService {
         escalationLevel: extra?.escalationLevel ?? 0,
         draftLockExpiresAt: extra?.draftLockExpiresAt ?? null,
         draftLockUserDisplayName: extra?.draftLockUserDisplayName ?? null,
+        verifiedAt: extra?.verifiedAt ?? null,
+        verifiedByName: extra?.verifiedByName ?? null,
       };
     });
 

--- a/apps/api/src/tracking-stage/tracking-stage.controller.ts
+++ b/apps/api/src/tracking-stage/tracking-stage.controller.ts
@@ -1,0 +1,45 @@
+import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import type { SessionUser } from '@ses/domain';
+import { AuthGuard } from '../auth.guard';
+import { CurrentUser } from '../common/current-user';
+import { TrackingStageService } from './tracking-stage.service';
+
+@Controller()
+@UseGuards(AuthGuard)
+export class TrackingStageController {
+  constructor(private readonly stage: TrackingStageService) {}
+
+  @Get('tracking/:idOrCode/stage-comments')
+  list(
+    @Param('idOrCode') idOrCode: string,
+    @Query('stage') stage: string | undefined,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.stage.listComments(idOrCode, user, stage?.trim() || undefined);
+  }
+
+  @Post('tracking/:idOrCode/stage-comments')
+  add(
+    @Param('idOrCode') idOrCode: string,
+    @Body() body: { stage: string; body: string },
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.stage.addComment(idOrCode, user, body);
+  }
+
+  @Post('tracking/:idOrCode/verify')
+  verify(
+    @Param('idOrCode') idOrCode: string,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.stage.verify(idOrCode, user);
+  }
+
+  @Delete('tracking/:idOrCode/verify')
+  revert(
+    @Param('idOrCode') idOrCode: string,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.stage.revertVerification(idOrCode, user);
+  }
+}

--- a/apps/api/src/tracking-stage/tracking-stage.service.ts
+++ b/apps/api/src/tracking-stage/tracking-stage.service.ts
@@ -1,0 +1,219 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { EscalationStage } from '@prisma/client';
+import type { SessionUser } from '@ses/domain';
+import { createId } from '@ses/domain';
+import { PrismaService } from '../common/prisma.service';
+import { IdentifierService } from '../common/identifier.service';
+import { ActivityLogService } from '../common/activity-log.service';
+import { ProcessAccessService } from '../common/process-access.service';
+import { RealtimeGateway } from '../realtime/realtime.gateway';
+
+export interface StageCommentDto {
+  id: string;
+  displayCode: string;
+  stage: string;
+  authorId: string;
+  authorName: string;
+  body: string;
+  createdAt: string;
+}
+
+@Injectable()
+export class TrackingStageService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly identifiers: IdentifierService,
+    private readonly activity: ActivityLogService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly realtime: RealtimeGateway,
+  ) {}
+
+  private async loadEntry(idOrCode: string, user: SessionUser, permission: 'viewer' | 'editor' = 'viewer') {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      include: { process: { select: { id: true, displayCode: true, tenantId: true } } },
+    });
+    if (!entry) throw new NotFoundException(`Tracking entry ${idOrCode} not found`);
+    await this.processAccess.require(entry.processId, user, permission);
+    return entry;
+  }
+
+  private serializeComment(row: {
+    id: string;
+    displayCode: string;
+    stage: string;
+    authorId: string;
+    authorName: string;
+    body: string;
+    createdAt: Date;
+  }): StageCommentDto {
+    return {
+      id: row.id,
+      displayCode: row.displayCode,
+      stage: row.stage,
+      authorId: row.authorId,
+      authorName: row.authorName,
+      body: row.body,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+
+  async listComments(idOrCode: string, user: SessionUser, stage?: string) {
+    const entry = await this.loadEntry(idOrCode, user, 'viewer');
+    const rows = await this.prisma.trackingStageComment.findMany({
+      where: { trackingEntryId: entry.id, ...(stage ? { stage } : {}) },
+      orderBy: { createdAt: 'asc' },
+    });
+    return { comments: rows.map((r) => this.serializeComment(r)) };
+  }
+
+  async addComment(
+    idOrCode: string,
+    user: SessionUser,
+    body: { stage: string; body: string },
+  ) {
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+    const stage = (body.stage ?? '').trim();
+    const text = (body.body ?? '').trim();
+    if (!stage) throw new BadRequestException('stage is required');
+    if (!text) throw new BadRequestException('body is required');
+    if (text.length > 4000) {
+      throw new BadRequestException('Comment must be at most 4000 characters.');
+    }
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      return tx.trackingStageComment.create({
+        data: {
+          id: createId(),
+          displayCode: await this.identifiers.nextStageCommentCode(tx),
+          trackingEntryId: entry.id,
+          stage,
+          authorId: user.id,
+          authorName: user.displayName,
+          body: text,
+        },
+      });
+    });
+
+    await this.activity.append(this.prisma, {
+      actorId: user.id,
+      actorEmail: user.email,
+      processId: entry.processId,
+      entityType: 'tracking_entry',
+      entityId: entry.id,
+      entityCode: entry.displayCode,
+      action: 'tracking.stage_comment_added',
+      metadata: { stage, commentId: created.id },
+    });
+
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: entry.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+
+    return this.serializeComment(created);
+  }
+
+  async verify(idOrCode: string, user: SessionUser) {
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+    if (entry.verifiedAt) {
+      // Idempotent — first verifier wins; second call is a no-op.
+      return { ok: true, stage: entry.stage, verifiedAt: entry.verifiedAt.toISOString() };
+    }
+    const now = new Date();
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const row = await tx.trackingEntry.update({
+        where: { id: entry.id },
+        data: {
+          verifiedById: user.id,
+          verifiedAt: now,
+          stage: EscalationStage.RESOLVED,
+          resolved: true,
+          rowVersion: { increment: 1 },
+        },
+      });
+      await tx.trackingEvent.create({
+        data: {
+          id: createId(),
+          displayCode: await this.identifiers.nextTrackingEventCode(tx),
+          trackingId: entry.id,
+          kind: 'auditor_verified',
+          channel: 'manual',
+          note: 'Auditor verified resolution.',
+          reason: 'verification',
+          triggeredById: user.id,
+        },
+      });
+      await this.activity.append(tx, {
+        actorId: user.id,
+        actorEmail: user.email,
+        processId: entry.processId,
+        entityType: 'tracking_entry',
+        entityId: entry.id,
+        entityCode: entry.displayCode,
+        action: 'tracking.verified',
+      });
+      return row;
+    });
+
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: updated.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+
+    return { ok: true, stage: updated.stage, verifiedAt: now.toISOString() };
+  }
+
+  async revertVerification(idOrCode: string, user: SessionUser) {
+    if (user.role !== 'admin') {
+      throw new ForbiddenException('Admin role required to revert verification.');
+    }
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+    if (!entry.verifiedAt) {
+      return { ok: true, stage: entry.stage };
+    }
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const row = await tx.trackingEntry.update({
+        where: { id: entry.id },
+        data: {
+          verifiedById: null,
+          verifiedAt: null,
+          resolved: false,
+          rowVersion: { increment: 1 },
+        },
+      });
+      await tx.trackingEvent.create({
+        data: {
+          id: createId(),
+          displayCode: await this.identifiers.nextTrackingEventCode(tx),
+          trackingId: entry.id,
+          kind: 'verification_reverted',
+          channel: 'manual',
+          note: 'Verification reverted by admin.',
+          reason: 'verification_revert',
+          triggeredById: user.id,
+        },
+      });
+      await this.activity.append(tx, {
+        actorId: user.id,
+        actorEmail: user.email,
+        processId: entry.processId,
+        entityType: 'tracking_entry',
+        entityId: entry.id,
+        entityCode: entry.displayCode,
+        action: 'tracking.verification_reverted',
+      });
+      return row;
+    });
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: updated.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+    return { ok: true, stage: updated.stage };
+  }
+}

--- a/apps/web/src/components/escalations/ActivityFeed.tsx
+++ b/apps/web/src/components/escalations/ActivityFeed.tsx
@@ -1,11 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
+import type { ProcessEscalationManagerRow } from '@ses/domain';
 import { fetchTrackingEvents } from '../../lib/api/escalationsApi';
+import { StageGraph } from './StageGraph';
 import { TrackingTimeline } from './TrackingTimeline';
 
 // Thin container — the rendering lives in the reusable TrackingTimeline
 // so both this panel and anywhere else that wants an activity feed can
-// use the same presentation.
-export function ActivityFeed({ trackingIdOrCode }: { trackingIdOrCode: string | null }) {
+// use the same presentation. Issue #76 adds a StageGraph on top to give
+// auditors a one-glance read on where the ladder is at.
+export function ActivityFeed({
+  trackingIdOrCode,
+  row,
+}: {
+  trackingIdOrCode: string | null;
+  row?: ProcessEscalationManagerRow | null;
+}) {
   const q = useQuery({
     queryKey: ['tracking-events', trackingIdOrCode],
     queryFn: () => fetchTrackingEvents(trackingIdOrCode!),
@@ -20,21 +29,25 @@ export function ActivityFeed({ trackingIdOrCode }: { trackingIdOrCode: string | 
   if (!trackingIdOrCode) {
     return <p className="text-sm text-gray-500">No tracking record for this manager.</p>;
   }
-  if (q.isLoading) {
-    return (
-      <ol className="relative space-y-3 pl-6">
-        <span aria-hidden className="absolute left-[11px] top-2 h-[calc(100%-1rem)] w-px bg-gray-200 dark:bg-gray-800" />
-        {[0, 1, 2].map((i) => (
-          <li key={i} className="relative">
-            <span className="absolute -left-[20px] top-0 inline-block h-6 w-6 animate-pulse rounded-full bg-gray-200 dark:bg-gray-800" />
-            <div className="h-16 animate-pulse rounded-lg border border-gray-100 bg-gray-50 dark:border-gray-800 dark:bg-gray-900" />
-          </li>
-        ))}
-      </ol>
-    );
-  }
-  if (q.isError) {
-    return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
-  }
-  return <TrackingTimeline events={q.data ?? []} />;
+
+  return (
+    <div className="space-y-4">
+      {row ? <StageGraph row={row} trackingIdOrCode={trackingIdOrCode} /> : null}
+      {q.isLoading ? (
+        <ol className="relative space-y-3 pl-6">
+          <span aria-hidden className="absolute left-[11px] top-2 h-[calc(100%-1rem)] w-px bg-gray-200 dark:bg-gray-800" />
+          {[0, 1, 2].map((i) => (
+            <li key={i} className="relative">
+              <span className="absolute -left-[20px] top-0 inline-block h-6 w-6 animate-pulse rounded-full bg-gray-200 dark:bg-gray-800" />
+              <div className="h-16 animate-pulse rounded-lg border border-gray-100 bg-gray-50 dark:border-gray-800 dark:bg-gray-900" />
+            </li>
+          ))}
+        </ol>
+      ) : q.isError ? (
+        <p className="text-sm text-red-600">{(q.error as Error).message}</p>
+      ) : (
+        <TrackingTimeline events={q.data ?? []} />
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/escalations/EscalationPanel.tsx
+++ b/apps/web/src/components/escalations/EscalationPanel.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { BadgeCheck } from 'lucide-react';
 import type { ProcessEscalationManagerRow } from '@ses/domain';
+import { verifyTracking } from '../../lib/api/trackingStageApi';
 import { ActivityFeed } from './ActivityFeed';
 import { Composer } from './Composer';
 import { FindingsTab } from './FindingsTab';
@@ -21,6 +25,23 @@ export function EscalationPanel({
 }) {
   const [tab, setTab] = useState<TabId>('findings');
   const panelRef = useRef<HTMLDivElement>(null);
+  const qc = useQueryClient();
+  const trackingRef = row?.trackingId ?? row?.trackingDisplayCode ?? null;
+  const awaitingVerification = Boolean(row && row.stage === 'RESOLVED' && !row.verifiedAt);
+  const canVerify = Boolean(row && !row.verifiedAt);
+
+  const verifyMut = useMutation({
+    mutationFn: () => {
+      if (!trackingRef) return Promise.reject(new Error('No tracking row'));
+      return verifyTracking(trackingRef);
+    },
+    onSuccess: () => {
+      toast.success('Verified — moved to Resolved.');
+      void qc.invalidateQueries({ queryKey: ['escalations'] });
+      void qc.invalidateQueries({ queryKey: ['tracking-events', trackingRef] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -67,6 +88,16 @@ export function EscalationPanel({
             <div className="mt-1 flex flex-wrap gap-2 text-xs">
               <span className="rounded bg-gray-100 px-2 py-0.5 dark:bg-gray-800">{row.stage ?? '—'}</span>
               <span className="text-gray-500">SLA: {slaText}</span>
+              {awaitingVerification ? (
+                <span className="rounded bg-amber-100 px-2 py-0.5 font-medium text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
+                  Awaiting auditor verification
+                </span>
+              ) : null}
+              {row.verifiedAt ? (
+                <span className="rounded bg-green-100 px-2 py-0.5 font-medium text-green-900 dark:bg-green-900/40 dark:text-green-100">
+                  Verified {row.verifiedByName ? `by ${row.verifiedByName}` : ''}
+                </span>
+              ) : null}
             </div>
           </div>
           <button
@@ -103,11 +134,30 @@ export function EscalationPanel({
         <div className="min-h-0 flex-1 overflow-y-auto p-4">
           {tab === 'findings' ? <FindingsTab processId={processId} row={row} /> : null}
           {tab === 'compose' ? <Composer processDisplayCode={processDisplayCode} row={row} onDone={onClose} /> : null}
-          {tab === 'activity' ? <ActivityFeed trackingIdOrCode={row.trackingId ?? row.trackingDisplayCode} /> : null}
+          {tab === 'activity' ? (
+            <ActivityFeed trackingIdOrCode={row.trackingId ?? row.trackingDisplayCode} row={row} />
+          ) : null}
           {tab === 'attachments' ? (
             <p className="text-sm text-gray-500">Attachments will be available in a later release.</p>
           ) : null}
         </div>
+        {canVerify && trackingRef ? (
+          <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3 dark:border-gray-800">
+            <span className="text-xs text-gray-500">
+              {awaitingVerification
+                ? 'Manager marked resolved — review the evidence and verify to close the loop.'
+                : 'Verifying closes the row to Resolved with your name stamped on it.'}
+            </span>
+            <button
+              type="button"
+              onClick={() => verifyMut.mutate()}
+              disabled={verifyMut.isPending}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60"
+            >
+              <BadgeCheck size={14} /> Verified — Resolve
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/escalations/ManagerTable.tsx
+++ b/apps/web/src/components/escalations/ManagerTable.tsx
@@ -207,7 +207,17 @@ export function ManagerTable({
                   </div>
                 </td>
                 <td className="px-3 py-2">
-                  <span className="rounded bg-gray-100 px-2 py-0.5 text-xs dark:bg-gray-800">{row.stage ?? '—'}</span>
+                  <div className="flex flex-wrap items-center gap-1">
+                    <span className="rounded bg-gray-100 px-2 py-0.5 text-xs dark:bg-gray-800">{row.stage ?? '—'}</span>
+                    {row.stage === 'RESOLVED' && !row.verifiedAt ? (
+                      <span
+                        className="rounded bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
+                        title="Manager marked resolved — needs auditor verification"
+                      >
+                        Awaiting verification
+                      </span>
+                    ) : null}
+                  </div>
                 </td>
                 <td className="px-3 py-2 text-xs text-gray-600">
                   {row.lastContactAt ? new Date(row.lastContactAt).toLocaleDateString() : '—'}

--- a/apps/web/src/components/escalations/StageGraph.tsx
+++ b/apps/web/src/components/escalations/StageGraph.tsx
@@ -1,0 +1,196 @@
+import { memo, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Check, MessageCircle } from 'lucide-react';
+import toast from 'react-hot-toast';
+import type { ProcessEscalationManagerRow } from '@ses/domain';
+import { addStageComment, fetchStageComments } from '../../lib/api/trackingStageApi';
+
+/**
+ * Seven-node ladder shown at the top of the Activity tab (Issue #76).
+ *
+ * Each node has three possible states:
+ *   - completed (green ✓): the underlying counter or stage says this step
+ *     has already happened.
+ *   - current  (blue ring): this is the node the cycle is resting on — the
+ *     first unfinished step.
+ *   - future   (grey outline): the step is ahead of the cycle; clicking it
+ *     still opens the comment thread so auditors can note intent before
+ *     the step actually lands ("will retry Thursday" etc).
+ *
+ * Clicking any node opens a side panel with the per-stage comment thread
+ * scoped to `(trackingEntryId, stage)`. The thread is append-only.
+ */
+
+type StageKey = 'DRAFTED' | 'OUTLOOK_1' | 'OUTLOOK_2' | 'TEAMS' | 'RESPONDED' | 'VERIFIED' | 'RESOLVED';
+
+interface StageNode {
+  key: StageKey;
+  label: string;
+  completed: boolean;
+}
+
+function buildStages(row: ProcessEscalationManagerRow): StageNode[] {
+  const outlook = row.outlookCount ?? 0;
+  const teams = row.teamsCount ?? 0;
+  const stage = row.stage ?? '';
+  const responded = stage === 'RESPONDED' || Boolean(row.verifiedAt);
+  const verified = Boolean(row.verifiedAt);
+  const resolved = row.resolved === true || stage === 'RESOLVED';
+  const drafted =
+    stage === 'DRAFTED' ||
+    stage === 'SENT' ||
+    stage === 'AWAITING_RESPONSE' ||
+    outlook >= 1 ||
+    teams >= 1;
+
+  return [
+    { key: 'DRAFTED', label: 'Drafted', completed: drafted },
+    { key: 'OUTLOOK_1', label: 'Outlook #1', completed: outlook >= 1 },
+    { key: 'OUTLOOK_2', label: 'Outlook #2', completed: outlook >= 2 },
+    { key: 'TEAMS', label: 'Teams', completed: teams >= 1 },
+    { key: 'RESPONDED', label: 'Manager responded', completed: responded },
+    { key: 'VERIFIED', label: 'Auditor verified', completed: verified },
+    { key: 'RESOLVED', label: 'Resolved', completed: resolved && verified },
+  ];
+}
+
+function currentNodeIndex(nodes: StageNode[]): number {
+  for (let i = 0; i < nodes.length; i += 1) {
+    if (!nodes[i]!.completed) return i;
+  }
+  return nodes.length - 1;
+}
+
+export const StageGraph = memo(function StageGraph({
+  row,
+  trackingIdOrCode,
+}: {
+  row: ProcessEscalationManagerRow;
+  trackingIdOrCode: string;
+}) {
+  const [openStage, setOpenStage] = useState<StageKey | null>(null);
+  const nodes = useMemo(() => buildStages(row), [row]);
+  const current = currentNodeIndex(nodes);
+
+  return (
+    <div className="space-y-3">
+      <ol className="flex flex-wrap items-center gap-1 text-[11px]">
+        {nodes.map((node, index) => {
+          const status: 'done' | 'current' | 'future' = node.completed
+            ? 'done'
+            : index === current
+            ? 'current'
+            : 'future';
+          return (
+            <li key={node.key} className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setOpenStage(node.key)}
+                className={`group inline-flex items-center gap-1 rounded-full border px-2 py-1 transition ${
+                  status === 'done'
+                    ? 'border-green-300 bg-green-50 text-green-800 hover:bg-green-100 dark:border-green-900 dark:bg-green-950 dark:text-green-200'
+                    : status === 'current'
+                    ? 'border-brand/40 bg-brand/5 text-brand ring-2 ring-brand/30'
+                    : 'border-gray-200 bg-white text-gray-500 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400'
+                }`}
+                title={`Open notes for ${node.label}`}
+              >
+                <span className="flex h-4 w-4 items-center justify-center rounded-full">
+                  {status === 'done' ? <Check size={12} /> : <span>{index + 1}</span>}
+                </span>
+                <span>{node.label}</span>
+              </button>
+              {index < nodes.length - 1 ? (
+                <span className={`h-px w-4 ${status === 'done' ? 'bg-green-300' : 'bg-gray-200 dark:bg-gray-700'}`} />
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+      {openStage ? (
+        <StageCommentThread
+          trackingIdOrCode={trackingIdOrCode}
+          stage={openStage}
+          onClose={() => setOpenStage(null)}
+        />
+      ) : null}
+    </div>
+  );
+});
+
+function StageCommentThread({
+  trackingIdOrCode,
+  stage,
+  onClose,
+}: {
+  trackingIdOrCode: string;
+  stage: StageKey;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [body, setBody] = useState('');
+
+  const q = useQuery({
+    queryKey: ['tracking-stage-comments', trackingIdOrCode, stage],
+    queryFn: () => fetchStageComments(trackingIdOrCode, stage),
+  });
+
+  const addMut = useMutation({
+    mutationFn: () => addStageComment(trackingIdOrCode, { stage, body: body.trim() }),
+    onSuccess: () => {
+      setBody('');
+      void qc.invalidateQueries({ queryKey: ['tracking-stage-comments', trackingIdOrCode, stage] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-100">
+          <MessageCircle size={14} /> {stage} notes
+        </div>
+        <button type="button" onClick={onClose} className="text-xs text-gray-500 hover:underline">
+          Close
+        </button>
+      </div>
+      <ul className="mt-2 space-y-2 text-sm">
+        {q.isLoading ? <li className="text-xs text-gray-500">Loading…</li> : null}
+        {q.data && q.data.length === 0 ? (
+          <li className="text-xs text-gray-500">No notes yet — add the first one below.</li>
+        ) : null}
+        {q.data?.map((c) => (
+          <li key={c.id} className="rounded border border-gray-100 bg-gray-50 px-2 py-1 dark:border-gray-800 dark:bg-gray-900/60">
+            <div className="text-[11px] text-gray-500">
+              {c.authorName} · {new Date(c.createdAt).toLocaleString()}
+            </div>
+            <div className="whitespace-pre-wrap">{c.body}</div>
+          </li>
+        ))}
+      </ul>
+      <form
+        className="mt-2 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!body.trim()) return;
+          addMut.mutate();
+        }}
+      >
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={2}
+          placeholder={`Add a note for ${stage}…`}
+          className="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900"
+        />
+        <button
+          type="submit"
+          disabled={addMut.isPending || !body.trim()}
+          className="rounded bg-brand px-3 py-1 text-xs font-medium text-white disabled:opacity-50"
+        >
+          Post
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/trackingStageApi.ts
+++ b/apps/web/src/lib/api/trackingStageApi.ts
@@ -1,0 +1,62 @@
+import { parseApiError } from './client';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export interface StageComment {
+  id: string;
+  displayCode: string;
+  stage: string;
+  authorId: string;
+  authorName: string;
+  body: string;
+  createdAt: string;
+}
+
+export async function fetchStageComments(
+  trackingIdOrCode: string,
+  stage?: string,
+): Promise<StageComment[]> {
+  const qs = stage ? `?stage=${encodeURIComponent(stage)}` : '';
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/stage-comments${qs}`,
+    { credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to load stage comments');
+  const json = (await res.json()) as { comments: StageComment[] };
+  return json.comments;
+}
+
+export async function addStageComment(
+  trackingIdOrCode: string,
+  body: { stage: string; body: string },
+): Promise<StageComment> {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/stage-comments`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to add comment');
+  return (await res.json()) as StageComment;
+}
+
+export async function verifyTracking(trackingIdOrCode: string) {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/verify`,
+    { method: 'POST', credentials: 'include', headers: JSON_HEADERS },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Verify failed');
+  return (await res.json()) as { ok: boolean; stage: string; verifiedAt: string };
+}
+
+export async function revertVerification(trackingIdOrCode: string) {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/verify`,
+    { method: 'DELETE', credentials: 'include', headers: JSON_HEADERS },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Revert verification failed');
+  return (await res.json()) as { ok: boolean; stage: string };
+}

--- a/apps/web/src/pages/EscalationCenter.tsx
+++ b/apps/web/src/pages/EscalationCenter.tsx
@@ -69,6 +69,9 @@ export function EscalationCenter() {
   const engine = (search.get('engine') as FunctionId) || '';
   const sla = (search.get('sla') as SlaFilter) || 'all';
   const assignedToMe = search.get('mine') === '1';
+  // Issue #76: surface RESOLVED-but-unverified rows so auditors can finish
+  // the verification step without hunting for them.
+  const needsVerification = search.get('needsVerification') === '1';
 
   const selectedStages = useMemo(() => parseStagesParam(search.get('stages')), [search]);
 
@@ -155,9 +158,10 @@ export function EscalationCenter() {
         const b = slaBucket(row, currentTime);
         if (b !== sla) return false;
       }
+      if (needsVerification && !(row.stage === 'RESOLVED' && !row.verifiedAt)) return false;
       return true;
     });
-  }, [assignedToMe, currentTime, currentUser?.email, engine, q.data?.rows, selectedStages, sla]);
+  }, [assignedToMe, currentTime, currentUser?.email, engine, needsVerification, q.data?.rows, selectedStages, sla]);
 
   const toggleStage = (stage: string) => {
     const next = new Set(selectedStages);
@@ -235,6 +239,18 @@ export function EscalationCenter() {
             </Link>
             <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Escalation Center</h1>
             <span className="flex-1" />
+            <button
+              type="button"
+              onClick={() => setParam({ needsVerification: needsVerification ? null : '1' })}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium ${
+                needsVerification
+                  ? 'border border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100'
+                  : 'border border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-300'
+              }`}
+              title="Show only rows marked RESOLVED that still need auditor verification"
+            >
+              Needs verification
+            </button>
             <button
               type="button"
               onClick={() => {

--- a/packages/domain/src/escalations.ts
+++ b/packages/domain/src/escalations.ts
@@ -34,8 +34,16 @@ export interface ProcessEscalationManagerRow {
   trackingId: string | null;
   trackingDisplayCode: string | null;
   /**
-   * Current counters on the tracking entry (Issue #75). The UI uses these
-   * to render the `Outlook N/2` / `Teams N/1` pills and to mirror the
+   * Issue #76: an auditor must click "Verified — Resolve" before a
+   * RESOLVED-stage entry truly leaves the active list. When `stage`
+   * reads RESOLVED but `verifiedAt` is null the row renders with an
+   * orange "Awaiting verification" pill.
+   */
+  verifiedAt?: string | null;
+  verifiedByName?: string | null;
+  /**
+   * Counters on the tracking entry (Issue #75). The UI uses these to
+   * render the `Outlook N/2` / `Teams N/1` pills and to mirror the
    * server-side channel gate.
    */
   outlookCount?: number;


### PR DESCRIPTION
Closes #76

## Summary

Adds a 7-node escalation ladder graph at the top of the Activity tab, per-stage comment threads, and an explicit auditor verification step before a RESOLVED row leaves the active list.

## Changes

- **Backend**
  - `TrackingEntry.verifiedById` + `verifiedAt` columns; new `TrackingStageComment` model with indices on `(trackingEntryId, stage)` and `(trackingEntryId, createdAt)`.
  - `TrackingStageService` — list / add stage comments, `verify` (editor+, idempotent), `revertVerification` (admin only). All mutations emit `tracking.updated`.
  - `TrackingStageController` — `GET/POST /tracking/:id/stage-comments`, `POST/DELETE /tracking/:id/verify`.
  - `EscalationsService` + `escalationsAggregator` surface `verifiedAt`, `verifiedByName`, `outlookCount`, `teamsCount` on the row so the UI can draw the ladder without additional fetches.
  - New `IdentifierService.nextStageCommentCode`.
  - `AppModule` wires the new service + controller.
- **Frontend**
  - New `trackingStageApi.ts` — list/add comment, verify, revert.
  - New `StageGraph.tsx` — 7 pills (Drafted → Outlook #1 → Outlook #2 → Teams → Manager responded → Auditor verified → Resolved) with per-pill comment threads.
  - `ActivityFeed.tsx` renders `<StageGraph />` above the existing `<TrackingTimeline />`.
  - `EscalationPanel.tsx` gains an amber "Awaiting auditor verification" pill for `stage=RESOLVED && !verifiedAt`, a green "Verified by X" pill when verified, and a footer "Verified — Resolve" button (single click, editor+).
  - `ManagerTable.tsx` shows the same orange pill inline on the list row.
  - `EscalationCenter.tsx` — new "Needs verification" toggle in the header and `?needsVerification=1` URL param filter.
- **Database**
  - `20260422233000_issue76_verification_and_stage_comments`: adds the two columns, the stage-comments table, and the three required indices.

## Behavior

- `stage === 'RESOLVED' && verifiedAt == null` → row stays in the active list with an orange pill until an auditor clicks **Verified — Resolve**.
- Clicking any node in the graph opens an append-only comment thread for that `(trackingEntryId, stage)` pair; comments surface live via `tracking.updated`.
- Clicking a future (grey) node is intentionally still allowed so auditors can leave intent notes ("will retry Thursday") before the step actually happens.
- `DELETE /tracking/:id/verify` is admin-only; it reverts verification and re-opens the row.

## Constraints Handled

- Verify is **idempotent** — first writer wins, subsequent callers get `ok: true` with the existing `verifiedAt`.
- Comment body capped at 4000 chars; stage + body required.
- `authorName` denormalised on the comment row so display survives user deletion.
- All write paths emit `tracking.updated` so other open sessions re-render without polling.

## Testing

- `tsc --noEmit` clean for `packages/domain`, `apps/api`, `apps/web`.
- Not verified in a browser — needs smoke test of (a) verify path, (b) orange pill, (c) stage comment posting + live update across sessions, (d) admin revert.

## Notes

- Migration is additive. Existing `RESOLVED` rows come out of the migration with `verifiedAt = null`, so they'll display as "Awaiting verification" until an auditor signs off. Intended — that's the compliance hole the issue closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)