### PR TITLE
fix(escalations): refresh unmapped state after directory enrichment

### DIFF
--- a/apps/api/src/directory/resolve-issue-emails.ts
+++ b/apps/api/src/directory/resolve-issue-emails.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
+import { normalizeObservedManagerLabel } from '@ses/domain';
 import { matchRawNameToDirectoryEntries } from './directory-matching';
 
 type TxOrClient = Prisma.TransactionClient | PrismaClient;
@@ -12,6 +13,11 @@ export interface ResolveIssueEmailsOutcome<T extends IssueEmailInput> {
   issues: T[];
   resolvedFromDirectory: number;
   unresolvedManagerNames: string[];
+}
+
+function parseAliasList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((x): x is string => typeof x === 'string');
 }
 
 /**
@@ -55,11 +61,40 @@ export async function resolveIssueEmailsFromDirectory<T extends IssueEmailInput>
     return { issues, resolvedFromDirectory: 0, unresolvedManagerNames: names };
   }
 
+  // Build an exact normalized-key index first so deterministic matches
+  // (including "Last, First" and whitespace/case variants) never fall
+  // through to the fuzzy matcher. If two active entries share a key, the
+  // exact lookup abstains and we hand off to the fuzzy path, which treats
+  // the tie as a collision.
+  const exactEmailByKey = new Map<string, string | null>();
+  for (const e of entries) {
+    if (!e.active) continue;
+    const register = (rawKey: string) => {
+      const key = rawKey.trim().toLowerCase();
+      if (!key) return;
+      if (!exactEmailByKey.has(key)) {
+        exactEmailByKey.set(key, e.email);
+      } else if (exactEmailByKey.get(key) !== e.email) {
+        exactEmailByKey.set(key, null); // ambiguous — let fuzzy handle
+      }
+    };
+    register(e.normalizedKey);
+    for (const alias of parseAliasList(e.aliases)) {
+      register(normalizeObservedManagerLabel(alias));
+    }
+  }
+
   // Match once per unique name — engines can produce hundreds of issues
   // for the same manager; matching is O(entries) per call so cache it.
   const resolvedEmailByName = new Map<string, string>();
   const unresolved: string[] = [];
   for (const name of names) {
+    const exactKey = normalizeObservedManagerLabel(name).toLowerCase();
+    const exactEmail = exactKey ? exactEmailByKey.get(exactKey) : undefined;
+    if (exactEmail) {
+      resolvedEmailByName.set(name, exactEmail);
+      continue;
+    }
     const match = matchRawNameToDirectoryEntries(name, entries);
     if (match.autoMatch && !match.collision) {
       resolvedEmailByName.set(name, match.autoMatch.email);

--- a/apps/api/src/escalations-aggregator.ts
+++ b/apps/api/src/escalations-aggregator.ts
@@ -180,6 +180,9 @@ export function aggregateEscalations(
   }
 
   const enginesWithIssues = FUNCTION_IDS.filter((id) => (perEngineIssueCounts[id] ?? 0) > 0);
+  // Provisional: pre-directory-enrichment. EscalationsService recomputes
+  // this after joining ManagerDirectory so a Directory import clears the
+  // banner without needing an audit rerun. See escalations.service.ts.
   const unmappedManagerCount = rows.filter((r) => r.isUnmapped && (r.totalIssues > 0 || !r.resolved)).length;
 
   const summary: ProcessEscalationsSummary = {

--- a/apps/api/src/escalations.service.ts
+++ b/apps/api/src/escalations.service.ts
@@ -119,9 +119,16 @@ export class EscalationsService {
       const directoryEmail =
         directoryByKey.get(row.managerKey.trim().toLowerCase()) ?? directoryByKey.get(nk) ?? null;
       const extra = row.trackingId ? lockById.get(row.trackingId) : undefined;
+      // The aggregator runs before directory enrichment, so its isUnmapped
+      // is provisional. Recompute here using the effective email (tracking
+      // or issue email, else directory) so a Directory import clears the
+      // flag on the next refetch without waiting for a rerun.
+      const effectiveEmail = row.resolvedEmail ?? directoryEmail;
+      const isUnmapped = !effectiveEmail;
       return {
         ...row,
         directoryEmail,
+        isUnmapped,
         escalationLevel: extra?.escalationLevel ?? 0,
         draftLockExpiresAt: extra?.draftLockExpiresAt ?? null,
         draftLockUserDisplayName: extra?.draftLockUserDisplayName ?? null,
@@ -130,6 +137,14 @@ export class EscalationsService {
       };
     });
 
-    return { ...payload, rows };
+    const unmappedManagerCount = rows.filter(
+      (r) => r.isUnmapped && (r.totalIssues > 0 || !r.resolved),
+    ).length;
+
+    return {
+      ...payload,
+      summary: { ...payload.summary, unmappedManagerCount },
+      rows,
+    };
   }
 }

--- a/apps/api/test/escalations.service.test.ts
+++ b/apps/api/test/escalations.service.test.ts
@@ -1,0 +1,158 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { SessionUser } from '@ses/domain';
+import { EscalationsService } from '../src/escalations.service';
+
+type AnyObj = Record<string, unknown>;
+
+function buildService(opts: {
+  issues: Array<{ issueKey: string; projectManager: string; email: string | null; projectNo: string | null; projectName: string | null }>;
+  tracking: Array<AnyObj>;
+  directory: Array<{ normalizedKey: string; email: string }>;
+}) {
+  const prisma = {
+    auditRun: {
+      // Emit a single completed run for the master-data engine; the other
+      // engines short-circuit to null. That's enough to exercise the
+      // aggregator-plus-enrichment path end-to-end.
+      findFirst: (args: AnyObj) => {
+        const where = (args.where as AnyObj) ?? {};
+        const file = (where.file as AnyObj) ?? {};
+        if (file.functionId !== 'master-data') return Promise.resolve(null);
+        return Promise.resolve({
+          issues: opts.issues,
+        });
+      },
+    },
+    trackingEntry: {
+      findMany: () => Promise.resolve(opts.tracking),
+    },
+    managerDirectory: {
+      findMany: () => Promise.resolve(opts.directory),
+    },
+  };
+  const access = {
+    findAccessibleProcessOrThrow: async () => ({ id: 'proc-1', tenantId: 't1' }),
+  };
+  return new EscalationsService(prisma as never, access as never);
+}
+
+const user: SessionUser = {
+  id: 'u1',
+  displayCode: 'USR-1',
+  email: 'me@example.com',
+  displayName: 'Me',
+  role: 'auditor',
+} as SessionUser;
+
+describe('EscalationsService directory enrichment', () => {
+  it('clears isUnmapped when directory resolves the manager after aggregation', async () => {
+    const svc = buildService({
+      issues: [
+        {
+          issueKey: 'k1',
+          projectManager: 'Bob Example',
+          email: null,
+          projectNo: 'P1',
+          projectName: 'N1',
+        },
+      ],
+      tracking: [
+        {
+          id: 't1',
+          displayCode: 'TRK-1',
+          managerKey: 'missing-email:bob-example',
+          managerName: 'Bob Example',
+          managerEmail: null,
+          stage: 'OPEN',
+          escalationLevel: 0,
+          resolved: false,
+          lastContactAt: null,
+          slaDueAt: null,
+          verifiedAt: null,
+          verifiedBy: null,
+          outlookCount: 0,
+          teamsCount: 0,
+          draftLockExpiresAt: null,
+          draftLockUser: null,
+        },
+      ],
+      directory: [{ normalizedKey: 'bob example', email: 'bob@example.com' }],
+    });
+
+    const payload = await svc.getForProcess('proc-1', user);
+
+    assert.equal(payload.rows.length, 1);
+    const row = payload.rows[0]!;
+    assert.equal(row.directoryEmail, 'bob@example.com');
+    // The aggregator flagged this row unmapped because the tracking/issue
+    // carried no email and the key was missing-email:*. After directory
+    // enrichment the service treats the directoryEmail as the effective
+    // email and drops the flag.
+    assert.equal(row.isUnmapped, false);
+    assert.equal(payload.summary.unmappedManagerCount, 0);
+  });
+
+  it('keeps rows truly unmapped when no directory entry matches', async () => {
+    const svc = buildService({
+      issues: [
+        {
+          issueKey: 'k1',
+          projectManager: 'Alice Ghost',
+          email: null,
+          projectNo: 'P1',
+          projectName: 'N1',
+        },
+      ],
+      tracking: [],
+      directory: [{ normalizedKey: 'bob example', email: 'bob@example.com' }],
+    });
+
+    const payload = await svc.getForProcess('proc-1', user);
+
+    assert.equal(payload.rows.length, 1);
+    const row = payload.rows[0]!;
+    assert.equal(row.directoryEmail, null);
+    assert.equal(row.isUnmapped, true);
+    assert.equal(payload.summary.unmappedManagerCount, 1);
+  });
+
+  it('handles mixed rows: one tracking-mapped, one directory-mapped, one unmapped', async () => {
+    const svc = buildService({
+      issues: [
+        {
+          issueKey: 'k1',
+          projectManager: 'Alice',
+          email: 'alice@example.com',
+          projectNo: 'P1',
+          projectName: 'N1',
+        },
+        {
+          issueKey: 'k2',
+          projectManager: 'Bob Example',
+          email: null,
+          projectNo: 'P2',
+          projectName: 'N2',
+        },
+        {
+          issueKey: 'k3',
+          projectManager: 'Ghost',
+          email: null,
+          projectNo: 'P3',
+          projectName: 'N3',
+        },
+      ],
+      tracking: [],
+      directory: [{ normalizedKey: 'bob example', email: 'bob@example.com' }],
+    });
+
+    const payload = await svc.getForProcess('proc-1', user);
+
+    const byName = new Map(payload.rows.map((r) => [r.managerName, r]));
+    assert.equal(byName.get('Alice')!.isUnmapped, false);
+    assert.equal(byName.get('Bob Example')!.isUnmapped, false);
+    assert.equal(byName.get('Bob Example')!.directoryEmail, 'bob@example.com');
+    assert.equal(byName.get('Ghost')!.isUnmapped, true);
+    assert.equal(payload.summary.unmappedManagerCount, 1);
+  });
+});

--- a/apps/api/test/resolve-issue-emails.test.ts
+++ b/apps/api/test/resolve-issue-emails.test.ts
@@ -1,0 +1,90 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { resolveIssueEmailsFromDirectory } from '../src/directory/resolve-issue-emails';
+
+type DirectoryRow = {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  normalizedKey: string;
+  aliases: string[];
+  active: boolean;
+};
+
+function fakeTx(entries: DirectoryRow[]) {
+  return {
+    managerDirectory: {
+      findMany: async () => entries,
+    },
+  } as never;
+}
+
+describe('resolveIssueEmailsFromDirectory exact-key lookup', () => {
+  it('resolves "Last, First" via exact normalized key before fuzzy', async () => {
+    const entries: DirectoryRow[] = [
+      {
+        id: 'e1',
+        email: 'jane@x.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        normalizedKey: 'doe jane',
+        aliases: [],
+        active: true,
+      },
+    ];
+    const issues = [{ projectManager: 'Doe, Jane', email: undefined as string | undefined }];
+    const out = await resolveIssueEmailsFromDirectory(fakeTx(entries), 't1', issues);
+    assert.equal(out.resolvedFromDirectory, 1);
+    assert.equal(out.issues[0]!.email, 'jane@x.com');
+    assert.deepEqual(out.unresolvedManagerNames, []);
+  });
+
+  it('resolves case/spacing variants deterministically', async () => {
+    const entries: DirectoryRow[] = [
+      {
+        id: 'e1',
+        email: 'jane@x.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        normalizedKey: 'doe jane',
+        aliases: [],
+        active: true,
+      },
+    ];
+    const issues = [{ projectManager: '  JANE   doe ', email: undefined as string | undefined }];
+    const out = await resolveIssueEmailsFromDirectory(fakeTx(entries), 't1', issues);
+    assert.equal(out.resolvedFromDirectory, 1);
+    assert.equal(out.issues[0]!.email, 'jane@x.com');
+  });
+
+  it('defers to fuzzy matcher when exact key is ambiguous', async () => {
+    // Two active entries with the same normalizedKey → ambiguous exact
+    // hit. The exact path abstains and the fuzzy matcher flags a
+    // collision, leaving the issue unresolved.
+    const entries: DirectoryRow[] = [
+      {
+        id: 'e1',
+        email: 'a@x.com',
+        firstName: 'John',
+        lastName: 'Smith',
+        normalizedKey: 'john smith',
+        aliases: [],
+        active: true,
+      },
+      {
+        id: 'e2',
+        email: 'b@x.com',
+        firstName: 'John',
+        lastName: 'Smith',
+        normalizedKey: 'john smith',
+        aliases: [],
+        active: true,
+      },
+    ];
+    const issues = [{ projectManager: 'John Smith', email: undefined as string | undefined }];
+    const out = await resolveIssueEmailsFromDirectory(fakeTx(entries), 't1', issues);
+    assert.equal(out.resolvedFromDirectory, 0);
+    assert.deepEqual(out.unresolvedManagerNames, ['John Smith']);
+  });
+});

--- a/apps/web/src/components/escalations/AnalyticsStrip.tsx
+++ b/apps/web/src/components/escalations/AnalyticsStrip.tsx
@@ -41,7 +41,10 @@ export function AnalyticsStrip({ rows, now }: Props) {
         topOffender.name = row.managerName ?? 'Unknown';
         topOffender.count = open;
       }
-      if (!row.resolvedEmail) missingEmail += 1;
+      // Effective mapping: backend falls back to ManagerDirectory when the
+      // tracking/issue email is missing. Mirror that so the tile doesn't
+      // count managers already resolvable via Directory.
+      if (!row.resolvedEmail && !row.directoryEmail) missingEmail += 1;
       if (row.slaDueAt) {
         const t = new Date(row.slaDueAt).getTime();
         if (t < now) breached += 1;


### PR DESCRIPTION
## Summary
- `EscalationsService.getForProcess` now re-derives `isUnmapped` per row from `resolvedEmail ?? directoryEmail` and recomputes `summary.unmappedManagerCount` after attaching `directoryEmail`, so a Manager Directory import clears the Escalation Center banner on the next refetch without requiring an audit rerun.
- Aggregator's `unmappedManagerCount` is now documented as provisional / pre-enrichment (the service overwrites it).
- `AnalyticsStrip` "Missing email" tile counts `(resolvedEmail || directoryEmail)`-missing rows so it matches backend row semantics.
- `resolveIssueEmailsFromDirectory` does an exact normalized-key lookup (including aliases) before the fuzzy matcher, so deterministic variants like `Last, First` and spacing/case no longer depend on the 90-score threshold. Ambiguous keys abstain and fall back to the fuzzy collision path.

## Root cause
The backend computed `summary.unmappedManagerCount` in `escalations-aggregator.ts` before directory enrichment ran in `escalations.service.ts`. Later, `directoryEmail` was attached to each row but `isUnmapped` and `summary` were never recomputed, so adding the manager to the Directory had no effect on the banner or row state until a rerun.

## Changes
- `apps/api/src/escalations.service.ts` — recompute `isUnmapped`, overwrite `summary.unmappedManagerCount` post-enrichment.
- `apps/api/src/escalations-aggregator.ts` — comment marking the count as provisional.
- `apps/web/src/components/escalations/AnalyticsStrip.tsx` — effective-mapping check on the Missing Email tile.
- `apps/api/src/directory/resolve-issue-emails.ts` — exact normalized-key index before fuzzy matcher.
- Tests: `apps/api/test/escalations.service.test.ts`, `apps/api/test/resolve-issue-emails.test.ts`.

## Test plan
- [x] `npm run test --workspace @ses/api` — 42/42 pass (6 new)
- [x] `npm run test --workspace @ses/domain` — 74/74 pass
- [x] `npm run test --workspace @ses/web` — 20/20 pass
- [x] `npm run typecheck --workspace @ses/api` — clean
- [x] `npm run typecheck --workspace @ses/web` — clean
- [x] `npm run lint` — no new warnings (pre-existing warnings untouched)
- [ ] Manual smoke: with Escalation Center open, import the missing manager into Manager Directory; confirm the amber banner count and the "Missing email" tile decrement/clear on the next realtime refetch (no rerun required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)