### PR TITLE
feat(issue-77): attachments tab for tracking entries

### DIFF
--- a/apps/api/prisma/migrations/20260422234500_issue77_tracking_attachments/migration.sql
+++ b/apps/api/prisma/migrations/20260422234500_issue77_tracking_attachments/migration.sql
@@ -1,0 +1,22 @@
+-- Issue #77: evidence attachments for TrackingEntry. Inline BYTEA (same
+-- pattern WorkbookFile uses); capped at 10 MB per file / 20 per entry by
+-- the service layer, not by the schema.
+CREATE TABLE "TrackingAttachment" (
+  "id"              TEXT NOT NULL PRIMARY KEY,
+  "displayCode"     TEXT NOT NULL UNIQUE,
+  "trackingEntryId" TEXT NOT NULL REFERENCES "TrackingEntry"("id") ON DELETE CASCADE,
+  "uploadedById"    TEXT NOT NULL REFERENCES "User"("id"),
+  "fileName"        TEXT NOT NULL,
+  "mimeType"        TEXT NOT NULL,
+  "sizeBytes"       INTEGER NOT NULL,
+  "content"         BYTEA NOT NULL,
+  "comment"         TEXT NOT NULL DEFAULT '',
+  "createdAt"       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "deletedAt"       TIMESTAMPTZ NULL
+);
+
+CREATE INDEX "TrackingAttachment_trackingEntryId_idx"
+  ON "TrackingAttachment" ("trackingEntryId");
+
+CREATE INDEX "TrackingAttachment_trackingEntryId_deletedAt_idx"
+  ON "TrackingAttachment" ("trackingEntryId", "deletedAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -78,6 +78,7 @@ model User {
   trackingDraftLocks TrackingEntry[] @relation("TrackingDraftLock")
   trackingVerifications TrackingEntry[] @relation("TrackingVerifier")
   trackingStageComments TrackingStageComment[] @relation("TrackingStageCommentBy")
+  trackingAttachments TrackingAttachment[] @relation("TrackingAttachmentBy")
 }
 
 model Process {
@@ -473,6 +474,7 @@ model TrackingEntry {
   verifiedBy     User?    @relation("TrackingVerifier", fields: [verifiedById], references: [id], onDelete: SetNull)
   notificationLogs NotificationLog[]
   stageComments  TrackingStageComment[]
+  attachments    TrackingAttachment[]
 
   @@unique([processId, managerKey])
   @@index([processId, stage, slaDueAt])
@@ -499,6 +501,30 @@ model TrackingStageComment {
 
   @@index([trackingEntryId, stage])
   @@index([trackingEntryId, createdAt])
+}
+
+/// Issue #77: inline-BYTEA attachments tied to a TrackingEntry. Evidence
+/// auditors upload (screenshots, forwarded manager replies, policy docs,
+/// correction PDFs). Soft-deleted via `deletedAt` for an append-only audit
+/// trail; callers must always filter on `deletedAt IS NULL`.
+model TrackingAttachment {
+  id              String        @id
+  displayCode     String        @unique
+  trackingEntryId String
+  uploadedById    String
+  fileName        String
+  mimeType        String
+  sizeBytes       Int
+  content         Bytes
+  comment         String        @default("")
+  createdAt       DateTime      @default(now())
+  deletedAt       DateTime?
+
+  trackingEntry   TrackingEntry @relation(fields: [trackingEntryId], references: [id], onDelete: Cascade)
+  uploadedBy      User          @relation("TrackingAttachmentBy", fields: [uploadedById], references: [id])
+
+  @@index([trackingEntryId])
+  @@index([trackingEntryId, deletedAt])
 }
 
 model TrackingEvent {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -59,6 +59,8 @@ import { TrackingComposeController } from './tracking-compose/tracking-compose.c
 import { TrackingComposeService } from './tracking-compose/tracking-compose.service';
 import { TrackingStageController } from './tracking-stage/tracking-stage.controller';
 import { TrackingStageService } from './tracking-stage/tracking-stage.service';
+import { TrackingAttachmentsController } from './tracking-attachments/tracking-attachments.controller';
+import { TrackingAttachmentsService } from './tracking-attachments/tracking-attachments.service';
 import { OutboundDeliveryService } from './outbound/outbound-delivery.service';
 import { TrackingBulkController } from './tracking-bulk.controller';
 import { TrackingBulkService } from './tracking-bulk.service';
@@ -103,6 +105,7 @@ import { SlaEngineService } from './sla-engine.service';
     EscalationTemplatesController,
     TrackingComposeController,
     TrackingStageController,
+    TrackingAttachmentsController,
     TrackingBulkController,
     InAppNotificationsController,
     SavedViewsController,
@@ -144,6 +147,7 @@ import { SlaEngineService } from './sla-engine.service';
     EscalationTemplatesService,
     TrackingComposeService,
     TrackingStageService,
+    TrackingAttachmentsService,
     TrackingBulkService,
     InAppNotificationsService,
     SavedViewsService,

--- a/apps/api/src/common/identifier.service.ts
+++ b/apps/api/src/common/identifier.service.ts
@@ -128,4 +128,9 @@ export class IdentifierService {
     const value = await this.nextSequence(tx, 'TSC');
     return `TSC-${pad(value, 9)}`;
   }
+
+  async nextTrackingAttachmentCode(tx: TxLike): Promise<string> {
+    const value = await this.nextSequence(tx, 'TAT');
+    return `TAT-${pad(value, 9)}`;
+  }
 }

--- a/apps/api/src/tracking-attachments/tracking-attachments.controller.ts
+++ b/apps/api/src/tracking-attachments/tracking-attachments.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Throttle } from '@nestjs/throttler';
+import type { Response } from 'express';
+import { memoryStorage } from 'multer';
+import type { SessionUser } from '@ses/domain';
+import { AuthGuard } from '../auth.guard';
+import { CurrentUser } from '../common/current-user';
+import { attachmentContentDisposition } from '../common/http';
+import {
+  MAX_ATTACHMENT_BYTES,
+  TrackingAttachmentsService,
+} from './tracking-attachments.service';
+
+@Controller()
+@UseGuards(AuthGuard)
+export class TrackingAttachmentsController {
+  constructor(private readonly svc: TrackingAttachmentsService) {}
+
+  @Get('tracking/:idOrCode/attachments')
+  list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    return this.svc.list(idOrCode, user);
+  }
+
+  @Post('tracking/:idOrCode/attachments')
+  @Throttle({ default: { limit: 40, ttl: 60_000 } })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: MAX_ATTACHMENT_BYTES },
+    }),
+  )
+  upload(
+    @Param('idOrCode') idOrCode: string,
+    @UploadedFile() file: Express.Multer.File | undefined,
+    @Body('comment') comment: string | undefined,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.svc.create(idOrCode, user, file, comment ?? '');
+  }
+
+  @Get('tracking/:idOrCode/attachments/:attIdOrCode/download')
+  async download(
+    @Param('idOrCode') idOrCode: string,
+    @Param('attIdOrCode') attIdOrCode: string,
+    @CurrentUser() user: SessionUser,
+    @Res() res: Response,
+  ) {
+    const { fileName, mimeType, content } = await this.svc.download(idOrCode, attIdOrCode, user);
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Content-Disposition', attachmentContentDisposition(fileName));
+    res.setHeader('Content-Length', String(content.length));
+    // Buffer straight out — no streaming needed at 10 MB cap.
+    res.send(content);
+  }
+
+  @Patch('tracking/:idOrCode/attachments/:attIdOrCode')
+  patch(
+    @Param('idOrCode') idOrCode: string,
+    @Param('attIdOrCode') attIdOrCode: string,
+    @Body() body: { comment: string },
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.svc.patch(idOrCode, attIdOrCode, user, body);
+  }
+
+  @Delete('tracking/:idOrCode/attachments/:attIdOrCode')
+  remove(
+    @Param('idOrCode') idOrCode: string,
+    @Param('attIdOrCode') attIdOrCode: string,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.svc.remove(idOrCode, attIdOrCode, user);
+  }
+}

--- a/apps/api/src/tracking-attachments/tracking-attachments.service.ts
+++ b/apps/api/src/tracking-attachments/tracking-attachments.service.ts
@@ -1,0 +1,286 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import type { SessionUser } from '@ses/domain';
+import { createId } from '@ses/domain';
+import { PrismaService } from '../common/prisma.service';
+import { IdentifierService } from '../common/identifier.service';
+import { ActivityLogService } from '../common/activity-log.service';
+import { ProcessAccessService } from '../common/process-access.service';
+import { RealtimeGateway } from '../realtime/realtime.gateway';
+
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10 MB
+export const MAX_ATTACHMENTS_PER_ENTRY = 20;
+
+/**
+ * Mime allow-list — deliberately narrow. The controller enforces the
+ * content-type coming off multer; the service sanity-checks the filename
+ * extension too so a renamed .exe masquerading as a .pdf still gets
+ * rejected.
+ */
+const ALLOWED_MIME = new Set<string>([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+  'application/msword', // legacy .doc
+  'application/vnd.ms-excel', // legacy .xls
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'text/plain',
+  'message/rfc822', // .eml
+  'application/vnd.ms-outlook', // .msg
+]);
+
+const ALLOWED_EXT = /\.(pdf|docx?|xlsx?|png|jpe?g|txt|eml|msg)$/i;
+
+export interface AttachmentMetaDto {
+  id: string;
+  displayCode: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  comment: string;
+  uploadedById: string;
+  uploadedByName: string;
+  createdAt: string;
+}
+
+@Injectable()
+export class TrackingAttachmentsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly identifiers: IdentifierService,
+    private readonly activity: ActivityLogService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly realtime: RealtimeGateway,
+  ) {}
+
+  private async loadEntry(idOrCode: string, user: SessionUser, min: 'viewer' | 'editor') {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      include: { process: { select: { id: true, displayCode: true } } },
+    });
+    if (!entry) throw new NotFoundException(`Tracking entry ${idOrCode} not found`);
+    await this.processAccess.require(entry.processId, user, min);
+    return entry;
+  }
+
+  private async loadAttachment(trackingEntryId: string, idOrCode: string) {
+    const att = await this.prisma.trackingAttachment.findFirst({
+      where: {
+        trackingEntryId,
+        OR: [{ id: idOrCode }, { displayCode: idOrCode }],
+      },
+    });
+    if (!att) throw new NotFoundException(`Attachment ${idOrCode} not found`);
+    return att;
+  }
+
+  private serialize(row: {
+    id: string;
+    displayCode: string;
+    fileName: string;
+    mimeType: string;
+    sizeBytes: number;
+    comment: string;
+    uploadedById: string;
+    createdAt: Date;
+    uploadedBy?: { displayName: string } | null;
+  }): AttachmentMetaDto {
+    return {
+      id: row.id,
+      displayCode: row.displayCode,
+      fileName: row.fileName,
+      mimeType: row.mimeType,
+      sizeBytes: row.sizeBytes,
+      comment: row.comment,
+      uploadedById: row.uploadedById,
+      uploadedByName: row.uploadedBy?.displayName ?? '',
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+
+  async list(idOrCode: string, user: SessionUser) {
+    const entry = await this.loadEntry(idOrCode, user, 'viewer');
+    const rows = await this.prisma.trackingAttachment.findMany({
+      where: { trackingEntryId: entry.id, deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        displayCode: true,
+        fileName: true,
+        mimeType: true,
+        sizeBytes: true,
+        comment: true,
+        uploadedById: true,
+        createdAt: true,
+        uploadedBy: { select: { displayName: true } },
+      },
+    });
+    return { attachments: rows.map((r) => this.serialize(r)) };
+  }
+
+  async create(
+    idOrCode: string,
+    user: SessionUser,
+    file: Express.Multer.File | undefined,
+    comment: string,
+  ) {
+    if (!file) throw new BadRequestException('File is required.');
+    if (file.size === 0) throw new BadRequestException('File is empty.');
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      throw new PayloadTooLargeException(
+        `Attachment exceeds ${MAX_ATTACHMENT_BYTES / 1024 / 1024} MB limit.`,
+      );
+    }
+    const mime = (file.mimetype ?? '').toLowerCase();
+    if (!ALLOWED_MIME.has(mime)) {
+      throw new BadRequestException(`Unsupported file type: ${mime || 'unknown'}.`);
+    }
+    const name = (file.originalname ?? '').trim();
+    if (!name) throw new BadRequestException('File name is required.');
+    if (!ALLOWED_EXT.test(name)) {
+      throw new BadRequestException('File extension is not in the allow-list.');
+    }
+
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+
+    const active = await this.prisma.trackingAttachment.count({
+      where: { trackingEntryId: entry.id, deletedAt: null },
+    });
+    if (active >= MAX_ATTACHMENTS_PER_ENTRY) {
+      throw new ConflictException(
+        `Attachment limit reached (${MAX_ATTACHMENTS_PER_ENTRY} per tracking entry).`,
+      );
+    }
+
+    const trimmedComment = (comment ?? '').slice(0, 2000);
+    // multer gives us Node's Buffer; coerce to a plain Uint8Array so the
+    // Prisma `Bytes` column accepts it without a TS mismatch.
+    const content = new Uint8Array(file.buffer);
+    const row = await this.prisma.$transaction(async (tx) => {
+      return tx.trackingAttachment.create({
+        data: {
+          id: createId(),
+          displayCode: await this.identifiers.nextTrackingAttachmentCode(tx),
+          trackingEntryId: entry.id,
+          uploadedById: user.id,
+          fileName: name,
+          mimeType: mime,
+          sizeBytes: file.size,
+          content,
+          comment: trimmedComment,
+        },
+        select: {
+          id: true,
+          displayCode: true,
+          fileName: true,
+          mimeType: true,
+          sizeBytes: true,
+          comment: true,
+          uploadedById: true,
+          createdAt: true,
+          uploadedBy: { select: { displayName: true } },
+        },
+      });
+    });
+
+    await this.activity.append(this.prisma, {
+      actorId: user.id,
+      actorEmail: user.email,
+      processId: entry.processId,
+      entityType: 'tracking_entry',
+      entityId: entry.id,
+      entityCode: entry.displayCode,
+      action: 'tracking.attachment_added',
+      metadata: { attachmentId: row.id, fileName: row.fileName, sizeBytes: row.sizeBytes },
+    });
+
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: entry.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+
+    return this.serialize(row);
+  }
+
+  async download(idOrCode: string, attIdOrCode: string, user: SessionUser) {
+    const entry = await this.loadEntry(idOrCode, user, 'viewer');
+    const att = await this.loadAttachment(entry.id, attIdOrCode);
+    if (att.deletedAt) throw new NotFoundException('Attachment has been deleted.');
+    return {
+      fileName: att.fileName,
+      mimeType: att.mimeType,
+      content: att.content,
+    };
+  }
+
+  async patch(
+    idOrCode: string,
+    attIdOrCode: string,
+    user: SessionUser,
+    body: { comment?: string },
+  ) {
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+    const att = await this.loadAttachment(entry.id, attIdOrCode);
+    if (att.deletedAt) throw new NotFoundException('Attachment has been deleted.');
+    if (typeof body.comment !== 'string') {
+      throw new BadRequestException('comment is required');
+    }
+    const comment = body.comment.slice(0, 2000);
+    const updated = await this.prisma.trackingAttachment.update({
+      where: { id: att.id },
+      data: { comment },
+      select: {
+        id: true,
+        displayCode: true,
+        fileName: true,
+        mimeType: true,
+        sizeBytes: true,
+        comment: true,
+        uploadedById: true,
+        createdAt: true,
+        uploadedBy: { select: { displayName: true } },
+      },
+    });
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: entry.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+    return this.serialize(updated);
+  }
+
+  async remove(idOrCode: string, attIdOrCode: string, user: SessionUser) {
+    const entry = await this.loadEntry(idOrCode, user, 'editor');
+    const att = await this.loadAttachment(entry.id, attIdOrCode);
+    if (att.deletedAt) return { ok: true };
+    if (att.uploadedById !== user.id && user.role !== 'admin') {
+      throw new ForbiddenException('Only the uploader or an admin can delete an attachment.');
+    }
+    await this.prisma.trackingAttachment.update({
+      where: { id: att.id },
+      data: { deletedAt: new Date() },
+    });
+    await this.activity.append(this.prisma, {
+      actorId: user.id,
+      actorEmail: user.email,
+      processId: entry.processId,
+      entityType: 'tracking_entry',
+      entityId: entry.id,
+      entityCode: entry.displayCode,
+      action: 'tracking.attachment_deleted',
+      metadata: { attachmentId: att.id, fileName: att.fileName },
+    });
+    this.realtime.emitToProcess(entry.process.displayCode, 'tracking.updated', {
+      trackingId: entry.id,
+      stage: entry.stage,
+    }, { actor: { id: user.id, code: user.displayCode, email: user.email, displayName: user.displayName } });
+    return { ok: true };
+  }
+}

--- a/apps/web/src/components/escalations/AttachmentsTab.tsx
+++ b/apps/web/src/components/escalations/AttachmentsTab.tsx
@@ -1,0 +1,277 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import toast from 'react-hot-toast';
+import { Download, FileText, Image as ImageIcon, Mail, Paperclip, Trash2, Upload } from 'lucide-react';
+import {
+  attachmentDownloadUrl,
+  deleteAttachment,
+  listAttachments,
+  patchAttachmentComment,
+  uploadAttachment,
+  type TrackingAttachmentMeta,
+} from '../../lib/api/trackingAttachmentsApi';
+import { useCurrentUser } from '../auth/authContext';
+import { Button } from '../shared/Button';
+
+const MAX_BYTES = 10 * 1024 * 1024;
+const MAX_COUNT = 20;
+const ACCEPT =
+  '.pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg,.txt,.eml,.msg';
+
+function iconFor(mime: string) {
+  if (mime.startsWith('image/')) return <ImageIcon size={16} className="text-gray-500" />;
+  if (mime === 'message/rfc822' || mime === 'application/vnd.ms-outlook') {
+    return <Mail size={16} className="text-gray-500" />;
+  }
+  return <FileText size={16} className="text-gray-500" />;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function AttachmentsTab({ trackingIdOrCode }: { trackingIdOrCode: string | null }) {
+  const qc = useQueryClient();
+  const user = useCurrentUser();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  const q = useQuery({
+    queryKey: ['tracking-attachments', trackingIdOrCode],
+    queryFn: () => listAttachments(trackingIdOrCode!),
+    enabled: Boolean(trackingIdOrCode),
+    staleTime: 15_000,
+  });
+
+  const uploadMut = useMutation({
+    mutationFn: ({ file, comment }: { file: File; comment: string }) =>
+      uploadAttachment(trackingIdOrCode!, file, comment),
+    onSuccess: () => {
+      toast.success('Attachment uploaded.');
+      void qc.invalidateQueries({ queryKey: ['tracking-attachments', trackingIdOrCode] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  if (!trackingIdOrCode) {
+    return <p className="text-sm text-gray-500">No tracking record for this manager.</p>;
+  }
+
+  const rows = q.data ?? [];
+  const atLimit = rows.length >= MAX_COUNT;
+
+  function handleFile(file: File, comment = '') {
+    if (file.size > MAX_BYTES) {
+      toast.error(`${file.name} exceeds the 10 MB limit.`);
+      return;
+    }
+    if (atLimit) {
+      toast.error(`Attachment limit reached (${MAX_COUNT} per entry).`);
+      return;
+    }
+    uploadMut.mutate({ file, comment });
+  }
+
+  function onPickChange(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (f) handleFile(f);
+    // Reset so the same file can be re-selected after a failure.
+    if (inputRef.current) inputRef.current.value = '';
+  }
+
+  function onDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setDragOver(false);
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleFile(f);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={onDrop}
+        aria-label="Upload attachment"
+        className={`flex cursor-pointer flex-col items-center gap-1 rounded-lg border-2 border-dashed px-4 py-6 text-center text-sm transition ${
+          dragOver
+            ? 'border-brand bg-brand/5 text-brand'
+            : 'border-gray-300 bg-gray-50 text-gray-600 hover:border-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300'
+        } ${atLimit ? 'pointer-events-none opacity-60' : ''}`}
+      >
+        <Upload size={18} />
+        <div>
+          <span className="font-medium">Drag & drop</span> a file, or click to browse
+        </div>
+        <div className="text-[11px] text-gray-500">
+          PDF · DOCX · XLSX · PNG · JPG · TXT · EML · MSG — up to 10 MB, max {MAX_COUNT} per entry
+          {atLimit ? ' (limit reached)' : ''}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPT}
+          className="hidden"
+          onChange={onPickChange}
+        />
+      </div>
+
+      {q.isLoading ? (
+        <div className="text-sm text-gray-500">Loading attachments…</div>
+      ) : null}
+      {q.isError ? (
+        <div className="text-sm text-red-600">{(q.error as Error).message}</div>
+      ) : null}
+
+      {rows.length === 0 && !q.isLoading ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+          <div className="mb-1 flex items-center gap-1 font-medium">
+            <Paperclip size={14} /> No attachments yet.
+          </div>
+          <div className="text-xs">
+            Examples: screenshots of corrections, forwarded emails from the manager, supporting policy docs.
+          </div>
+        </div>
+      ) : null}
+
+      <ul className="space-y-2">
+        {rows.map((att) => (
+          <AttachmentCard
+            key={att.id}
+            att={att}
+            trackingIdOrCode={trackingIdOrCode}
+            canDelete={att.uploadedById === user?.id || user?.role === 'admin'}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AttachmentCard({
+  att,
+  trackingIdOrCode,
+  canDelete,
+}: {
+  att: TrackingAttachmentMeta;
+  trackingIdOrCode: string;
+  canDelete: boolean;
+}) {
+  const qc = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [comment, setComment] = useState(att.comment);
+
+  const patchMut = useMutation({
+    mutationFn: (next: string) => patchAttachmentComment(trackingIdOrCode, att.id, next),
+    onSuccess: () => {
+      setEditing(false);
+      void qc.invalidateQueries({ queryKey: ['tracking-attachments', trackingIdOrCode] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const delMut = useMutation({
+    mutationFn: () => deleteAttachment(trackingIdOrCode, att.id),
+    onSuccess: () => {
+      toast.success('Attachment removed.');
+      void qc.invalidateQueries({ queryKey: ['tracking-attachments', trackingIdOrCode] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <li className="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+      <div className="flex items-start gap-2">
+        <div className="pt-0.5">{iconFor(att.mimeType)}</div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <a
+              href={attachmentDownloadUrl(trackingIdOrCode, att.id)}
+              className="truncate text-sm font-medium text-gray-900 hover:underline dark:text-white"
+              title={att.fileName}
+            >
+              {att.fileName}
+            </a>
+            <span className="text-[11px] text-gray-500">{formatSize(att.sizeBytes)}</span>
+          </div>
+          <div className="text-[11px] text-gray-500">
+            Uploaded by {att.uploadedByName || 'unknown'} · {new Date(att.createdAt).toLocaleString()}
+          </div>
+          {editing ? (
+            <div className="mt-2 flex gap-2">
+              <input
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                className="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900"
+                placeholder="What is this file?"
+              />
+              <Button
+                type="button"
+                onClick={() => patchMut.mutate(comment)}
+                disabled={patchMut.isPending}
+              >
+                Save
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  setComment(att.comment);
+                  setEditing(false);
+                }}
+                disabled={patchMut.isPending}
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="mt-1 block w-full text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800/60"
+              onClick={() => setEditing(true)}
+              title="Click to edit the comment"
+            >
+              {att.comment || <span className="italic text-gray-400">Click to add a comment</span>}
+            </button>
+          )}
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <a
+            href={attachmentDownloadUrl(trackingIdOrCode, att.id)}
+            className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300"
+            title="Download"
+          >
+            <Download size={12} /> Download
+          </a>
+          {canDelete ? (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-60 dark:border-red-900 dark:hover:bg-red-950"
+              disabled={delMut.isPending}
+              onClick={() => {
+                if (!window.confirm('Remove this attachment?')) return;
+                delMut.mutate();
+              }}
+            >
+              <Trash2 size={12} /> Delete
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/components/escalations/EscalationPanel.tsx
+++ b/apps/web/src/components/escalations/EscalationPanel.tsx
@@ -5,6 +5,7 @@ import { BadgeCheck } from 'lucide-react';
 import type { ProcessEscalationManagerRow } from '@ses/domain';
 import { verifyTracking } from '../../lib/api/trackingStageApi';
 import { ActivityFeed } from './ActivityFeed';
+import { AttachmentsTab } from './AttachmentsTab';
 import { Composer } from './Composer';
 import { FindingsTab } from './FindingsTab';
 
@@ -121,11 +122,10 @@ export function EscalationPanel({
             <button
               key={id}
               type="button"
-              disabled={id === 'attachments'}
               onClick={() => setTab(id)}
               className={`flex-1 px-2 py-2 font-medium ${
                 tab === id ? 'border-b-2 border-brand text-brand' : 'text-gray-500'
-              } disabled:cursor-not-allowed disabled:opacity-50`}
+              }`}
             >
               {label}
             </button>
@@ -138,7 +138,7 @@ export function EscalationPanel({
             <ActivityFeed trackingIdOrCode={row.trackingId ?? row.trackingDisplayCode} row={row} />
           ) : null}
           {tab === 'attachments' ? (
-            <p className="text-sm text-gray-500">Attachments will be available in a later release.</p>
+            <AttachmentsTab trackingIdOrCode={row.trackingId ?? row.trackingDisplayCode} />
           ) : null}
         </div>
         {canVerify && trackingRef ? (

--- a/apps/web/src/lib/api/trackingAttachmentsApi.ts
+++ b/apps/web/src/lib/api/trackingAttachmentsApi.ts
@@ -1,0 +1,75 @@
+import { parseApiError } from './client';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export interface TrackingAttachmentMeta {
+  id: string;
+  displayCode: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  comment: string;
+  uploadedById: string;
+  uploadedByName: string;
+  createdAt: string;
+}
+
+export async function listAttachments(trackingIdOrCode: string): Promise<TrackingAttachmentMeta[]> {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/attachments`,
+    { credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to load attachments');
+  const json = (await res.json()) as { attachments: TrackingAttachmentMeta[] };
+  return json.attachments;
+}
+
+export async function uploadAttachment(
+  trackingIdOrCode: string,
+  file: File,
+  comment: string,
+): Promise<TrackingAttachmentMeta> {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('comment', comment);
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/attachments`,
+    { method: 'POST', credentials: 'include', body: form },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Upload failed');
+  return (await res.json()) as TrackingAttachmentMeta;
+}
+
+export async function patchAttachmentComment(
+  trackingIdOrCode: string,
+  attIdOrCode: string,
+  comment: string,
+): Promise<TrackingAttachmentMeta> {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/attachments/${encodeURIComponent(attIdOrCode)}`,
+    {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ comment }),
+    },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Update failed');
+  return (await res.json()) as TrackingAttachmentMeta;
+}
+
+export async function deleteAttachment(
+  trackingIdOrCode: string,
+  attIdOrCode: string,
+): Promise<{ ok: boolean }> {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/attachments/${encodeURIComponent(attIdOrCode)}`,
+    { method: 'DELETE', credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Delete failed');
+  return (await res.json()) as { ok: boolean };
+}
+
+export function attachmentDownloadUrl(trackingIdOrCode: string, attIdOrCode: string): string {
+  return `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/attachments/${encodeURIComponent(attIdOrCode)}/download`;
+}

--- a/apps/web/src/pages/EscalationCenter.tsx
+++ b/apps/web/src/pages/EscalationCenter.tsx
@@ -120,6 +120,9 @@ export function EscalationCenter() {
         // Invalidate any open tracking-events queries too so the timeline
         // auto-advances when the SLA cron transitions a stage.
         void queryClient.invalidateQueries({ queryKey: ['tracking-events'] });
+        // Issue #77: attachments list rides on the same tracking.updated
+        // channel so a sibling auditor's upload shows up live.
+        void queryClient.invalidateQueries({ queryKey: ['tracking-attachments'] });
       } else if (envelope.event === 'directory.updated') {
         // Issue #74: a Manager Directory mutation (inline-add, alias,
         // merge, archive, delete) invalidates the "unmapped manager"


### PR DESCRIPTION
Closes #77

## Summary

Replaces the disabled "Attachments will be available in a later release" stub with a working attachments tab. Auditors can now attach evidence (screenshots, forwarded emails, policy docs, correction PDFs) to any tracking entry, edit per-attachment comments inline, download later, and soft-delete their own uploads.

## Changes

- **Backend**
  - New `TrackingAttachment` Prisma model + migration. Inline `BYTEA` for content (same pattern as `WorkbookFile`); `deletedAt` for soft-delete; indexes on `(trackingEntryId)` and `(trackingEntryId, deletedAt)`.
  - `TrackingAttachmentsService` — `list`, `create`, `download`, `patch` (comment only; content is immutable), `remove` (soft delete; uploader or admin only). All mutations emit `tracking.updated`.
  - `TrackingAttachmentsController` — five REST endpoints under `/api/v1/tracking/:idOrCode/attachments` including a dedicated `/download` that streams with `Content-Disposition: attachment`.
  - Size cap: **10 MB** per file (enforced by both multer's `limits.fileSize` and an explicit service-side check). Count cap: **20 active attachments per entry**. Mime allow-list + extension allow-list.
  - `IdentifierService.nextTrackingAttachmentCode` (`TAT-NNNNNNNNN`).
  - Wired into `AppModule`.
- **Frontend**
  - New `trackingAttachmentsApi.ts` — list, upload (FormData), patch comment, delete, download URL helper.
  - New `AttachmentsTab.tsx` — drag-and-drop + click-to-browse drop zone, per-card inline-editable comment, icon per mime, size label, uploader/timestamp, download link, Delete button (uploader/admin only).
  - `EscalationPanel.tsx` attachments tab un-disabled; renders `<AttachmentsTab />`.
  - `EscalationCenter.tsx` invalidates `['tracking-attachments']` on `tracking.updated` so a sibling session uploading sees the new row live.
- **Database**
  - `20260422234500_issue77_tracking_attachments` adds the table + two indexes.

## Behavior

- Drop or pick a file → server validates size / mime / extension / per-entry count → stores BYTEA → activity log entry + realtime event.
- Click a card comment to edit inline; save PATCHes the comment only (content is immutable post-upload).
- Download always hits the server, which sets `Content-Disposition: attachment; filename="…"` via the existing `attachmentContentDisposition` helper (sanitises quotes/newlines).
- Delete is a soft-delete (sets `deletedAt`); the row remains in the DB for the audit trail and stays hidden from lists.

## Constraints Handled

- **Size**: multer limit + explicit service check (defense in depth); exceeding returns 413.
- **Count**: 21st upload rejected with 409 "Attachment limit reached (20 per tracking entry)."
- **Mime allow-list**: `.pdf`, `.docx`, `.xlsx`, legacy `.doc`/`.xls`, `.png`, `.jpg/.jpeg`, `.txt`, `.eml`, `.msg`. Anything else is rejected 400; filename extension is validated independently.
- **Auth**: editor+ for upload / patch comment; uploader-or-admin for delete; any process member can list / download.
- **Realtime**: every mutation emits `tracking.updated` scoped to the process room.
- **Soft-delete** means repeat DELETEs are idempotent — second call returns `{ ok: true }` without touching the row.

## Testing

- `tsc --noEmit` clean for `packages/domain`, `apps/api`, `apps/web`.
- Not verified in a browser — needs smoke test of (a) drop zone drop, (b) 10 MB oversize rejection, (c) mime rejection of a renamed `.sh`, (d) inline comment editing, (e) delete-then-retry upload.

## Notes

- Storage is inline BYTEA (10 MB × 20 = ~200 MB worst case per entry). If customers exceed this in practice we'll revisit with an S3 or blob-store backend — see the Not-in-scope list in the issue.
- No virus scanning, no inline preview — both explicitly parked in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)