### PR TITLE
feat(escalations): green-highlight resolved rows and surface resolved…

### DIFF
--- a/apps/api/src/tracking-compose/tracking-compose.service.ts
+++ b/apps/api/src/tracking-compose/tracking-compose.service.ts
@@ -225,7 +225,7 @@ export class TrackingComposeService {
       throw new BadRequestException(`Send is not allowed from stage ${entry.stage}.`);
     }
 
-    const { subject, text, channel } = await this.resolveContent(entry, user, body);
+    const { subject, text, channel, managerEmail } = await this.resolveContent(entry, user, body);
     const sendChannel: EscalationSendChannel = channel ?? 'email';
     // Channel gate (Issue #75): the 2-Outlooks-then-1-Teams cycle is
     // enforced here so race conditions between multiple auditors can't
@@ -238,7 +238,7 @@ export class TrackingComposeService {
       throw new BadRequestException('Channel "both" is no longer supported — pick Outlook or Teams.');
     }
 
-    const to = (entry.managerEmail ?? '').trim();
+    const to = (managerEmail ?? '').trim();
     if (!to) {
       throw new BadRequestException('Manager email is required before send.');
     }
@@ -424,7 +424,7 @@ export class TrackingComposeService {
     },
     user: SessionUser,
     overrides: Partial<ComposeDraftPayload>,
-  ): Promise<{ subject: string; text: string; channel: EscalationSendChannel }> {
+  ): Promise<{ subject: string; text: string; channel: EscalationSendChannel; managerEmail: string | null }> {
     const tenantId = this.tenantId(user);
     const stageKey = stageKeyForLevel(entry.escalationLevel);
     const tpl = await this.pickTemplate(tenantId, stageKey, overrides.templateId);
@@ -438,6 +438,7 @@ export class TrackingComposeService {
 
     const esc = await this.escalations.getForProcess(entry.process.displayCode, user);
     const row = esc.rows.find((r) => r.trackingId === entry.id);
+    const managerEmail = row?.resolvedEmail ?? row?.directoryEmail ?? entry.managerEmail ?? null;
     const lines: EngineFindingLine[] = [];
     const removed = new Set((overrides.removedEngineIds ?? draft.removedEngineIds ?? []).map(String));
     if (row) {
@@ -473,6 +474,6 @@ export class TrackingComposeService {
     };
     const subject = substitute(baseSubject, slots);
     const text = substitute(baseBody, slots);
-    return { subject, text, channel };
+    return { subject, text, channel, managerEmail };
   }
 }

--- a/apps/web/src/components/escalations/AnalyticsStrip.tsx
+++ b/apps/web/src/components/escalations/AnalyticsStrip.tsx
@@ -65,14 +65,25 @@ export function AnalyticsStrip({ rows, now }: Props) {
 
   if (analytics.total === 0) return null;
 
+  const openManagers = analytics.total - analytics.resolvedManagers;
+  const resolvedPercent =
+    analytics.total > 0 ? Math.round((analytics.resolvedManagers / analytics.total) * 100) : 0;
+
   return (
-    <div className="mb-4 grid gap-2 md:grid-cols-2 lg:grid-cols-5">
+    <div className="mb-4 grid gap-2 md:grid-cols-2 lg:grid-cols-6">
       <Tile
         label="Managers"
         value={analytics.total}
-        hint={`${analytics.resolvedManagers} resolved`}
+        hint={`${openManagers} open`}
         tone="gray"
         Icon={Users}
+      />
+      <Tile
+        label="Resolved"
+        value={analytics.resolvedManagers}
+        hint={analytics.resolvedManagers > 0 ? `${resolvedPercent}% complete` : 'None resolved yet'}
+        tone="emerald"
+        Icon={CheckCircle2}
       />
       <Tile
         label="Open findings"

--- a/apps/web/src/components/escalations/Composer.tsx
+++ b/apps/web/src/components/escalations/Composer.tsx
@@ -18,6 +18,7 @@ import { useAutosaveOnLeave } from '../../hooks/useAutosaveOnLeave';
 import { Button } from '../shared/Button';
 import { useConfirm } from '../shared/ConfirmProvider';
 import { PreviewPane } from './PreviewPane';
+import { effectiveManagerEmail } from './nextAction';
 
 type SendChannel = 'email' | 'teams';
 
@@ -59,6 +60,7 @@ export function Composer({
   const qc = useQueryClient();
   const confirm = useConfirm();
   const trackingRef = row.trackingId ?? row.trackingDisplayCode;
+  const managerEmail = effectiveManagerEmail(row);
 
   // Issue #75 — Composer defaults to Preview so the auditor reviews before
   // sending. Edit is a toggle-back; send actions live in the preview footer.
@@ -368,7 +370,7 @@ export function Composer({
       <div>
         <div className="text-xs font-medium text-gray-500">To</div>
         <div className="mt-1 rounded border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900">
-          {row.managerName} &lt;{row.resolvedEmail ?? '—'}&gt;
+          {row.managerName} &lt;{managerEmail ?? '—'}&gt;
         </div>
       </div>
 

--- a/apps/web/src/components/escalations/EscalationPanel.tsx
+++ b/apps/web/src/components/escalations/EscalationPanel.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { BadgeCheck, Maximize2, Minimize2 } from 'lucide-react';
-import type { ProcessEscalationManagerRow } from '@ses/domain';
-import { verifyTracking } from '../../lib/api/trackingStageApi';
+import { BadgeCheck, CheckCircle2, Maximize2, MessageCircleReply, Minimize2 } from 'lucide-react';
+import { canTransition, isEscalationStage, type ProcessEscalationManagerRow } from '@ses/domain';
+import { transitionTracking, verifyTracking } from '../../lib/api/trackingStageApi';
 import { ActivityFeed } from './ActivityFeed';
 import { AttachmentsTab } from './AttachmentsTab';
 import { Composer } from './Composer';
 import { FindingsTab } from './FindingsTab';
+import { effectiveManagerEmail } from './nextAction';
 
 type TabId = 'findings' | 'compose' | 'activity' | 'attachments';
 
@@ -58,7 +59,23 @@ export function EscalationPanel({
   const panelRef = useRef<HTMLDivElement>(null);
   const qc = useQueryClient();
   const trackingRef = row?.trackingId ?? row?.trackingDisplayCode ?? null;
+  const stage = row && isEscalationStage(row.stage) ? row.stage : null;
   const awaitingVerification = Boolean(row && row.stage === 'RESOLVED' && !row.verifiedAt);
+  const managerEmail = row ? effectiveManagerEmail(row) : null;
+  const canMarkResponded = Boolean(
+    trackingRef &&
+      row &&
+      !row.resolved &&
+      stage &&
+      canTransition(stage, 'RESPONDED'),
+  );
+  const canMarkResolved = Boolean(
+    trackingRef &&
+      row &&
+      !row.resolved &&
+      stage &&
+      canTransition(stage, 'RESOLVED'),
+  );
   // B14: only surface the Verify action when it's actually meaningful — the
   // row is RESOLVED but an auditor hasn't closed the loop yet. Previously
   // the button showed on every row that simply lacked a verifiedAt, which
@@ -72,6 +89,19 @@ export function EscalationPanel({
     },
     onSuccess: () => {
       toast.success('Verified — moved to Resolved.');
+      void qc.invalidateQueries({ queryKey: ['escalations'] });
+      void qc.invalidateQueries({ queryKey: ['tracking-events', trackingRef] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const transitionMut = useMutation({
+    mutationFn: (payload: { to: 'RESPONDED' | 'RESOLVED'; reason: string; sourceAction: string }) => {
+      if (!trackingRef) return Promise.reject(new Error('No tracking row'));
+      return transitionTracking(trackingRef, payload);
+    },
+    onSuccess: (result) => {
+      toast.success(result.stage === 'RESOLVED' ? 'Marked resolved.' : 'Marked as manager responded.');
       void qc.invalidateQueries({ queryKey: ['escalations'] });
       void qc.invalidateQueries({ queryKey: ['tracking-events', trackingRef] });
     },
@@ -218,7 +248,7 @@ export function EscalationPanel({
             <h2 id="escalation-panel-title" className="text-lg font-semibold text-gray-900 dark:text-white">
               {row.managerName}
             </h2>
-            <div className="text-sm text-gray-500">{row.resolvedEmail ?? '—'}</div>
+            <div className="text-sm text-gray-500">{managerEmail ?? '—'}</div>
             <div className="mt-1 flex flex-wrap gap-2 text-xs">
               <span className="rounded bg-gray-100 px-2 py-0.5 dark:bg-gray-800">{row.stage ?? '—'}</span>
               <span className="text-gray-500">SLA: {slaText}</span>
@@ -286,21 +316,61 @@ export function EscalationPanel({
             <AttachmentsTab trackingIdOrCode={row.trackingId ?? row.trackingDisplayCode} />
           ) : null}
         </div>
-        {canVerify && trackingRef ? (
+        {trackingRef && (canMarkResponded || canMarkResolved || canVerify) ? (
           <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3 dark:border-gray-800">
             <span className="text-xs text-gray-500">
-              {awaitingVerification
+              {canMarkResolved
+                ? 'Use Resolve when the manager has responded and the finding can be closed. Auditor verification is the final close-out step.'
+                : canMarkResponded
+                ? 'Use Manager responded when the manager has replied but the finding is not ready to close yet.'
+                : awaitingVerification
                 ? 'Manager marked resolved — review the evidence and verify to close the loop.'
                 : 'Verifying closes the row to Resolved with your name stamped on it.'}
             </span>
-            <button
-              type="button"
-              onClick={() => verifyMut.mutate()}
-              disabled={verifyMut.isPending}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60"
-            >
-              <BadgeCheck size={14} /> Verified — Resolve
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              {canMarkResponded ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    transitionMut.mutate({
+                      to: 'RESPONDED',
+                      reason: 'manager_responded',
+                      sourceAction: 'panel.mark_responded',
+                    })
+                  }
+                  disabled={transitionMut.isPending}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800"
+                >
+                  <MessageCircleReply size={14} /> Manager responded
+                </button>
+              ) : null}
+              {canMarkResolved ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    transitionMut.mutate({
+                      to: 'RESOLVED',
+                      reason: 'manager_resolution_confirmed',
+                      sourceAction: 'panel.mark_resolved',
+                    })
+                  }
+                  disabled={transitionMut.isPending}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60"
+                >
+                  <CheckCircle2 size={14} /> Mark resolved
+                </button>
+              ) : null}
+              {canVerify ? (
+                <button
+                  type="button"
+                  onClick={() => verifyMut.mutate()}
+                  disabled={verifyMut.isPending}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-800 disabled:opacity-60"
+                >
+                  <BadgeCheck size={14} /> Verified — Resolve
+                </button>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/escalations/ManagerTable.tsx
+++ b/apps/web/src/components/escalations/ManagerTable.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import type { FunctionId, ProcessEscalationManagerRow } from '@ses/domain';
 import { FUNCTION_IDS } from '@ses/domain';
 import { EnginePill } from './EnginePill';
-import { computePriority, suggestNextAction } from './nextAction';
+import { computePriority, effectiveManagerEmail, suggestNextAction } from './nextAction';
 
 export type SortKey = 'priority' | 'issues' | 'stage' | 'lastContact' | 'sla';
 
@@ -173,14 +173,19 @@ export function ManagerTable({
           {sorted.map((row, idx) => {
             const selected = idx === selectedIndex;
             const tone = slaTone(row, now);
+            const managerEmail = effectiveManagerEmail(row);
             return (
               <tr
                 key={row.managerKey}
                 tabIndex={0}
                 aria-selected={selected}
-                className={`cursor-pointer border-t border-gray-100 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/80 ${
-                  selected ? 'bg-brand/5 ring-1 ring-inset ring-brand/30' : ''
-                }`}
+                className={`cursor-pointer border-t border-gray-100 dark:border-gray-800 ${
+                  row.resolved
+                    ? 'bg-green-50 hover:bg-green-100 dark:bg-green-950/30 dark:hover:bg-green-900/40'
+                    : selected
+                      ? 'bg-brand/5 hover:bg-brand/10 dark:hover:bg-gray-800/80'
+                      : 'hover:bg-gray-50 dark:hover:bg-gray-800/80'
+                } ${selected ? 'ring-1 ring-inset ring-brand/30' : ''}`}
                 onClick={() => {
                   onSelectManagerKey(row.managerKey);
                   onOpenPanel(row);
@@ -198,8 +203,8 @@ export function ManagerTable({
                 </td>
                 <td className="px-3 py-2">
                   <div className="font-medium text-gray-900 dark:text-white">{row.managerName}</div>
-                  {row.resolvedEmail ? (
-                    <div className="text-xs text-gray-500">{row.resolvedEmail}</div>
+                  {managerEmail ? (
+                    <div className="text-xs text-gray-500">{managerEmail}</div>
                   ) : (
                     <div className="mt-0.5 inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
                       Missing email — add to directory
@@ -264,7 +269,7 @@ export function ManagerTable({
                         className="block w-full px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800"
                         onClick={(e) => {
                           e.stopPropagation();
-                          const em = row.resolvedEmail;
+                          const em = effectiveManagerEmail(row);
                           if (em) void navigator.clipboard.writeText(em).then(() => toast.success('Email copied')).catch(() => toast.error('Copy failed'));
                           else toast.error('No email');
                           setMenuRow(null);

--- a/apps/web/src/components/escalations/__tests__/EscalationPanel.test.tsx
+++ b/apps/web/src/components/escalations/__tests__/EscalationPanel.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { ProcessEscalationManagerRow } from '@ses/domain';
+import { EscalationPanel } from '../EscalationPanel';
+
+function row(p: Partial<ProcessEscalationManagerRow> = {}): ProcessEscalationManagerRow {
+  return {
+    managerKey: 'kumar-arjun',
+    managerName: 'Kumar, Arjun',
+    resolvedEmail: 'arjun.kumar@demo.com',
+    directoryEmail: null,
+    isUnmapped: false,
+    totalIssues: 3,
+    countsByEngine: { 'master-data': 3 },
+    findingsByEngine: {},
+    stage: 'ESCALATED_L1',
+    resolved: false,
+    lastContactAt: null,
+    slaDueAt: null,
+    trackingId: 'trk-1',
+    trackingDisplayCode: 'TRK-1',
+    outlookCount: 2,
+    teamsCount: 1,
+    ...p,
+  };
+}
+
+function renderPanel(panelRow: ProcessEscalationManagerRow) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <EscalationPanel
+          processId="process-1"
+          processDisplayCode="PRC-1"
+          row={panelRow}
+          open
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('EscalationPanel', () => {
+  it('marks an escalated row resolved through the stage transition API', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ stage: 'RESOLVED', resolved: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPanel(row());
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/tracking/trk-1/transition',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            to: 'RESOLVED',
+            reason: 'manager_resolution_confirmed',
+            sourceAction: 'panel.mark_resolved',
+          }),
+        }),
+      );
+    });
+  });
+
+  it('shows auditor verification after a row is resolved but unverified', () => {
+    renderPanel(row({ stage: 'RESOLVED', resolved: true, verifiedAt: null }));
+
+    expect(screen.getByRole('button', { name: /verified/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mark resolved/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/escalations/__tests__/ManagerTable.test.tsx
+++ b/apps/web/src/components/escalations/__tests__/ManagerTable.test.tsx
@@ -109,4 +109,63 @@ describe('ManagerTable', () => {
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onOpenPanel).toHaveBeenCalledWith(rows[1]);
   });
+
+  it('uses directory email fallback for mapped rows without issue email', () => {
+    render(
+      <ManagerTable
+        now={0}
+        rows={[
+          row({
+            managerKey: 'missing-email:de-vries-lisa',
+            managerName: 'De Vries, Lisa',
+            directoryEmail: 'devries@email.com',
+            totalIssues: 4,
+            stage: 'NEW',
+          }),
+        ]}
+        selectedTrackingIds={new Set()}
+        onToggleTracking={vi.fn()}
+        onToggleAllVisible={vi.fn()}
+        selectedManagerKey={null}
+        onSelectManagerKey={vi.fn()}
+        onOpenPanel={vi.fn()}
+        sortKey="priority"
+        onSortKey={vi.fn()}
+        engineFilter=""
+        onEngineFromPill={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('devries@email.com')).toBeInTheDocument();
+    expect(screen.queryByText(/missing email/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Send reminder')).toBeInTheDocument();
+  });
+
+  it('highlights resolved rows in green', () => {
+    const { container } = render(
+      <ManagerTable
+        now={0}
+        rows={[
+          row({ managerKey: 'done', managerName: 'Done', resolved: true, stage: 'RESOLVED' }),
+          row({ managerKey: 'open', managerName: 'Open' }),
+        ]}
+        selectedTrackingIds={new Set()}
+        onToggleTracking={vi.fn()}
+        onToggleAllVisible={vi.fn()}
+        selectedManagerKey={null}
+        onSelectManagerKey={vi.fn()}
+        onOpenPanel={vi.fn()}
+        sortKey="priority"
+        onSortKey={vi.fn()}
+        engineFilter=""
+        onEngineFromPill={vi.fn()}
+      />,
+    );
+
+    const rowsEls = container.querySelectorAll('tbody tr');
+    const resolvedRow = Array.from(rowsEls).find((tr) => tr.textContent?.includes('Done'));
+    const openRow = Array.from(rowsEls).find((tr) => tr.textContent?.includes('Open'));
+    expect(resolvedRow?.className).toContain('bg-green-50');
+    expect(openRow?.className).not.toContain('bg-green-50');
+  });
 });

--- a/apps/web/src/components/escalations/nextAction.ts
+++ b/apps/web/src/components/escalations/nextAction.ts
@@ -10,6 +10,10 @@ export type NextAction =
 
 const FOUR_HOURS_MS = 4 * 3_600_000;
 
+export function effectiveManagerEmail(row: ProcessEscalationManagerRow): string | null {
+  return row.resolvedEmail ?? row.directoryEmail ?? null;
+}
+
 /**
  * Given a tracking row, decide what a human auditor would most likely
  * do next. Deterministic, no AI — just the rules the escalation ladder
@@ -20,7 +24,7 @@ export function suggestNextAction(row: ProcessEscalationManagerRow, now = Date.n
   if (row.resolved) {
     return { kind: 'wait', label: 'Resolved', tone: 'gray' };
   }
-  if (!row.resolvedEmail) {
+  if (!effectiveManagerEmail(row)) {
     return { kind: 'add_to_directory', label: 'Add to directory', tone: 'amber' };
   }
 
@@ -77,6 +81,6 @@ export function computePriority(row: ProcessEscalationManagerRow, now = Date.now
     if (diff < 0) score += 50; // Breached — jump to top.
     else if (diff < 48 * 3_600_000) score += 15;
   }
-  if (!row.resolvedEmail) score *= 0.4; // Can't act → de-weight.
+  if (!effectiveManagerEmail(row)) score *= 0.4; // Can't act → de-weight.
   return Math.round(score * 10) / 10;
 }

--- a/apps/web/src/lib/api/trackingStageApi.ts
+++ b/apps/web/src/lib/api/trackingStageApi.ts
@@ -52,6 +52,23 @@ export async function verifyTracking(trackingIdOrCode: string) {
   return (await res.json()) as { ok: boolean; stage: string; verifiedAt: string };
 }
 
+export async function transitionTracking(
+  trackingIdOrCode: string,
+  body: { to: string; reason: string; sourceAction: string },
+) {
+  const res = await fetch(
+    `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/transition`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Stage update failed');
+  return (await res.json()) as { stage: string; resolved: boolean };
+}
+
 export async function revertVerification(trackingIdOrCode: string) {
   const res = await fetch(
     `/api/v1/tracking/${encodeURIComponent(trackingIdOrCode)}/verify`,

--- a/apps/web/src/pages/EscalationCenter.tsx
+++ b/apps/web/src/pages/EscalationCenter.tsx
@@ -16,6 +16,7 @@ import { ShortcutOverlay } from '../components/escalations/ShortcutOverlay';
 import { AnalyticsStrip } from '../components/escalations/AnalyticsStrip';
 import { BulkComposer } from '../components/escalations/BulkComposer';
 import { BroadcastDialog } from '../components/escalations/BroadcastDialog';
+import { effectiveManagerEmail } from '../components/escalations/nextAction';
 import {
   AcknowledgeDialog,
   ReescalateDialog,
@@ -160,7 +161,7 @@ export function EscalationCenter() {
     return rows.filter((row) => {
       if (engine && (row.countsByEngine[engine] ?? 0) === 0) return false;
       if (assignedToMe && currentUser?.email) {
-        const em = (row.resolvedEmail ?? '').toLowerCase();
+        const em = (effectiveManagerEmail(row) ?? '').toLowerCase();
         if (em !== currentUser.email.toLowerCase()) return false;
       }
       if (selectedStages.size > 0 && row.stage && !selectedStages.has(String(row.stage))) return false;
@@ -504,7 +505,7 @@ export function EscalationCenter() {
         onDone={() => void q.refetch()}
         processIdOrCode={process.displayCode ?? process.id}
         estimatedAudience={
-          (q.data?.rows ?? []).filter((r) => !r.resolved && Boolean(r.resolvedEmail)).length
+          (q.data?.rows ?? []).filter((r) => !r.resolved && Boolean(effectiveManagerEmail(r))).length
         }
         functionOptions={FUNCTION_REGISTRY.map((f) => ({ id: f.id, label: f.label }))}
       />

--- a/apps/web/test/createProcessFlow.component.test.tsx
+++ b/apps/web/test/createProcessFlow.component.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import App from '../src/App';
+import { useAppStore } from '../src/store/useAppStore';
+
+const processRow = {
+  id: 'process-created',
+  displayCode: 'PRC-TEST',
+  rowVersion: 1,
+  name: 'Created from test',
+  description: '',
+  createdAt: '2026-04-23T10:00:00.000Z',
+  updatedAt: '2026-04-23T10:00:00.000Z',
+  nextAuditDue: null,
+  archivedAt: null,
+  auditPolicy: {},
+  policyVersion: 1,
+};
+
+describe('create process flow', () => {
+  test('creates a process and opens the tile dashboard without a render loop', async () => {
+    window.history.replaceState({}, '', '/');
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    useAppStore.setState({
+      processes: [],
+      activeProcessId: null,
+      activeWorkspaceTab: 'preview',
+      currentAuditResult: null,
+      isAuditRunning: false,
+      auditProgressText: '',
+      auditRunKey: null,
+      uploads: {},
+      fileDrafts: {},
+    });
+
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.pathname : input.url;
+      if (url.endsWith('/api/v1/auth/me')) {
+        return new Response(
+          JSON.stringify({
+            user: {
+              id: 'u1',
+              displayCode: 'USR-1',
+              email: 'admin@ses.local',
+              displayName: 'SES Admin',
+              role: 'admin',
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/v1/processes') && init?.method === 'POST') {
+        return new Response(JSON.stringify(processRow), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/v1/processes')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/tiles')) {
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/escalations')) {
+        return new Response(JSON.stringify({ summary: { perEngineManagerCounts: {} }, managers: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /create new process/i }));
+    await user.type(screen.getByLabelText(/process name/i), processRow.name);
+    await user.click(screen.getByRole('button', { name: /^create process$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: processRow.name })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
… count

- ManagerTable: resolved rows now render with a green row tint so auditors get immediate visual feedback once "Mark resolved" completes. Selection ring and hover states still layer on top.
- AnalyticsStrip: add a dedicated "Resolved" emerald KPI tile showing the count and percent complete; the "Managers" tile hint now shows open count so the two tiles don't duplicate each other.
- Bundle in-flight escalations fixes: directory-email fallback in the manager table, panel/composer tweaks, tracking stage API plumbing, and supporting tests (EscalationPanel, createProcessFlow).