### PR TITLE
missingplan

### DIFF
--- a/docs/AUDIT_ENGINE_REWORK.md
+++ b/docs/AUDIT_ENGINE_REWORK.md
@@ -34,7 +34,7 @@ This document prioritises the fixes and defines what we throw away.
 | ------------------- | ---------------------------------------------------- | ---------------- |
 | master-data         | Dedicated engine, 10 required-field rules + Others   | Real             |
 | over-planning       | Wraps legacy `runAudit()` (effort rules)             | Legacy           |
-| missing-plan        | Wraps legacy `runAudit()`                            | Placeholder      |
+| missing-plan        | Dedicated engine, `RUL-MP-EFFORT-ZERO` rule          | Real             |
 | function-rate       | Wraps legacy `runAudit()`                            | Placeholder      |
 | internal-cost-rate  | Wraps legacy `runAudit()`                            | Placeholder      |
 
@@ -359,3 +359,72 @@ flowchart LR
   in the DB; an editor is a future PR.
 - **Cross-process broadcast.** Broadcast is scoped to one process. Cross-
   process campaigns are a v2.
+
+---
+
+## 7. Missing Plan engine (shipped 2026-04-23)
+
+The `missing-plan` function now has a dedicated audit engine replacing the
+legacy effort-based placeholder.
+
+### Engine behaviour
+
+The engine iterates every valid, selected sheet in the uploaded workbook and
+checks each data row for an explicit zero in the Effort (H) column. A zero
+effort value indicates that planning hours have not been entered for an
+otherwise active project — a different concern from a blank cell (which
+means the column was not filled in at all and is not flagged here).
+
+| Condition | Flagged? | Reason |
+|-----------|----------|--------|
+| `Effort (H)` = 0 (number) | Yes | Zero effort |
+| `Effort (H)` = `"0"` (string) | Yes | Zero effort (coerced) |
+| `Effort (H)` = `0.0` | Yes | Zero effort |
+| `Effort (H)` = 40 | No | Non-zero — no finding |
+| `Effort (H)` = blank / absent | No | Missing column, not a planning gap |
+
+### Supported column name aliases
+
+The engine resolves the effort column by trying each alias in order:
+
+```
+Effort (H), Effort(H), effort(h), effort (h),
+Effort H, effort h, Effort h, EFFORT (H), EFFORT(H), EFFORT H,
+Effort, effort, EFFORT,
+Hours, hours, HOURS,
+Planned Effort, planned effort, PLANNED EFFORT,
+Measures Effort, measures effort
+```
+
+Matching is alias-based (exact string match after the workbook parser has
+normalised headers). Case variations and parenthesis/space differences are
+all covered by the alias list.
+
+### Rule codes
+
+| Rule code | Severity | Category | Description |
+|-----------|----------|----------|-------------|
+| `RUL-MP-EFFORT-ZERO` | Medium | Missing Planning | Effort (H) is 0 on a project row |
+
+All `RUL-MP-*` codes are owned exclusively by the `missing-plan` function.
+They will never appear in the master-data or over-planning catalogs.
+
+### Escalation reuse
+
+Issues produced by this engine flow through the **existing** audit pipeline
+unchanged:
+
+```
+missingPlanAuditEngine.run()
+  → AuditIssue[] (ruleCode = RUL-MP-EFFORT-ZERO)
+  → resolveIssueEmailsFromDirectory()   // API: audits.service.ts
+  → AuditIssue rows persisted
+  → statusReconciler.reconcileAfterAudit()
+      → upsert TrackingEntry per manager
+      → patch projectStatuses.byEngine['missing-plan']
+  → Escalation Center aggregation (unchanged)
+```
+
+No new escalation mechanism was added. The `EmptyPolicy` slice for
+`missing-plan` in `policies.ts` remains correct — this engine has no
+configurable thresholds.

--- a/packages/domain/src/auditRules.ts
+++ b/packages/domain/src/auditRules.ts
@@ -1,6 +1,7 @@
 import type { IssueCategory, Severity } from './types';
 import type { FunctionId } from './functions';
 import { MASTER_DATA_RULE_CATALOG } from './functions-audit/master-data/rules';
+import { MISSING_PLAN_RULE_CATALOG } from './functions-audit/missing-plan/rules';
 
 export interface RuleCatalogEntry {
   ruleCode: string;
@@ -109,7 +110,7 @@ export const OVER_PLANNING_RULE_CATALOG: RuleCatalogEntry[] = [
 export const RULE_CATALOG_BY_FUNCTION: Record<FunctionId, RuleCatalogEntry[]> = {
   'master-data': MASTER_DATA_RULE_CATALOG,
   'over-planning': OVER_PLANNING_RULE_CATALOG,
-  'missing-plan': [],
+  'missing-plan': MISSING_PLAN_RULE_CATALOG,
   'function-rate': [],
   'internal-cost-rate': [],
 };

--- a/packages/domain/src/functions-audit/index.ts
+++ b/packages/domain/src/functions-audit/index.ts
@@ -1,6 +1,7 @@
 import type { AuditPolicy, AuditResult, WorkbookFile } from '../types';
 import { FUNCTION_IDS, type FunctionId } from '../functions';
 import { masterDataAuditEngine } from './master-data';
+import { missingPlanAuditEngine } from './missing-plan';
 import { createLegacyEngine } from './legacy-engine';
 import type { FunctionAuditEngine, FunctionAuditOptions } from './types';
 
@@ -9,7 +10,7 @@ import type { FunctionAuditEngine, FunctionAuditOptions } from './types';
 export const FUNCTION_AUDIT_ENGINES: Record<FunctionId, FunctionAuditEngine> = {
   'master-data': masterDataAuditEngine,
   'over-planning': createLegacyEngine('over-planning'),
-  'missing-plan': createLegacyEngine('missing-plan'),
+  'missing-plan': missingPlanAuditEngine,
   'function-rate': createLegacyEngine('function-rate'),
   'internal-cost-rate': createLegacyEngine('internal-cost-rate'),
 };
@@ -46,6 +47,12 @@ export {
   missingFieldRuleCode,
 } from './master-data';
 export { isBadValue, isOthersToken, isNotAssignedToken, BAD_VALUE_TOKENS } from './bad-values';
+export {
+  MISSING_PLAN_RULE_CATALOG,
+  MISSING_PLAN_RULES_BY_CODE,
+  MP_EFFORT_ZERO_RULE_CODE,
+  MP_EFFORT_ALIASES,
+} from './missing-plan';
 export {
   normalizeProcessPolicies,
   createDefaultProcessPolicies,

--- a/packages/domain/src/functions-audit/missing-plan/columns.ts
+++ b/packages/domain/src/functions-audit/missing-plan/columns.ts
@@ -1,0 +1,100 @@
+// Authoritative column-name list for the Missing Plan function. Aliases
+// cover every common variation of "Effort (H)" seen in effort-tracking
+// exports so the engine works regardless of whitespace, casing, or whether
+// the unit suffix is parenthesised.
+//
+// Identifier-only columns (project no, name, state, manager, email) are
+// NOT audited — they're read solely to populate issue metadata, matching
+// the same pattern used by the master-data engine.
+
+import type { RowObject } from '../types';
+
+export interface ColumnSpec {
+  id: string;
+  label: string;
+  aliases: string[];
+}
+
+// All recognised spellings of the effort column. The engine tries each alias
+// in order until it finds a match in the row object.
+export const MP_EFFORT_ALIASES: readonly string[] = [
+  'Effort (H)',
+  'Effort(H)',
+  'effort(h)',
+  'effort (h)',
+  'Effort H',
+  'effort h',
+  'Effort h',
+  'EFFORT (H)',
+  'EFFORT(H)',
+  'EFFORT H',
+  'Effort',
+  'effort',
+  'EFFORT',
+  'Hours',
+  'hours',
+  'HOURS',
+  'Planned Effort',
+  'planned effort',
+  'PLANNED EFFORT',
+  'Measures Effort',
+  'measures effort',
+];
+
+// Identifier-only alias arrays. These mirror the aliases used by the
+// workbook header detector (workbook.ts COLUMN_ALIASES) and the master-data
+// engine so findings carry consistent metadata regardless of which engine
+// produced them.
+export const MP_PROJECT_NO_ALIASES: readonly string[] = [
+  'Project No.',
+  'Project No',
+  'Project Number',
+  'projectNo',
+  'Project ID',
+];
+export const MP_PROJECT_NAME_ALIASES: readonly string[] = [
+  'Project',
+  'Project Name',
+  'projectName',
+  'Name',
+];
+export const MP_STATE_ALIASES: readonly string[] = [
+  'Project State',
+  'projectState',
+  'State',
+];
+export const MP_MANAGER_ALIASES: readonly string[] = [
+  'Project Manager',
+  'projectManager',
+  'Manager',
+];
+export const MP_EMAIL_ALIASES: readonly string[] = [
+  'Project Manager Email',
+  'Manager Email',
+  'email',
+  'Email',
+];
+
+export function readCell(row: RowObject, aliases: readonly string[]): unknown {
+  for (const alias of aliases) {
+    if (Object.prototype.hasOwnProperty.call(row, alias)) {
+      const value = row[alias];
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+// Returns the numeric effort value from the row, or null if the cell is
+// absent, blank, or not parseable as a finite number.
+// Explicitly returns 0 when the cell is the number 0 or the string "0" /
+// "0.0" — callers must check for === 0 to detect the zero-effort condition.
+export function readEffortValue(row: RowObject, aliases: readonly string[]): number | null {
+  const raw = readCell(row, aliases);
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'number') return isFinite(raw) ? raw : null;
+  const text = String(raw).trim();
+  if (text === '') return null;
+  const parsed = Number(text);
+  return isFinite(parsed) ? parsed : null;
+}

--- a/packages/domain/src/functions-audit/missing-plan/engine.ts
+++ b/packages/domain/src/functions-audit/missing-plan/engine.ts
@@ -1,0 +1,176 @@
+import { createIssueKey } from '../../auditEngine';
+import type { AuditIssue, AuditResult, WorkbookFile } from '../../types';
+import type { FunctionAuditEngine, FunctionAuditOptions, RowObject } from '../types';
+import {
+  MP_EFFORT_ALIASES,
+  MP_EMAIL_ALIASES,
+  MP_MANAGER_ALIASES,
+  MP_PROJECT_NAME_ALIASES,
+  MP_PROJECT_NO_ALIASES,
+  MP_STATE_ALIASES,
+  readCell,
+  readEffortValue,
+} from './columns';
+import { MISSING_PLAN_RULES_BY_CODE, MP_EFFORT_ZERO_RULE_CODE } from './rules';
+
+function isBlankRow(row: unknown[]): boolean {
+  return row.every((cell) => String(cell ?? '').trim() === '');
+}
+
+function rowsToObjects(
+  rows: unknown[][],
+  headerRowIndex: number,
+  normalizedHeaders?: string[],
+): Array<{ row: RowObject; rowIndex: number }> {
+  const originalHeaders = (rows[headerRowIndex] ?? []).map((cell) => String(cell ?? '').trim());
+  const headers = normalizedHeaders?.length ? normalizedHeaders : originalHeaders;
+  return rows
+    .slice(headerRowIndex + 1)
+    .map((row, index) => ({ cells: row, rowIndex: headerRowIndex + 1 + index }))
+    .filter(({ cells }) => !isBlankRow(cells))
+    .map(({ cells, rowIndex }) => {
+      const row: RowObject = {};
+      headers.forEach((header, index) => {
+        const originalHeader = originalHeaders[index];
+        const cell = cells[index];
+        const canonicalKey = String(header ?? '').trim();
+        const originalKey = String(originalHeader ?? '').trim();
+        if (canonicalKey && !canonicalKey.startsWith('column') && row[canonicalKey] === undefined) {
+          row[canonicalKey] = cell;
+        }
+        if (originalKey && row[originalKey] === undefined) {
+          row[originalKey] = cell;
+        }
+      });
+      return { row, rowIndex };
+    });
+}
+
+function textValue(row: RowObject, aliases: readonly string[], fallback = ''): string {
+  const raw = readCell(row, aliases);
+  if (raw === null || raw === undefined) return fallback;
+  const text = String(raw).trim();
+  return text || fallback;
+}
+
+function pushIssue(
+  issues: AuditIssue[],
+  args: {
+    file: WorkbookFile;
+    sheetName: string;
+    rowIndex: number;
+    row: RowObject;
+    effortValue: number;
+    options: FunctionAuditOptions;
+  },
+): void {
+  const { file, sheetName, rowIndex, row, effortValue, options } = args;
+  const rule = MISSING_PLAN_RULES_BY_CODE.get(MP_EFFORT_ZERO_RULE_CODE);
+  if (!rule) return;
+
+  const projectNo = textValue(row, MP_PROJECT_NO_ALIASES, `Row ${rowIndex + 1}`);
+  const projectName = textValue(row, MP_PROJECT_NAME_ALIASES, 'Unnamed project');
+  const projectManager = textValue(row, MP_MANAGER_ALIASES, 'Unassigned');
+  const projectState = textValue(row, MP_STATE_ALIASES, 'Unknown');
+  const email = textValue(row, MP_EMAIL_ALIASES, '');
+
+  const reason = `Effort (H) is 0 — no planned effort recorded for this project.`;
+
+  issues.push({
+    id: `${file.id}-${sheetName}-${rowIndex}-${MP_EFFORT_ZERO_RULE_CODE}`,
+    ...(options.issueScope
+      ? {
+          issueKey: createIssueKey(options.issueScope, {
+            projectNo,
+            sheetName,
+            rowIndex,
+            ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+          }),
+        }
+      : {}),
+    projectNo,
+    projectName,
+    sheetName,
+    severity: rule.defaultSeverity,
+    projectManager,
+    projectState,
+    effort: effortValue,
+    auditStatus: MP_EFFORT_ZERO_RULE_CODE,
+    notes: reason,
+    rowIndex,
+    email,
+    ruleId: MP_EFFORT_ZERO_RULE_CODE,
+    ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+    ruleVersion: rule.version,
+    ruleName: rule.name,
+    auditRunCode: options.runCode,
+    category: rule.category,
+    reason,
+    thresholdLabel: '= 0',
+    recommendedAction:
+      'Enter the planned effort hours for this project in the source system and re-run the audit.',
+  });
+}
+
+function auditRow(args: {
+  file: WorkbookFile;
+  sheetName: string;
+  rowIndex: number;
+  row: RowObject;
+  options: FunctionAuditOptions;
+  issues: AuditIssue[];
+}): boolean {
+  const { file, sheetName, rowIndex, row, options, issues } = args;
+  const effortValue = readEffortValue(row, MP_EFFORT_ALIASES);
+
+  // Blank / non-numeric cells are not flagged — they indicate the effort
+  // column is simply absent or not yet entered, which is a different concern
+  // from a deliberate zero entry.
+  if (effortValue === null) return false;
+
+  if (effortValue === 0) {
+    pushIssue(issues, { file, sheetName, rowIndex, row, effortValue, options });
+    return true;
+  }
+
+  return false;
+}
+
+export const missingPlanAuditEngine: FunctionAuditEngine = {
+  functionId: 'missing-plan',
+  run(file, _policy, options) {
+    const issues: AuditIssue[] = [];
+    const sheetResults = file.sheets
+      .filter((sheet) => sheet.status === 'valid' && sheet.isSelected)
+      .map((sheet) => {
+        const rows = rowsToObjects(
+          file.rawData[sheet.name] ?? [],
+          sheet.headerRowIndex ?? 0,
+          sheet.normalizedHeaders,
+        );
+        let flaggedCount = 0;
+        rows.forEach(({ row, rowIndex }) => {
+          const flagged = auditRow({
+            file,
+            sheetName: sheet.name,
+            rowIndex,
+            row,
+            options,
+            issues,
+          });
+          if (flagged) flaggedCount += 1;
+        });
+        return { sheetName: sheet.name, rowCount: rows.length, flaggedCount };
+      });
+
+    const result: AuditResult = {
+      fileId: file.id,
+      runAt: new Date().toISOString(),
+      scannedRows: sheetResults.reduce((sum, sheet) => sum + sheet.rowCount, 0),
+      flaggedRows: sheetResults.reduce((sum, sheet) => sum + sheet.flaggedCount, 0),
+      issues,
+      sheets: sheetResults,
+    };
+    return result;
+  },
+};

--- a/packages/domain/src/functions-audit/missing-plan/index.ts
+++ b/packages/domain/src/functions-audit/missing-plan/index.ts
@@ -1,0 +1,7 @@
+export { missingPlanAuditEngine } from './engine';
+export {
+  MISSING_PLAN_RULE_CATALOG,
+  MISSING_PLAN_RULES_BY_CODE,
+  MP_EFFORT_ZERO_RULE_CODE,
+} from './rules';
+export { MP_EFFORT_ALIASES } from './columns';

--- a/packages/domain/src/functions-audit/missing-plan/rules.ts
+++ b/packages/domain/src/functions-audit/missing-plan/rules.ts
@@ -1,0 +1,26 @@
+import type { RuleCatalogEntry } from '../../auditRules';
+// NOTE: keep `import type` — a value import here would create a runtime
+// cycle with auditRules.ts, which imports MISSING_PLAN_RULE_CATALOG from us.
+
+// Stable rule code for the zero-effort finding. Prefixed RUL-MP-* to keep
+// the missing-plan namespace isolated from over-planning (RUL-EFFORT-*) and
+// master-data (RUL-MD-*) rules.
+export const MP_EFFORT_ZERO_RULE_CODE = 'RUL-MP-EFFORT-ZERO';
+
+export const MISSING_PLAN_RULE_CATALOG: RuleCatalogEntry[] = [
+  {
+    ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+    name: 'Zero effort',
+    category: 'Missing Planning',
+    defaultSeverity: 'Medium',
+    description:
+      'Project has Effort (H) = 0. Active projects should carry planned effort; a zero value indicates missing or deferred planning.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+];
+
+export const MISSING_PLAN_RULES_BY_CODE = new Map(
+  MISSING_PLAN_RULE_CATALOG.map((rule) => [rule.ruleCode, rule]),
+);

--- a/packages/domain/test/master-data-audit.test.ts
+++ b/packages/domain/test/master-data-audit.test.ts
@@ -337,7 +337,9 @@ test('master-data catalog contains a missing rule for every required column plus
 });
 
 test('unbuilt functions have empty catalogs, not inherited rules', () => {
-  for (const fn of ['missing-plan', 'function-rate', 'internal-cost-rate'] as const) {
+  // missing-plan now has its own dedicated engine and catalog (RUL-MP-EFFORT-ZERO).
+  // function-rate and internal-cost-rate remain unbuilt placeholders.
+  for (const fn of ['function-rate', 'internal-cost-rate'] as const) {
     assert.equal(getRuleCatalogForFunction(fn).length, 0, `${fn} should not inherit any rules`);
   }
 });

--- a/packages/domain/test/missing-plan-audit.test.ts
+++ b/packages/domain/test/missing-plan-audit.test.ts
@@ -1,0 +1,275 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ExcelJS from 'exceljs';
+import { parseWorkbook } from '../src/workbook.js';
+import { RULE_CATALOG_BY_FUNCTION, getRuleCatalogForFunction } from '../src/auditRules.js';
+import {
+  getFunctionAuditEngine,
+  MP_EFFORT_ALIASES,
+  MP_EFFORT_ZERO_RULE_CODE,
+  MISSING_PLAN_RULE_CATALOG,
+  runFunctionAudit,
+} from '../src/functions-audit/index.js';
+import type { WorkbookFile } from '../src/types.js';
+
+class TestFile extends Blob {
+  name: string;
+  lastModified: number;
+
+  constructor(parts: BlobPart[], name: string) {
+    super(parts);
+    this.name = name;
+    this.lastModified = Date.now();
+  }
+}
+
+// Minimal header set that satisfies the workbook parser's CORE_COLUMNS
+// threshold (projectNo + projectManager + projectState + effort) so the sheet
+// is marked valid and selected.
+const BASE_HEADERS = [
+  'Project No.',
+  'Project',
+  'Project State',
+  'Project Manager',
+  'Project Manager Email',
+  'Effort (H)',
+];
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}): unknown[] {
+  const defaults: Record<string, unknown> = {
+    'Project No.': '90032101',
+    Project: 'Digital Core SAP S4',
+    'Project State': 'Opened',
+    'Project Manager': 'Wagner, Anna',
+    'Project Manager Email': 'anna.wagner@example.com',
+    'Effort (H)': 40,
+  };
+  const merged = { ...defaults, ...overrides };
+  return BASE_HEADERS.map((h) => merged[h] ?? '');
+}
+
+async function buildWorkbook(
+  headers: string[],
+  dataRows: unknown[][],
+  fileName = 'effort-tracker.xlsx',
+): Promise<WorkbookFile> {
+  const workbook = new ExcelJS.Workbook();
+  // The workbook parser requires ≥5 rows to mark a sheet valid.
+  const filler = Array.from({ length: Math.max(0, 5 - dataRows.length) }, (_, i) => {
+    const base = headers.map(() => '');
+    // projectNo is always first in BASE_HEADERS; supply unique values for filler
+    const projectNoIndex = headers.indexOf('Project No.');
+    if (projectNoIndex >= 0) base[projectNoIndex] = `FILL-${i}`;
+    const effortIndex = headers.findIndex((h) =>
+      ['Effort (H)', 'Effort H', 'effort', 'hours', 'planned effort'].includes(h.toLowerCase()),
+    );
+    if (effortIndex >= 0) base[effortIndex] = 40; // non-zero filler so they don't pollute issue counts
+    const stateIndex = headers.indexOf('Project State');
+    if (stateIndex >= 0) base[stateIndex] = 'Opened';
+    const mgrIndex = headers.indexOf('Project Manager');
+    if (mgrIndex >= 0) base[mgrIndex] = 'Filler Manager';
+    return base;
+  });
+  workbook.addWorksheet('Effort').addRows([headers, ...dataRows, ...filler]);
+  const buffer = await workbook.xlsx.writeBuffer();
+  return parseWorkbook(new TestFile([buffer], fileName) as File);
+}
+
+// ─── Column matching ────────────────────────────────────────────────────────
+
+test('MP_EFFORT_ALIASES includes all expected variants', () => {
+  const lower = MP_EFFORT_ALIASES.map((a) => a.toLowerCase());
+  for (const variant of ['effort (h)', 'effort(h)', 'effort h', 'effort', 'hours', 'planned effort']) {
+    assert.ok(lower.includes(variant), `expected alias list to include "${variant}"`);
+  }
+});
+
+test('engine resolves effort column with messy header spellings', async () => {
+  const variants: Array<[string, unknown]> = [
+    ['effort(h)', 0],
+    ['EFFORT (H)', 0],
+    ['Effort H', 0],
+    ['planned effort', 0],
+    ['hours', 0],
+  ];
+
+  for (const [header, effortValue] of variants) {
+    const headers = ['Project No.', 'Project', 'Project State', 'Project Manager', header];
+    const dataRow = ['90032101', 'Test Project', 'Opened', 'Wagner, Anna', effortValue];
+    const file = await buildWorkbook(headers, [dataRow]);
+    const result = runFunctionAudit('missing-plan', file, undefined);
+    assert.ok(
+      result.issues.length >= 1,
+      `expected at least 1 issue for header variant "${header}", got ${result.issues.length}`,
+    );
+    assert.equal(result.issues[0]!.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+  }
+});
+
+// ─── Zero effort detection ──────────────────────────────────────────────────
+
+test('flags row with numeric effort = 0', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.ok(result.scannedRows >= 1);
+  assert.equal(result.flaggedRows, 1);
+  assert.equal(result.issues.length, 1);
+  const issue = result.issues[0]!;
+  assert.equal(issue.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+  assert.equal(issue.effort, 0);
+  assert.equal(issue.severity, 'Medium');
+  assert.equal(issue.category, 'Missing Planning');
+});
+
+test('flags row with string effort "0"', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': '0' })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+});
+
+test('flags row with float effort 0.0', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0.0 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+});
+
+// ─── Non-zero rows not flagged ───────────────────────────────────────────────
+
+test('does not flag row with effort = 40', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 40 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 0);
+  assert.equal(result.flaggedRows, 0);
+});
+
+test('does not flag row with effort = 0.5', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0.5 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 0);
+});
+
+// ─── Blank effort not flagged ────────────────────────────────────────────────
+
+test('does not flag row with blank effort cell', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': '' })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 0, 'blank effort should not produce a zero-effort finding');
+});
+
+test('does not flag row with undefined effort cell', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': undefined })]);
+  const result = runFunctionAudit('missing-plan', file, undefined);
+
+  assert.equal(result.issues.length, 0);
+});
+
+// ─── Engine registration ─────────────────────────────────────────────────────
+
+test('missing-plan routes to the dedicated engine, not the legacy engine', () => {
+  const engine = getFunctionAuditEngine('missing-plan');
+  assert.equal(engine.functionId, 'missing-plan');
+  // The legacy engine wraps runAudit and does NOT expose a named property we
+  // can inspect, so we verify via the rule catalog: the dedicated engine
+  // populates issues with MP_EFFORT_ZERO_RULE_CODE, which the legacy engine
+  // would never produce. We verify this indirectly via the catalog check below.
+});
+
+test('missing-plan rule catalog is not empty', () => {
+  const catalog = getRuleCatalogForFunction('missing-plan');
+  assert.ok(catalog.length > 0, 'expected at least one rule in the missing-plan catalog');
+  assert.ok(
+    catalog.some((r) => r.ruleCode === MP_EFFORT_ZERO_RULE_CODE),
+    `expected ${MP_EFFORT_ZERO_RULE_CODE} in the catalog`,
+  );
+});
+
+// ─── Rule isolation ──────────────────────────────────────────────────────────
+
+test('RUL-MP-* codes appear only under missing-plan in RULE_CATALOG_BY_FUNCTION', () => {
+  const entries = Object.entries(RULE_CATALOG_BY_FUNCTION) as Array<[string, typeof MISSING_PLAN_RULE_CATALOG]>;
+  for (const [functionId, rules] of entries) {
+    if (functionId === 'missing-plan') continue;
+    for (const rule of rules) {
+      assert.ok(
+        !rule.ruleCode.startsWith('RUL-MP-'),
+        `found RUL-MP-* code "${rule.ruleCode}" under function "${functionId}" — rule codes must be function-owned`,
+      );
+    }
+  }
+});
+
+test('no ruleCode appears in more than one function catalog', () => {
+  const seen = new Map<string, string>();
+  const entries = Object.entries(RULE_CATALOG_BY_FUNCTION) as Array<[string, typeof MISSING_PLAN_RULE_CATALOG]>;
+  for (const [functionId, rules] of entries) {
+    for (const rule of rules) {
+      if (seen.has(rule.ruleCode)) {
+        assert.fail(
+          `ruleCode "${rule.ruleCode}" appears under both "${seen.get(rule.ruleCode)}" and "${functionId}"`,
+        );
+      }
+      seen.set(rule.ruleCode, functionId);
+    }
+  }
+});
+
+// ─── Issue metadata ──────────────────────────────────────────────────────────
+
+test('issue payload carries all required metadata fields', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.equal(result.issues.length, 1);
+  const issue = result.issues[0]!;
+
+  assert.ok(issue.projectNo, 'projectNo must be populated');
+  assert.ok(issue.projectName, 'projectName must be populated');
+  assert.ok(issue.projectManager, 'projectManager must be populated');
+  assert.ok(issue.projectState, 'projectState must be populated');
+  assert.ok(issue.sheetName, 'sheetName must be populated');
+  assert.ok(typeof issue.rowIndex === 'number', 'rowIndex must be a number');
+  assert.equal(issue.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+  assert.ok(issue.severity, 'severity must be populated');
+  assert.equal(issue.category, 'Missing Planning');
+  assert.ok(issue.reason, 'reason must be populated');
+  assert.ok(issue.recommendedAction, 'recommendedAction must be populated');
+});
+
+// ─── End-to-end with issueKey ─────────────────────────────────────────────────
+
+test('end-to-end: zero-effort row produces issue with IKY- issueKey', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0 })]);
+  const result = runFunctionAudit('missing-plan', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.equal(result.issues.length, 1);
+  const issue = result.issues[0]!;
+  assert.ok(issue.issueKey, 'issueKey must be present when issueScope is provided');
+  assert.match(issue.issueKey!, /^IKY-/, 'issueKey must start with IKY-');
+  assert.equal(issue.ruleCode, MP_EFFORT_ZERO_RULE_CODE);
+  assert.equal(issue.effort, 0);
+});
+
+test('end-to-end: mixed rows — only zero-effort rows flagged', async () => {
+  const rows = [
+    makeRow({ 'Project No.': 'P001', 'Effort (H)': 0 }),
+    makeRow({ 'Project No.': 'P002', 'Effort (H)': 100 }),
+    makeRow({ 'Project No.': 'P003', 'Effort (H)': 0 }),
+    makeRow({ 'Project No.': 'P004', 'Effort (H)': 50 }),
+    makeRow({ 'Project No.': 'P005', 'Effort (H)': '' }),
+  ];
+  const file = await buildWorkbook(BASE_HEADERS, rows);
+  const result = runFunctionAudit('missing-plan', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.equal(result.flaggedRows, 2, 'only the two zero-effort rows should be flagged');
+  assert.equal(result.issues.length, 2);
+  const flaggedNos = result.issues.map((i) => i.projectNo).sort();
+  assert.deepEqual(flaggedNos, ['P001', 'P003']);
+});


### PR DESCRIPTION
## Summary
- Added a dedicated Missing Plan / Missing Effort audit engine to detect projects where `Effort (H)` is `0` (with robust column-name matching for messy/reordered uploads).
- Registered Missing Plan as its own function-owned engine/rule catalog path (removed reliance on legacy shared engine behavior for this function).
- Reused the existing audit-to-escalation pipeline (issue persistence, directory email resolution, tracking/escalation center) with no parallel flow introduced.

## Why
- Missing Effort is a function-specific business check and needs a clear, isolated engine/rule boundary similar to Master Data.
- Users upload varied Excel formats, so header normalization/synonym mapping is required for reliable detection.
- Keeping the current escalation pipeline avoids duplication and preserves operational consistency.

## What Changed
- Added Missing Plan engine module and rule definitions in domain layer.
- Updated function engine registry to route `missing-plan` to the new engine.
- Added/updated tests for header matching, zero-effort detection, and routing/integration behavior.
- Updated audit-engine documentation for Missing Plan behavior and supported columns.

## Behavior
- Rows with zero effort are flagged as Missing Plan issues.
- Generated issues flow into the same existing Escalation Center/tracking workflow.
- No changes to Master Data logic or unrelated function behavior.

## Test Plan
- Run domain tests for Missing Plan engine and rule matching.
- Run API audit flow test to verify issues are persisted and visible to escalation/tracking pipeline.
- Manual check with sample Missing Effort workbook:
  - upload file
  - run Missing Plan audit
  - verify flagged rows and escalation-center visibility.