### PR TITLE
feat(ui): mobile-first responsive polish across shell and escalation center

### DIFF
--- a/apps/web/src/components/escalations/AnalyticsStrip.tsx
+++ b/apps/web/src/components/escalations/AnalyticsStrip.tsx
@@ -70,7 +70,7 @@ export function AnalyticsStrip({ rows, now }: Props) {
     analytics.total > 0 ? Math.round((analytics.resolvedManagers / analytics.total) * 100) : 0;
 
   return (
-    <div className="mb-4 grid gap-2 md:grid-cols-2 lg:grid-cols-6">
+    <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
       <Tile
         label="Managers"
         value={analytics.total}

--- a/apps/web/src/components/escalations/EscalationFilters.tsx
+++ b/apps/web/src/components/escalations/EscalationFilters.tsx
@@ -25,7 +25,7 @@ export function EscalationFilters({
   onAssignedToMe: (v: boolean) => void;
 }) {
   return (
-    <aside className="w-56 shrink-0 space-y-4 border-r border-gray-200 pr-4 dark:border-gray-800">
+    <aside className="w-full shrink-0 space-y-4 rounded-xl border border-gray-200 bg-white p-3 md:w-56 md:rounded-none md:border-0 md:border-r md:bg-transparent md:p-0 md:pr-4 dark:border-gray-800 dark:bg-gray-900 md:dark:bg-transparent">
       <div>
         <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">Stage</div>
         <div className="space-y-1">

--- a/apps/web/src/components/escalations/ManagerTable.tsx
+++ b/apps/web/src/components/escalations/ManagerTable.tsx
@@ -161,11 +161,11 @@ export function ManagerTable({
             </th>
             <th scope="col" className="px-3 py-2">Manager</th>
             <th scope="col" className="px-3 py-2">{sortBtn('issues', 'Issues')}</th>
-            <th scope="col" className="px-3 py-2">Engines</th>
-            <th scope="col" className="px-3 py-2">{sortBtn('stage', 'Stage')}</th>
-            <th scope="col" className="px-3 py-2">{sortBtn('lastContact', 'Last contact')}</th>
+            <th scope="col" className="hidden px-3 py-2 lg:table-cell">Engines</th>
+            <th scope="col" className="hidden px-3 py-2 sm:table-cell">{sortBtn('stage', 'Stage')}</th>
+            <th scope="col" className="hidden px-3 py-2 md:table-cell">{sortBtn('lastContact', 'Last contact')}</th>
             <th scope="col" className="px-3 py-2">{sortBtn('sla', 'SLA')}</th>
-            <th scope="col" className="px-3 py-2">Next action</th>
+            <th scope="col" className="hidden px-3 py-2 sm:table-cell">Next action</th>
             <th scope="col" className="w-10 px-2 py-2" aria-label="Actions" />
           </tr>
         </thead>
@@ -212,7 +212,7 @@ export function ManagerTable({
                   )}
                 </td>
                 <td className="px-3 py-2 tabular-nums">{row.totalIssues}</td>
-                <td className="px-3 py-2">
+                <td className="hidden px-3 py-2 lg:table-cell">
                   <div className="flex flex-wrap gap-1">
                     {FUNCTION_IDS.map((fid) => (
                       <EnginePill
@@ -225,7 +225,7 @@ export function ManagerTable({
                     ))}
                   </div>
                 </td>
-                <td className="px-3 py-2">
+                <td className="hidden px-3 py-2 sm:table-cell">
                   <div className="flex flex-wrap items-center gap-1">
                     <span className="rounded bg-gray-100 px-2 py-0.5 text-xs dark:bg-gray-800">{row.stage ?? '—'}</span>
                     {row.stage === 'RESOLVED' && !row.verifiedAt ? (
@@ -238,7 +238,7 @@ export function ManagerTable({
                     ) : null}
                   </div>
                 </td>
-                <td className="px-3 py-2 text-xs text-gray-600">
+                <td className="hidden px-3 py-2 text-xs text-gray-600 md:table-cell">
                   {row.lastContactAt ? new Date(row.lastContactAt).toLocaleDateString() : '—'}
                 </td>
                 <td className="px-3 py-2">
@@ -247,7 +247,7 @@ export function ManagerTable({
                     <span className="text-xs text-gray-600 dark:text-gray-300">{slaCountdownLabel(row, now)}</span>
                   </div>
                 </td>
-                <td className="px-3 py-2">
+                <td className="hidden px-3 py-2 sm:table-cell">
                   <NextActionChip row={row} now={now} />
                 </td>
                 <td className="relative px-2 py-2">

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -41,7 +41,7 @@ export function AppShell({
       <div className="flex min-h-0 flex-1">
         {sidebar ? (
           collapsed ? (
-            <aside className="flex h-full w-12 shrink-0 flex-col items-center gap-3 border-r border-gray-200 bg-white py-3 dark:border-gray-800 dark:bg-gray-950">
+            <aside className="hidden h-full w-12 shrink-0 flex-col items-center gap-3 border-r border-gray-200 bg-white py-3 md:flex dark:border-gray-800 dark:bg-gray-950">
               <button
                 type="button"
                 onClick={toggle}
@@ -57,7 +57,7 @@ export function AppShell({
               </div>
             </aside>
           ) : (
-            <aside className="flex h-full w-[260px] shrink-0 flex-col border-r border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950">
+            <aside className="hidden h-full w-[260px] shrink-0 flex-col border-r border-gray-200 bg-white md:flex dark:border-gray-800 dark:bg-gray-950">
               <div className="flex items-center justify-end border-b border-gray-100 px-2 py-1 dark:border-gray-800">
                 <button
                   type="button"

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ArrowDownToLine, ArrowLeft, LayoutGrid, Loader2, LogOut, Play, Save } from 'lucide-react';
+import { AlertTriangle, ArrowDownToLine, ArrowLeft, LayoutGrid, Loader2, LogOut, Menu, Play, Save, X } from 'lucide-react';
 import { FormEvent, useEffect, useState, type ReactNode } from 'react';
 import toast from 'react-hot-toast';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
@@ -37,6 +37,7 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
   const saveOverCurrentVersion = useAppStore((state) => state.saveOverCurrentVersion);
   const saveAsNewRequestCount = useAppStore((state) => state.saveAsNewRequestCount);
   const [versionModalOpen, setVersionModalOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // The UnsavedAuditDialog lives in Workspace, but the Save-as-new modal
   // lives here. Bumping saveAsNewRequestCount from the store is how the
@@ -125,8 +126,17 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
   if (!process) {
     const isAdmin = sessionUser?.role === 'admin';
     return (
-      <header className="flex h-[52px] items-center justify-between gap-4 border-b border-gray-200 bg-white px-5 shadow-sm dark:border-gray-800 dark:bg-gray-950">
-        <div className="flex min-w-0 items-center gap-5">
+      <header className="relative flex min-h-[52px] flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-white px-4 py-2 shadow-sm sm:px-5 dark:border-gray-800 dark:bg-gray-950">
+        <div className="flex min-w-0 items-center gap-3 sm:gap-5">
+          <button
+            type="button"
+            className="rounded-md p-1.5 text-gray-600 hover:bg-gray-100 md:hidden dark:text-gray-300 dark:hover:bg-gray-800"
+            aria-label={mobileMenuOpen ? 'Close navigation' : 'Open navigation'}
+            aria-expanded={mobileMenuOpen}
+            onClick={() => setMobileMenuOpen((v) => !v)}
+          >
+            {mobileMenuOpen ? <X size={18} /> : <Menu size={18} />}
+          </button>
           <Link to="/" className="min-w-0">
             <BrandMark />
           </Link>
@@ -144,12 +154,24 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
             type="button"
             onClick={() => void signOutAndRedirect(navigate)}
             title="Sign out"
-            className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 hover:border-gray-300 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600"
+            className="flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-2 text-sm text-gray-700 hover:border-gray-300 sm:px-3 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600"
           >
             <LogOut size={14} />
             <span className="hidden sm:inline">Sign out</span>
           </button>
         </div>
+        {mobileMenuOpen ? (
+          <nav
+            className="flex w-full basis-full flex-col gap-1 border-t border-gray-100 pt-2 md:hidden dark:border-gray-800"
+            aria-label="Primary mobile"
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            <GlobalNavLink to="/" end label="Dashboard" />
+            <GlobalNavLink to="/compare" label="Compare" />
+            {isAdmin ? <GlobalNavLink to="/admin/directory" label="Directory" /> : null}
+            {isAdmin ? <GlobalNavLink to="/admin/templates" label="Templates" /> : null}
+          </nav>
+        ) : null}
       </header>
     );
   }
@@ -191,8 +213,17 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
   }
 
   return (
-    <header className="flex h-[52px] items-center justify-between gap-4 border-b border-gray-200 bg-white px-5 shadow-sm dark:border-gray-800 dark:bg-gray-950">
-      <div className="flex min-w-0 items-center gap-4">
+    <header className="relative flex min-h-[52px] flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-white px-4 py-2 shadow-sm sm:px-5 dark:border-gray-800 dark:bg-gray-950">
+      <div className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
+        <button
+          type="button"
+          className="rounded-md p-1.5 text-gray-600 hover:bg-gray-100 lg:hidden dark:text-gray-300 dark:hover:bg-gray-800"
+          aria-label={mobileMenuOpen ? 'Close sections menu' : 'Open sections menu'}
+          aria-expanded={mobileMenuOpen}
+          onClick={() => setMobileMenuOpen((v) => !v)}
+        >
+          {mobileMenuOpen ? <X size={18} /> : <Menu size={18} />}
+        </button>
         <Link
           to="/"
           onClick={confirmLeave}
@@ -213,7 +244,7 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
           <BrandMark compact />
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-2">
         <RealtimeStatusPill />
         <NotificationBell />
         {sessionUser?.role === 'admin' ? (
@@ -235,7 +266,7 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
           >
             {activeFile?.isAudited ? 'Re-run Audit' : 'Run Audit'}
           </Button>
-          {activeFile?.lastAuditedAt ? <div className="mt-0.5 text-[11px] text-gray-500">Last run: {new Date(activeFile.lastAuditedAt).toLocaleString()}</div> : null}
+          {activeFile?.lastAuditedAt ? <div className="mt-0.5 hidden text-xs text-gray-500 md:block">Last run: {new Date(activeFile.lastAuditedAt).toLocaleString()}</div> : null}
         </div>
         <SplitButton
           variant="secondary"
@@ -304,6 +335,30 @@ export function TopBar({ process, accessory }: { process?: AuditProcess | undefi
           <LogOut size={14} />
         </button>
       </div>
+      {mobileMenuOpen ? (
+        <nav
+          className="flex w-full basis-full flex-col gap-1 border-t border-gray-100 pt-2 lg:hidden dark:border-gray-800"
+          aria-label="Process sections mobile"
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          <ProcessNavLink to={tilesPath} active={onTiles} onClick={confirmLeave} icon={<LayoutGrid size={13} />} label="Tiles" />
+          <ProcessNavLink to={escalationsPath} active={onEscalations} onClick={confirmLeave} icon={<AlertTriangle size={13} />} label="Escalations" />
+          {sessionUser?.role === 'admin' ? (
+            <Link
+              to="/admin/directory"
+              onClick={confirmLeave}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              Directory
+            </Link>
+          ) : null}
+          {activeFile?.lastAuditedAt ? (
+            <div className="px-2.5 text-[11px] text-gray-500">
+              Last run: {new Date(activeFile.lastAuditedAt).toLocaleString()}
+            </div>
+          ) : null}
+        </nav>
+      ) : null}
       {versionModalOpen && process && latestResult ? <SaveVersionModal process={process} onClose={() => setVersionModalOpen(false)} /> : null}
     </header>
   );

--- a/apps/web/src/pages/EscalationCenter.tsx
+++ b/apps/web/src/pages/EscalationCenter.tsx
@@ -239,16 +239,16 @@ export function EscalationCenter() {
 
   return (
     <AppShell process={process}>
-      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-8 lg:flex-row lg:px-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-6 sm:py-8 lg:flex-row lg:px-6">
         <div className="min-w-0 flex-1">
-          <div className="mb-4 flex flex-wrap items-center gap-3">
+          <div className="mb-4 flex flex-wrap items-center gap-2 sm:gap-3">
             <Link
               to={processDashboardPath(process.id)}
               className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-300"
             >
               <ArrowLeft size={14} /> Dashboard
             </Link>
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Escalation Center</h1>
+            <h1 className="text-xl font-semibold text-gray-900 sm:text-2xl dark:text-white">Escalation Center</h1>
             <span className="flex-1" />
             <button
               type="button"
@@ -383,7 +383,7 @@ export function EscalationCenter() {
               list at ~560px so users can see several rows and scroll
               the rest within the panel rather than losing the summary
               cards when paging through 15+ managers. */}
-          <div className="flex h-[560px] gap-4">
+          <div className="flex flex-col gap-4 md:h-[560px] md:flex-row">
             <EscalationFilters
               stages={stages}
               selectedStages={selectedStages}
@@ -395,7 +395,7 @@ export function EscalationCenter() {
               assignedToMe={assignedToMe}
               onAssignedToMe={(v) => setParam({ mine: v ? '1' : null })}
             />
-            <div className="w-52 shrink-0">
+            <div className="hidden w-52 shrink-0 lg:block">
               <SavedViewsRail
                 current={Object.fromEntries(search.entries())}
                 onApply={(filters) => {
@@ -405,7 +405,7 @@ export function EscalationCenter() {
                 }}
               />
             </div>
-            <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex min-h-[420px] min-w-0 flex-1 flex-col md:min-h-0">
               <ManagerTable
                 rows={filteredRows}
                 now={currentTime}


### PR DESCRIPTION
## Summary
A surgical responsive pass — no new dependencies, no library swaps. Fixes the concrete issues found in the audit: primary nav unreachable on mobile, escalation table forcing horizontal scroll, filters/saved-views row cramped at narrow widths, KPI tiles rendering as a 1-up tall column.

**Shell**
- `AppShell`: documents sidebar is now `hidden md:flex` so phones get the full-width main content.
- `TopBar`: header is `min-h-[52px] flex-wrap` instead of a fixed 52px row. Right-side actions wrap instead of overflowing. A hamburger reveals primary nav (logged-out/home) or process sections + directory + last-run caption (process mode).

**Escalation Center**
- Inner filters / saved-views / table layout stacks vertically on mobile (`flex-col md:flex-row`), no forced 560px height below `md`. SavedViewsRail is `hidden lg:block` — noise on narrow screens.
- `EscalationFilters`: full-width bordered card on mobile, reverts to the 56-wide aside at `md+`.
- `ManagerTable`: hides Engines (lg+), Stage / Next action (sm+), Last contact (md+). Mobile sees Manager / Issues / SLA — the columns that actually matter for triage.
- `AnalyticsStrip`: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-6` (was `md:grid-cols-2 lg:grid-cols-6` which meant a 1-up column on phones).

## Test plan
- [x] `vitest run` — 25/25 tests pass.
- [x] `tsc --noEmit` (apps/web) — clean.
- [x] `vite build` — succeeds; bundle size unchanged aside from ~0.5 kB of CSS.
- [ ] Manual: load Escalation Center at 375px / 768px / 1280px. Confirm no horizontal scroll, filters+saved-views+table stack cleanly on mobile, hamburger reveals process nav, KPI tiles render 2-up on phone.
- [ ] Manual: dark mode at each breakpoint.
- [ ] Manual: confirm existing desktop behaviour is unchanged at `lg+` (sidebar, 6-tile KPI row, 3-column filters/saved-views/table).

## Out of scope
- Not touched: Dashboard, Workspace, VersionCompare, ManagerResponse, template admin. Those pages weren't the pain points flagged in the audit — happy to do a follow-up if you want another pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)