### PR TITLE
Implement dedicated overplanning PD engine with mapping-source driven escalation

### DIFF
--- a/apps/api/src/audits.controller.ts
+++ b/apps/api/src/audits.controller.ts
@@ -19,6 +19,15 @@ export class AuditsController {
     return this.auditsService.run(idOrCode, body, user);
   }
 
+  @Get('processes/:idOrCode/audit-runs')
+  listForProcess(
+    @Param('idOrCode') idOrCode: string,
+    @Query('functionId') functionId: string | undefined,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.auditsService.listForProcess(idOrCode, functionId, user);
+  }
+
   // Latest completed audit run for a file. The web client calls this when
   // the user lands on the Audit Results tab via a deep link (Escalation
   // Center "Open evidence", a bookmark, etc.) and there's no in-session

--- a/apps/api/src/audits.service.ts
+++ b/apps/api/src/audits.service.ts
@@ -9,11 +9,13 @@ import {
   buildIssuesCsv,
   createId,
   createIssueKey,
+  normalizeObservedManagerLabel,
   normalizeProcessPolicies,
   resolveFunctionPolicy,
   runFunctionAudit,
 } from '@ses/domain';
 import type { FunctionId } from '@ses/domain';
+import type { MappingSourceDto } from './dto/audits.dto';
 import { PrismaService } from './common/prisma.service';
 import { IdentifierService } from './common/identifier.service';
 import { ActivityLogService } from './common/activity-log.service';
@@ -205,7 +207,7 @@ export class AuditsService {
     };
   }
 
-  async run(processIdOrCode: string, body: { fileIdOrCode: string }, user: SessionUser) {
+  async run(processIdOrCode: string, body: { fileIdOrCode: string; mappingSource?: MappingSourceDto }, user: SessionUser) {
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'editor');
     const file = await this.prisma.workbookFile.findFirst({
       where: {
@@ -272,6 +274,13 @@ export class AuditsService {
         runCode,
       });
 
+      // Pre-resolve emails from an explicit mapping source (over-planning only).
+      let resolvedFromMapping = 0;
+      if (file.functionId === 'over-planning' && body.mappingSource && body.mappingSource.type !== 'none') {
+        const preMap = await this.buildMappingSourceMap(tx, process, file, body.mappingSource);
+        resolvedFromMapping = this.applyPreResolvedEmails(result.issues, preMap);
+      }
+
       // Master Data exports have no email column at all — every owner must
       // be looked up from the tenant's Manager Directory. For over-planning
       // we also prefer the directory: it's canonical, the workbook isn't.
@@ -298,6 +307,16 @@ export class AuditsService {
           resolvedCount: directoryResolution.resolvedFromDirectory,
           unresolvedNames: directoryResolution.unresolvedManagerNames,
         },
+        ...(file.functionId === 'over-planning'
+          ? {
+              overplanning: {
+                pdThreshold: (functionPolicy as { pdThreshold?: number })?.pdThreshold ?? 30,
+                mappingSourceType: body.mappingSource?.type ?? 'none',
+                resolvedFromMapping,
+                allowUnresolvedFallback: body.mappingSource?.allowUnresolvedFallback ?? true,
+              },
+            }
+          : {}),
       };
 
       for (const issue of issuesWithCodes) {
@@ -482,6 +501,104 @@ export class AuditsService {
           contentType,
         } as any, // PRISMA-JSON: unavoidable until Prisma 6 supports typed JSON columns
       });
+    });
+  }
+
+  // Build a name → email map from either an uploaded mapping file or a completed master-data run.
+  private async buildMappingSourceMap(
+    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
+    process: { id: string; displayCode: string },
+    auditFile: { id: string },
+    src: MappingSourceDto,
+  ): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+
+    if (src.type === 'uploaded_file') {
+      if (!src.uploadId) return map;
+      if (src.uploadId === auditFile.id) {
+        throw new BadRequestException('Mapping file must differ from the audit file');
+      }
+      const mf = await (tx as any).workbookFile.findFirst({
+        where: { id: src.uploadId, processId: process.id },
+      });
+      if (!mf) throw new BadRequestException(`Mapping file ${src.uploadId} not found in this process`);
+      const sheet = await (tx as any).workbookSheet.findFirst({ where: { fileId: mf.id } });
+      const rows: unknown[][] = (sheet?.rows as unknown[][]) ?? [];
+      if (rows.length < 2) return map;
+      const headerRow = (rows[0] ?? []).map((c) => String(c ?? '').toLowerCase());
+      const nameCol = headerRow.findIndex((h) => ['manager', 'name', 'project manager'].includes(h));
+      const emailCol = headerRow.findIndex((h) => h === 'email');
+      if (nameCol < 0 || emailCol < 0) return map;
+      for (const row of rows.slice(1)) {
+        const name = String((row as unknown[])[nameCol] ?? '').trim();
+        const email = String((row as unknown[])[emailCol] ?? '').trim();
+        if (name && email) map.set(normalizeObservedManagerLabel(name), email);
+      }
+      return map;
+    }
+
+    if (src.type === 'master_data_version') {
+      if (!src.masterDataVersionId) return map;
+      const run = await (tx as any).auditRun.findFirst({
+        where: {
+          id: src.masterDataVersionId,
+          processId: process.id,
+          status: 'completed',
+          file: { functionId: 'master-data' },
+        },
+      });
+      if (!run) {
+        throw new BadRequestException(
+          'Master Data version not found, or does not belong to this process, or is not completed',
+        );
+      }
+      const issues = await (tx as any).auditIssue.findMany({
+        where: { auditRunId: run.id },
+        select: { projectManager: true, email: true },
+      });
+      for (const issue of issues) {
+        const name = String(issue.projectManager ?? '').trim();
+        const email = String(issue.email ?? '').trim();
+        if (name && email) map.set(normalizeObservedManagerLabel(name), email);
+      }
+      return map;
+    }
+
+    return map;
+  }
+
+  private applyPreResolvedEmails(issues: AuditIssue[], map: Map<string, string>): number {
+    let count = 0;
+    for (const issue of issues) {
+      if (issue.email) continue;
+      const key = normalizeObservedManagerLabel(issue.projectManager ?? '');
+      const email = map.get(key);
+      if (email) {
+        issue.email = email;
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  async listForProcess(processIdOrCode: string, functionId: string | undefined, user: SessionUser) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'viewer');
+    return this.prisma.auditRun.findMany({
+      where: {
+        processId: process.id,
+        status: 'completed',
+        ...(functionId ? { file: { functionId } } : {}),
+      },
+      orderBy: { completedAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        displayCode: true,
+        completedAt: true,
+        scannedRows: true,
+        flaggedRows: true,
+        file: { select: { functionId: true, name: true, displayCode: true } },
+      },
     });
   }
 

--- a/apps/api/src/dto/audits.dto.ts
+++ b/apps/api/src/dto/audits.dto.ts
@@ -1,8 +1,33 @@
-import { IsString, MaxLength, MinLength } from 'class-validator';
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength, MinLength, ValidateIf, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class MappingSourceDto {
+  @IsIn(['master_data_version', 'uploaded_file', 'none'])
+  type!: 'master_data_version' | 'uploaded_file' | 'none';
+
+  @IsString()
+  @ValidateIf((o: MappingSourceDto) => o.type === 'master_data_version')
+  masterDataVersionId?: string;
+
+  @IsString()
+  @ValidateIf((o: MappingSourceDto) => o.type === 'uploaded_file')
+  uploadId?: string;
+
+  /** When false: issues without email are still created; unresolved names surfaced in run summary. Default true. */
+  @IsBoolean()
+  @IsOptional()
+  allowUnresolvedFallback?: boolean;
+}
 
 export class RunAuditDto {
   @IsString()
   @MinLength(1)
   @MaxLength(128)
   fileIdOrCode!: string;
+
+  @ValidateNested()
+  @Type(() => MappingSourceDto)
+  @IsOptional()
+  mappingSource?: MappingSourceDto;
 }
+

--- a/apps/web/src/components/workspace/AuditResultsTab.tsx
+++ b/apps/web/src/components/workspace/AuditResultsTab.tsx
@@ -1,5 +1,7 @@
 import { CheckCircle2, ChevronRight, Circle, Settings, X } from 'lucide-react';
 import { Fragment, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import type { MappingSourceInput } from '../../lib/api/auditsApi';
+import { MappingSourcePanel } from './MappingSourcePanel';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import toast from 'react-hot-toast';
 import { useSearchParams } from 'react-router-dom';
@@ -114,7 +116,24 @@ function issueRuleKey(issue: AuditIssue): string {
   return issue.ruleCode ?? issue.ruleId ?? issue.auditStatus ?? '';
 }
 
-export function AuditResultsTab({ process, file }: { process: AuditProcess; file?: WorkbookFile | undefined }) {
+function isMappingSourceValid(src: MappingSourceInput | undefined): boolean {
+  if (!src || src.type === 'none') return true;
+  if (src.type === 'master_data_version') return Boolean(src.masterDataVersionId);
+  if (src.type === 'uploaded_file') return Boolean(src.uploadId);
+  return true;
+}
+
+export function AuditResultsTab({
+  process,
+  file,
+  mappingSource,
+  onMappingSourceChange,
+}: {
+  process: AuditProcess;
+  file?: WorkbookFile | undefined;
+  mappingSource?: MappingSourceInput | undefined;
+  onMappingSourceChange?: (src: MappingSourceInput | undefined) => void;
+}) {
   // The Zustand `currentAuditResult` is only populated by an interactive
   // run from this same browser session — it gets cleared whenever the user
   // navigates between processes or functions (see useAppStore lines 321,
@@ -127,13 +146,14 @@ export function AuditResultsTab({ process, file }: { process: AuditProcess; file
   // pattern (Workspace.tsx:198,213).
   const liveResult = useAppStore((state) => state.currentAuditResult);
   const result = useMemo(() => {
-    if (liveResult && (!file || liveResult.fileId === file.id)) return liveResult;
-    if (process.latestAuditResult && (!file || process.latestAuditResult.fileId === file.id)) {
+    if (!file) return null;
+    if (liveResult && liveResult.fileId === file.id) return liveResult;
+    if (process.latestAuditResult && process.latestAuditResult.fileId === file.id) {
       return process.latestAuditResult;
     }
     // process.versions is sorted newest-first elsewhere; index 0 is latest.
     const latestVersion = process.versions?.[0]?.result;
-    if (latestVersion && (!file || latestVersion.fileId === file.id)) return latestVersion;
+    if (latestVersion && latestVersion.fileId === file.id) return latestVersion;
     return null;
   }, [liveResult, file, process.latestAuditResult, process.versions]);
   const runAudit = useAppStore((state) => state.runAudit);
@@ -150,6 +170,11 @@ export function AuditResultsTab({ process, file }: { process: AuditProcess; file
   const [sort, setSort] = useState<SortKey>('severity');
   const [expanded, setExpanded] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const overPlanningFiles = useMemo(
+    () => process.files.filter((f) => f.functionId === 'over-planning'),
+    [process.files],
+  );
+  const mappingSourceOk = file?.functionId !== 'over-planning' || isMappingSourceValid(mappingSource);
   const searchRef = useRef<HTMLInputElement>(null);
   useKeyboardShortcut('/', () => searchRef.current?.focus(), Boolean(result));
   const policyChanged = Boolean(result && isPolicyChanged(process.auditPolicy, result.policySnapshot));
@@ -388,7 +413,31 @@ export function AuditResultsTab({ process, file }: { process: AuditProcess; file
             <Step done={false}>{isMasterData ? 'Run Master Data audit' : 'Run audit with the QGC policy'}</Step>
             <Step done={false}>Save a version for traceability</Step>
           </div>
-          {file ? <button onClick={() => runAudit(process.id, file.id)} disabled={!hasSelected} className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white disabled:opacity-40">Run Audit</button> : null}
+          {file ? (
+            <>
+              {file.functionId === 'over-planning' && process.displayCode && (
+                <div className="mb-3 w-full max-w-sm text-left">
+                  <MappingSourcePanel
+                    processId={process.id}
+                    processDisplayCode={process.displayCode}
+                    auditFileId={file.id}
+                    overPlanningFiles={overPlanningFiles}
+                    value={mappingSource}
+                    onChange={onMappingSourceChange ?? (() => {})}
+                  />
+                </div>
+              )}
+              <button
+                onClick={() => {
+                  void runAudit(process.id, file.id, mappingSource ? { mappingSource } : undefined);
+                }}
+                disabled={!hasSelected || !mappingSourceOk}
+                className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white disabled:opacity-40"
+              >
+                Run Audit
+              </button>
+            </>
+          ) : null}
         </EmptyState>
       ) : (
         <>
@@ -422,8 +471,10 @@ export function AuditResultsTab({ process, file }: { process: AuditProcess; file
               {file ? (
                 <button
                   type="button"
-                  onClick={() => runAudit(process.id, file.id)}
-                  disabled={!hasSelected}
+                  onClick={() => {
+                    void runAudit(process.id, file.id, mappingSource ? { mappingSource } : undefined);
+                  }}
+                  disabled={!hasSelected || !mappingSourceOk}
                   className="rounded-lg bg-amber-600 px-3 py-2 text-xs font-semibold text-white hover:bg-amber-700 disabled:opacity-40"
                 >
                   Re-run audit
@@ -556,7 +607,7 @@ export function AuditResultsTab({ process, file }: { process: AuditProcess; file
         </>
       )}
 
-      {settingsOpen ? <QgcSettingsDrawer process={process} file={file} onClose={() => setSettingsOpen(false)} /> : null}
+      {settingsOpen ? <QgcSettingsDrawer process={process} file={file} mappingSource={mappingSource} onClose={() => setSettingsOpen(false)} /> : null}
     </div>
   );
 }
@@ -643,11 +694,23 @@ function Detail({ label, value }: { label: string; value: string }) {
   );
 }
 
-function QgcSettingsDrawer({ process, file, onClose }: { process: AuditProcess; file?: WorkbookFile | undefined; onClose: () => void }) {
+function QgcSettingsDrawer({
+  process,
+  file,
+  mappingSource,
+  onClose,
+}: {
+  process: AuditProcess;
+  file?: WorkbookFile | undefined;
+  mappingSource?: MappingSourceInput | undefined;
+  onClose: () => void;
+}) {
   const updateAuditPolicy = useAppStore((state) => state.updateAuditPolicy);
   const resetAuditPolicy = useAppStore((state) => state.resetAuditPolicy);
   const runAudit = useAppStore((state) => state.runAudit);
   const [draft, setDraft] = useState<AuditPolicy>(process.auditPolicy);
+  const isOverPlanning = file?.functionId === 'over-planning';
+  const isMissingPlan = file?.functionId === 'missing-plan';
 
   function setNumber(key: keyof AuditPolicy, value: string) {
     setDraft((state) => ({ ...state, [key]: Number(value) || 0 }));
@@ -661,7 +724,8 @@ function QgcSettingsDrawer({ process, file, onClose }: { process: AuditProcess; 
     event.preventDefault();
     updateAuditPolicy(process.id, { ...draft, mediumEffortMin: 0, mediumEffortMax: 0, lowEffortEnabled: false });
     if (file) {
-      void runAudit(process.id, file.id).then(() => toast.success('Settings saved and audit re-run'));
+      const runOptions = isOverPlanning && mappingSource ? { mappingSource } : undefined;
+      void runAudit(process.id, file.id, runOptions).then(() => toast.success('Settings saved and audit re-run'));
     } else {
       toast.success('Settings saved');
     }
@@ -686,24 +750,23 @@ function QgcSettingsDrawer({ process, file, onClose }: { process: AuditProcess; 
           <button type="button" onClick={onClose} aria-label="Close" className="rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-800"><X size={18} /></button>
         </div>
 
-        <SettingsSection title="Overplanning">
-          <NumberField label="Overplanned when effort is greater than" value={draft.highEffortThreshold} suffix="hours" onChange={(value) => setNumber('highEffortThreshold', value)} />
-        </SettingsSection>
-
-        <SettingsSection title="Missing Planning">
-          <Toggle label="Flag missing effort" checked={draft.missingEffortEnabled} onChange={(checked) => setFlag('missingEffortEnabled', checked)} />
-          <Toggle label="Flag zero effort" checked={draft.zeroEffortEnabled} onChange={(checked) => setFlag('zeroEffortEnabled', checked)} />
-        </SettingsSection>
-
-        <details className="mt-5 rounded-xl border border-gray-200 p-4 dark:border-gray-700">
-          <summary className="cursor-pointer font-semibold">Advanced rules</summary>
-          <div className="mt-3 space-y-3">
-            <Toggle label="Flag missing manager" checked={draft.missingManagerEnabled} onChange={(checked) => setFlag('missingManagerEnabled', checked)} />
-            <Toggle label="Flag In Planning with effort" checked={draft.inPlanningEffortEnabled} onChange={(checked) => setFlag('inPlanningEffortEnabled', checked)} />
-            <Toggle label="Flag On Hold with effort" checked={draft.onHoldEffortEnabled} onChange={(checked) => setFlag('onHoldEffortEnabled', checked)} />
-            <NumberField label="Flag On Hold when effort is greater than" value={draft.onHoldEffortThreshold} suffix="hours" onChange={(value) => setNumber('onHoldEffortThreshold', value)} />
-          </div>
-        </details>
+        {isOverPlanning ? (
+          <SettingsSection title="Overplanning threshold">
+            <NumberField
+              label="Flag when monthly Effort PD exceeds"
+              value={draft.pdThreshold ?? 30}
+              suffix="PD per month"
+              onChange={(value) => setNumber('pdThreshold', value)}
+            />
+          </SettingsSection>
+        ) : isMissingPlan ? (
+          <SettingsSection title="Missing Planning rules">
+            <Toggle label="Flag missing effort (absent / blank)" checked={draft.missingEffortEnabled} onChange={(checked) => setFlag('missingEffortEnabled', checked)} />
+            <Toggle label="Flag zero effort" checked={draft.zeroEffortEnabled} onChange={(checked) => setFlag('zeroEffortEnabled', checked)} />
+          </SettingsSection>
+        ) : (
+          <p className="mt-4 text-sm text-gray-500">No configurable thresholds for this function.</p>
+        )}
 
         <div className="sticky bottom-0 mt-6 flex gap-2 border-t border-gray-200 bg-white pt-4 dark:border-gray-700 dark:bg-gray-900">
           <button type="submit" className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover">{file ? 'Save & Re-run Audit' : 'Save Settings'}</button>

--- a/apps/web/src/components/workspace/MappingSourcePanel.tsx
+++ b/apps/web/src/components/workspace/MappingSourcePanel.tsx
@@ -19,6 +19,7 @@ export function MappingSourcePanel({ processId, processDisplayCode, auditFileId,
 
   useEffect(() => {
     if (type !== 'master_data_version') return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- loading flag before async fetch
     setMdRunsLoading(true);
     fetchAuditRunsForProcess(processDisplayCode, 'master-data')
       .then(setMdRuns)

--- a/apps/web/src/components/workspace/MappingSourcePanel.tsx
+++ b/apps/web/src/components/workspace/MappingSourcePanel.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import type { WorkbookFile } from '../../lib/types';
+import type { MappingSourceInput, ApiAuditRunListItem } from '../../lib/api/auditsApi';
+import { fetchAuditRunsForProcess } from '../../lib/api/auditsApi';
+
+interface Props {
+  processId: string;
+  processDisplayCode: string;
+  auditFileId: string;
+  overPlanningFiles: WorkbookFile[];
+  value: MappingSourceInput | undefined;
+  onChange: (src: MappingSourceInput | undefined) => void;
+}
+
+export function MappingSourcePanel({ processId, processDisplayCode, auditFileId, overPlanningFiles, value, onChange }: Props) {
+  const type = value?.type ?? 'none';
+  const [mdRuns, setMdRuns] = useState<ApiAuditRunListItem[]>([]);
+  const [mdRunsLoading, setMdRunsLoading] = useState(false);
+
+  useEffect(() => {
+    if (type !== 'master_data_version') return;
+    setMdRunsLoading(true);
+    fetchAuditRunsForProcess(processDisplayCode, 'master-data')
+      .then(setMdRuns)
+      .catch(() => setMdRuns([]))
+      .finally(() => setMdRunsLoading(false));
+  }, [type, processDisplayCode]);
+  function setType(newType: 'none' | 'master_data_version' | 'uploaded_file') {
+    if (newType === 'none') {
+      onChange(undefined);
+    } else {
+      onChange({ type: newType, allowUnresolvedFallback: value?.allowUnresolvedFallback ?? true });
+    }
+  }
+
+  function setMasterDataVersionId(id: string) {
+    onChange({ type: 'master_data_version', masterDataVersionId: id, allowUnresolvedFallback: value?.allowUnresolvedFallback ?? true });
+  }
+
+  function setUploadId(id: string) {
+    onChange({ type: 'uploaded_file', uploadId: id, allowUnresolvedFallback: value?.allowUnresolvedFallback ?? true });
+  }
+
+  function setAllowUnresolved(checked: boolean) {
+    if (!value || value.type === 'none') return;
+    onChange({ ...value, allowUnresolvedFallback: checked });
+  }
+
+  const mappingFiles = overPlanningFiles.filter((f) => f.id !== auditFileId);
+
+  return (
+    <div className="rounded-xl border border-gray-200 p-4 dark:border-gray-700">
+      <h4 className="font-semibold text-sm text-gray-700 dark:text-gray-200">Manager Mapping Source</h4>
+      <p className="mt-1 text-xs text-gray-500">How to match project managers to escalation email addresses for this run.</p>
+
+      <div className="mt-3 space-y-2">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="radio" name={`mapping-${processId}`} checked={type === 'none'} onChange={() => setType('none')} />
+          None <span className="text-xs text-gray-400">(fall through to Manager Directory)</span>
+        </label>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="radio" name={`mapping-${processId}`} checked={type === 'master_data_version'} onChange={() => setType('master_data_version')} />
+          Master Data version
+        </label>
+        {type === 'master_data_version' && (
+          <div className="ml-6">
+            <select
+              value={value?.masterDataVersionId ?? ''}
+              onChange={(e) => setMasterDataVersionId(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <option value="">{mdRunsLoading ? 'Loading…' : 'Select a Master Data run…'}</option>
+              {mdRuns.map((run) => (
+                <option key={run.id} value={run.id}>
+                  Run {run.displayCode} — {run.completedAt ? new Date(run.completedAt).toLocaleDateString() : '?'} — {run.flaggedRows} issues
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="radio" name={`mapping-${processId}`} checked={type === 'uploaded_file'} onChange={() => setType('uploaded_file')} />
+          Uploaded mapping file
+        </label>
+        {type === 'uploaded_file' && (
+          <div className="ml-6">
+            <select
+              value={value?.uploadId ?? ''}
+              onChange={(e) => setUploadId(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <option value="">Select a mapping file…</option>
+              {mappingFiles.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} — uploaded {f.uploadedAt ? new Date(f.uploadedAt).toLocaleDateString() : '?'}
+                </option>
+              ))}
+            </select>
+            {mappingFiles.length === 0 && (
+              <p className="mt-1 text-xs text-gray-400">No other over-planning files in this process.</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {type !== 'none' && (
+        <label className="mt-3 flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={value?.allowUnresolvedFallback ?? true}
+            onChange={(e) => setAllowUnresolved(e.target.checked)}
+          />
+          Allow unresolved fallback
+          <span className="text-xs text-gray-400">(issues without email are still created)</span>
+        </label>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/auditsApi.ts
+++ b/apps/web/src/lib/api/auditsApi.ts
@@ -1,5 +1,21 @@
 import { JSON_HEADERS, parseApiError } from './client';
 
+export interface MappingSourceInput {
+  type: 'master_data_version' | 'uploaded_file' | 'none';
+  masterDataVersionId?: string;
+  uploadId?: string;
+  allowUnresolvedFallback?: boolean;
+}
+
+export interface ApiAuditRunListItem {
+  id: string;
+  displayCode: string;
+  completedAt: string | null;
+  scannedRows: number;
+  flaggedRows: number;
+  file: { functionId: string; name: string; displayCode: string };
+}
+
 export interface ApiAuditRunIssue {
   id: string;
   displayCode: string;
@@ -42,15 +58,29 @@ export interface ApiAuditRunSummary {
 export async function runAuditOnApi(
   processIdOrCode: string,
   fileIdOrCode: string,
+  options?: { mappingSource?: MappingSourceInput },
 ): Promise<ApiAuditRunSummary> {
   const res = await fetch(`/api/v1/processes/${encodeURIComponent(processIdOrCode)}/audit/run`, {
     method: 'POST',
     credentials: 'include',
     headers: JSON_HEADERS,
-    body: JSON.stringify({ fileIdOrCode }),
+    body: JSON.stringify({ fileIdOrCode, ...(options?.mappingSource ? { mappingSource: options.mappingSource } : {}) }),
   });
   if (!res.ok) throw await parseApiError(res, 'Audit run failed');
   return (await res.json()) as ApiAuditRunSummary;
+}
+
+export async function fetchAuditRunsForProcess(
+  processIdOrCode: string,
+  functionId?: string,
+): Promise<ApiAuditRunListItem[]> {
+  const params = functionId ? `?functionId=${encodeURIComponent(functionId)}` : '';
+  const res = await fetch(
+    `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/audit-runs${params}`,
+    { credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to load audit runs');
+  return (await res.json()) as ApiAuditRunListItem[];
 }
 
 export async function fetchAuditIssues(runIdOrCode: string): Promise<ApiAuditRunIssue[]> {

--- a/apps/web/src/lib/excelParser.ts
+++ b/apps/web/src/lib/excelParser.ts
@@ -73,7 +73,7 @@ function detectHeader(rows: unknown[][]): HeaderCandidate | null {
     const candidate = rowHeaderScore(row);
     if (!best || candidate.score > best.score) best = { ...candidate, headerRowIndex: index };
   }
-  if (!best || best.score < 5 || !CORE_COLUMNS.some((column) => best.matchedColumns.has(column))) return null;
+  if (!best || best.score < 4 || !CORE_COLUMNS.some((column) => best.matchedColumns.has(column))) return null;
   return best;
 }
 

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -69,6 +69,7 @@ export function Workspace() {
   const [resolutionOpen, setResolutionOpen] = useState(false);
   const [versionModalOpen, setVersionModalOpen] = useState(false);
   const [mappingSource, setMappingSource] = useState<MappingSourceInput | undefined>(undefined);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- reset mapping source on function navigation
   useEffect(() => { setMappingSource(undefined); }, [functionId]);
   const hydrateAttemptedRef = useRef(false);
   const queryClient = useQueryClient();
@@ -363,6 +364,7 @@ export function Workspace() {
     latestResult,
     correctionCount,
     canRun,
+    mappingSourceValid,
     canSave,
     canDownload,
     hasSavedVersion,

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -18,6 +18,7 @@ import { usePageHeader } from '../components/layout/usePageHeader';
 import { PresenceBar } from '../components/shared/PresenceBar';
 import { useCurrentUser } from '../components/auth/authContext';
 import { downloadAuditedWorkbook } from '../lib/excelParser';
+import type { MappingSourceInput } from '../lib/api/auditsApi';
 import { selectCorrectionCount, selectHasUnsavedAudit, selectLatestAuditResult } from '../store/selectors';
 import { useAppStore } from '../store/useAppStore';
 import { isLegacyTileTrackingTabEnabled } from '../lib/featureFlags';
@@ -67,6 +68,8 @@ export function Workspace() {
   const [membersOpen, setMembersOpen] = useState(false);
   const [resolutionOpen, setResolutionOpen] = useState(false);
   const [versionModalOpen, setVersionModalOpen] = useState(false);
+  const [mappingSource, setMappingSource] = useState<MappingSourceInput | undefined>(undefined);
+  useEffect(() => { setMappingSource(undefined); }, [functionId]);
   const hydrateAttemptedRef = useRef(false);
   const queryClient = useQueryClient();
   const [hydrateFinished, setHydrateFinished] = useState(false);
@@ -137,8 +140,10 @@ export function Workspace() {
   useEffect(() => {
     if (tab !== 'results') return;
     if (!processRecordId) return;
-    const targetFileId = process?.activeFileId
-      ?? process?.files.find((file) => (file.functionId ?? DEFAULT_FUNCTION_ID) === functionId)?.id;
+    // Only hydrate from a file that belongs to the current function — using
+    // process.activeFileId directly would leak another function's file ID.
+    const functionFiles = process?.files.filter((file) => (file.functionId ?? DEFAULT_FUNCTION_ID) === functionId) ?? [];
+    const targetFileId = functionFiles.find((file) => file.id === process?.activeFileId)?.id ?? functionFiles[0]?.id;
     if (!targetFileId) return;
     void hydrateLatestAuditResult(processRecordId, targetFileId);
   }, [tab, processRecordId, process?.activeFileId, process?.files, functionId, hydrateLatestAuditResult]);
@@ -184,14 +189,24 @@ export function Workspace() {
   const headVersion = process?.versions[0];
   const headVersionName = headVersion?.versionName ?? '';
   const nextVersionNumber = (process?.versions.length ?? 0) + 1;
-  const canRun = Boolean(process && activeFile && selectedSheets > 0 && !isAuditRunning);
+  function isMappingSourceValid(src: MappingSourceInput | undefined): boolean {
+    if (!src || src.type === 'none') return true;
+    if (src.type === 'master_data_version') return Boolean(src.masterDataVersionId);
+    if (src.type === 'uploaded_file') return Boolean(src.uploadId);
+    return true;
+  }
+  const mappingSourceValid = activeFile?.functionId !== 'over-planning' || isMappingSourceValid(mappingSource);
+  const canRun = Boolean(process && activeFile && selectedSheets > 0 && !isAuditRunning && mappingSourceValid);
   const canSave = Boolean(process && latestResult && !isAuditRunning);
   const canDownload = Boolean(process && activeFile && latestResult && hasSavedVersion && !isAuditRunning);
 
   const onRunAudit = useCallback(async () => {
     if (!process || !activeFile) return;
     const priorAnchor = anchorResultForFile(process.versions, activeFile.id);
-    await runAudit(process.id, activeFile.id);
+    const runOptions = activeFile.functionId === 'over-planning' && mappingSource
+      ? { mappingSource }
+      : undefined;
+    await runAudit(process.id, activeFile.id, runOptions);
     const runResult = useAppStore.getState().currentAuditResult;
     if (!runResult) return;
     const diff = summarizeDiff(priorAnchor, runResult);
@@ -202,7 +217,7 @@ export function Workspace() {
     } else {
       toast.success(`Audit complete - ${runResult.scannedRows} rows scanned, ${runResult.issues.length} issues found`);
     }
-  }, [process, activeFile, runAudit]);
+  }, [process, activeFile, mappingSource, runAudit]);
 
   const onQuickSave = useCallback(() => {
     if (!process || !latestResult) return;
@@ -258,6 +273,8 @@ export function Workspace() {
       ? 'Upload a file first'
       : selectedSheets === 0
       ? 'Select at least one valid sheet'
+      : !mappingSourceValid
+      ? 'Select a mapping source version or file before running'
       : activeFile.isAudited
       ? 'Re-run the audit with the current sheet selection'
       : 'Run the audit with the current sheet selection';
@@ -414,7 +431,12 @@ export function Workspace() {
         ) : null}
         {tab === 'results' ? (
           <TabPanel>
-            <AuditResultsTab process={scopedProcess} file={activeFile} />
+            <AuditResultsTab
+              process={scopedProcess}
+              file={activeFile}
+              mappingSource={mappingSource}
+              onMappingSourceChange={setMappingSource}
+            />
           </TabPanel>
         ) : null}
         {tab === 'notifications' ? (

--- a/apps/web/src/realtime/socket.ts
+++ b/apps/web/src/realtime/socket.ts
@@ -37,9 +37,6 @@ function setConnectionState(next: RealtimeConnectionState): void {
 
 function ensureSocket(): Socket {
   if (socket) return socket;
-  // #region agent log
-  fetch('http://localhost:7379/ingest/e7cd3935-38b5-4daf-a68c-293c83da2364',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'a43ed5'},body:JSON.stringify({sessionId:'a43ed5',runId:'run1',hypothesisId:'H1',location:'apps/web/src/realtime/socket.ts:ensureSocket:init',message:'Creating socket client',data:{path:'/api/v1/realtime',transports:['websocket','polling'],withCredentials:true,timeoutMs:10000},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
   socket = io({
     path: '/api/v1/realtime',
     transports: ['websocket', 'polling'],
@@ -70,26 +67,14 @@ function ensureSocket(): Socket {
 
   socket.on('connect', () => setConnectionState('connected'));
   socket.on('disconnect', (reason) => {
-    // #region agent log
-    fetch('http://localhost:7379/ingest/e7cd3935-38b5-4daf-a68c-293c83da2364',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'a43ed5'},body:JSON.stringify({sessionId:'a43ed5',runId:'run1',hypothesisId:'H2',location:'apps/web/src/realtime/socket.ts:disconnect',message:'Socket disconnected',data:{reason},timestamp:Date.now()})}).catch(()=>{});
-    // #endregion
+    void reason;
     setConnectionState('disconnected');
   });
-  socket.on('connect_error', (error) => {
-    // #region agent log
-    fetch('http://localhost:7379/ingest/e7cd3935-38b5-4daf-a68c-293c83da2364',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'a43ed5'},body:JSON.stringify({sessionId:'a43ed5',runId:'run1',hypothesisId:'H3',location:'apps/web/src/realtime/socket.ts:connect_error',message:'Socket connect error',data:{message:error?.message,name:error?.name,description:(error as { description?: string } | undefined)?.description,context:(error as { context?: unknown } | undefined)?.context},timestamp:Date.now()})}).catch(()=>{});
-    // #endregion
-  });
-  socket.on('reconnect_attempt', (attempt) => {
-    // #region agent log
-    fetch('http://localhost:7379/ingest/e7cd3935-38b5-4daf-a68c-293c83da2364',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'a43ed5'},body:JSON.stringify({sessionId:'a43ed5',runId:'run1',hypothesisId:'H4',location:'apps/web/src/realtime/socket.ts:reconnect_attempt',message:'Socket reconnect attempt',data:{attempt},timestamp:Date.now()})}).catch(()=>{});
-    // #endregion
+  socket.on('connect_error', () => {});
+  socket.on('reconnect_attempt', () => {
     setConnectionState('connecting');
   });
-  socket.io.on('reconnect_attempt', (attempt) => {
-    // #region agent log
-    fetch('http://localhost:7379/ingest/e7cd3935-38b5-4daf-a68c-293c83da2364',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'a43ed5'},body:JSON.stringify({sessionId:'a43ed5',runId:'run1',hypothesisId:'H4',location:'apps/web/src/realtime/socket.ts:io_reconnect_attempt',message:'Manager reconnect attempt',data:{attempt},timestamp:Date.now()})}).catch(()=>{});
-    // #endregion
+  socket.io.on('reconnect_attempt', () => {
     setConnectionState('connecting');
   });
   socket.io.on('reconnect', () => setConnectionState('connected'));

--- a/apps/web/src/store/useAppStore.ts
+++ b/apps/web/src/store/useAppStore.ts
@@ -11,13 +11,13 @@ import {
 import { createDefaultAuditPolicy, normalizeAuditPolicy } from '../lib/auditPolicy';
 import { runAuditAsync } from '../lib/auditRunner';
 import { deleteWorkbookRawData, getWorkbookRawData, putWorkbookRawData, renameWorkbookRawDataKey } from '../lib/blobStore';
-import { parseWorkbook } from '../lib/excelParser';
+import { detectWorkbookSheets, parseWorkbook } from '../lib/excelParser';
 import { createId } from '../lib/id';
 import { createProcessOnApi, deleteProcessOnApi, fetchProcessesFromApi, updateProcessOnApi } from '../lib/api/processesApi';
 import { uploadFileToApi, deleteFileOnApi, listFilesOnApi, type ApiFileSummary } from '../lib/api/filesApi';
 import { listFileVersionsOnApi } from '../lib/api/fileVersionsApi';
 import { deleteFileDraftOnApi, getFileDraftOnApi, promoteFileDraftOnApi, saveFileDraftOnApi } from '../lib/api/fileDraftsApi';
-import { fetchAuditIssues, fetchLatestAuditRunForFile, runAuditOnApi, type ApiAuditRunIssue, type ApiAuditRunSummary } from '../lib/api/auditsApi';
+import { fetchAuditIssues, fetchLatestAuditRunForFile, runAuditOnApi, type ApiAuditRunIssue, type ApiAuditRunSummary, type MappingSourceInput } from '../lib/api/auditsApi';
 import { upsertTrackingOnApi, addTrackingEventOnApi } from '../lib/api/trackingApi';
 import {
   addIssueCommentOnApi,
@@ -94,7 +94,7 @@ type AppStore = {
   currentAuditResultForFile: (processId: string, fileId: string) => AuditResult | null;
   updateAuditPolicy: (processId: string, patch: Partial<AuditPolicy>) => void;
   resetAuditPolicy: (processId: string) => void;
-  runAudit: (processId: string, fileId: string) => Promise<void>;
+  runAudit: (processId: string, fileId: string, runOptions?: { mappingSource?: MappingSourceInput }) => Promise<void>;
   cancelAudit: () => void;
   // Pull the latest completed audit run for (processId, fileId) from the
   // server and hydrate `currentAuditResult` from it. Used when the user
@@ -251,6 +251,29 @@ function mapApiAuditToResult(
 
 async function mapApiFileToWorkbookFile(file: ApiFileSummary): Promise<WorkbookFile> {
   const rawData = (await getWorkbookRawData(file.id)) ?? {};
+  // Re-derive sheet statuses from local rawData when available so that parser
+  // improvements (e.g. threshold fixes) take effect without a re-upload.
+  // Preserve the user's per-sheet isSelected choice from the API.
+  const hasRawData = Object.keys(rawData).length > 0;
+  const freshSheets = hasRawData ? detectWorkbookSheets(rawData) : null;
+  const apiSheetMap = new Map(file.sheets.map((s) => [s.name, s]));
+  const sheets = (freshSheets ?? file.sheets.map((sheet) => ({
+    name: sheet.name,
+    status: sheet.status,
+    rowCount: sheet.rowCount,
+    isSelected: sheet.isSelected,
+    ...(sheet.headerRowIndex !== null ? { headerRowIndex: sheet.headerRowIndex } : {}),
+    ...(sheet.originalHeaders !== undefined ? { originalHeaders: sheet.originalHeaders } : {}),
+    ...(sheet.normalizedHeaders !== undefined ? { normalizedHeaders: sheet.normalizedHeaders } : {}),
+  }))).map((sheet) => {
+    if (!freshSheets) return sheet;
+    const api = apiSheetMap.get(sheet.name);
+    return {
+      ...sheet,
+      // For newly-valid sheets preserve prior selection; invalid sheets deselect.
+      isSelected: sheet.status === 'valid' ? (api?.isSelected ?? true) : false,
+    };
+  });
   return {
     id: file.id,
     displayCode: file.displayCode,
@@ -265,15 +288,7 @@ async function mapApiFileToWorkbookFile(file: ApiFileSummary): Promise<WorkbookF
     serverBacked: true,
     sizeBytes: file.sizeBytes,
     mimeType: file.mimeType,
-    sheets: file.sheets.map((sheet) => ({
-      name: sheet.name,
-      status: sheet.status,
-      rowCount: sheet.rowCount,
-      isSelected: sheet.isSelected,
-      ...(sheet.headerRowIndex !== null ? { headerRowIndex: sheet.headerRowIndex } : {}),
-      ...(sheet.originalHeaders !== undefined ? { originalHeaders: sheet.originalHeaders } : {}),
-      ...(sheet.normalizedHeaders !== undefined ? { normalizedHeaders: sheet.normalizedHeaders } : {}),
-    })),
+    sheets,
     rawData,
   };
 }
@@ -319,6 +334,9 @@ export const useAppStore = create<AppStore>()(
       hydrateFunctionWorkspace: async (processId, functionId) => {
         const process = get().processes.find((item) => item.id === processId || item.displayCode === processId);
         if (!process) return;
+        // Clear any stale result from a previous function so the results tab
+        // never shows another function's audit while the new workspace loads.
+        set({ currentAuditResult: null });
         const processRef = process.displayCode ?? process.id;
         const [apiFiles, draft] = await Promise.all([
           listFilesOnApi(processRef, functionId),
@@ -550,7 +568,16 @@ export const useAppStore = create<AppStore>()(
           currentAuditResult: state.currentAuditResult?.fileId === fileId ? null : state.currentAuditResult,
           processes: patchProcess(state.processes, processId, (process) => {
             const files = process.files.filter((file) => file.id !== fileId);
-            return { ...process, files, activeFileId: process.activeFileId === fileId ? files[0]?.id ?? null : process.activeFileId, updatedAt: new Date().toISOString() };
+            const updated: AuditProcess = {
+              ...process,
+              files,
+              activeFileId: process.activeFileId === fileId ? files[0]?.id ?? null : process.activeFileId,
+              updatedAt: new Date().toISOString(),
+            };
+            if (process.latestAuditResult?.fileId === fileId) {
+              delete updated.latestAuditResult;
+            }
+            return updated;
           }),
         }));
       },
@@ -594,12 +621,14 @@ export const useAppStore = create<AppStore>()(
         return [...(process?.versions ?? [])].reverse().find((version) => version.result.fileId === fileId)?.result ?? null;
       },
 
-      runAudit: async (processId, fileId) => {
+      runAudit: async (processId, fileId, runOptions) => {
         const process = get().processes.find((item) => item.id === processId);
         const file = process?.files.find((item) => item.id === fileId);
         if (!process || !file) return;
         const selected = file.sheets.filter((sheet) => sheet.status === 'valid' && sheet.isSelected);
-        if (!selected.length) return;
+        if (!selected.length) {
+          return;
+        }
 
         // Claim this run with a fresh key. Any earlier in-flight run with
         // a different key will refuse to commit its result at the end.
@@ -652,7 +681,7 @@ export const useAppStore = create<AppStore>()(
 
         try {
           if (useServer) {
-            const apiResult = await runAuditOnApi(process.displayCode!, fileDisplayCode!);
+            const apiResult = await runAuditOnApi(process.displayCode!, fileDisplayCode!, runOptions);
             const apiIssues = await fetchAuditIssues(apiResult.displayCode);
             if (!stillActive()) return;
             const mapped = mapApiAuditToResult(file.id, apiResult, apiIssues);

--- a/docs/AUDIT_ENGINE_REWORK.md
+++ b/docs/AUDIT_ENGINE_REWORK.md
@@ -33,7 +33,7 @@ This document prioritises the fixes and defines what we throw away.
 | Function            | Today                                                | Truth            |
 | ------------------- | ---------------------------------------------------- | ---------------- |
 | master-data         | Dedicated engine, 10 required-field rules + Others   | Real             |
-| over-planning       | Wraps legacy `runAudit()` (effort rules)             | Legacy           |
+| over-planning       | Dedicated engine, `RUL-OP-MONTH-PD-HIGH` rule        | Real             |
 | missing-plan        | Dedicated engine, `RUL-MP-EFFORT-ZERO` rule          | Real             |
 | function-rate       | Wraps legacy `runAudit()`                            | Placeholder      |
 | internal-cost-rate  | Wraps legacy `runAudit()`                            | Placeholder      |
@@ -428,3 +428,70 @@ missingPlanAuditEngine.run()
 No new escalation mechanism was added. The `EmptyPolicy` slice for
 `missing-plan` in `policies.ts` remains correct — this engine has no
 configurable thresholds.
+
+---
+
+## Section 8 — Over-Planning Engine (shipped 2026-04-23)
+
+### Behaviour
+
+The dedicated `overPlanningAuditEngine` detects dynamic monthly **Effort PD**
+columns and flags projects where any month's PD value **strictly exceeds**
+`pdThreshold` (default **30**).
+
+### Column detection
+
+`detectPdColumns(rawRows)` uses two strategies and returns whichever finds
+more PD columns:
+
+- **Strategy A (single-row):** scans each header row (up to first 3) for
+  cells that satisfy `isPdColumn`. A column is a PD column if it contains
+  `\bpd\b` AND a month name (short or long), a numeric month (`01`–`12`),
+  or a 4-digit year.
+- **Strategy B (two-row merge):** for consecutive row pairs `(i, i+1)`,
+  concatenates cells column-by-column and checks if the merged label is a
+  PD column (handles `"Effort PD"` + `"Mar 2025"` split-header layouts).
+
+### Rule
+
+`RUL-OP-MONTH-PD-HIGH` — **High** / **Overplanning**
+
+`reason` string: `"<column>: <value> PD exceeds threshold of <N> PD."`
+
+The 7 legacy `RUL-EFFORT-*`, `RUL-MGR-*`, `RUL-STATE-*` rules are retained
+in `OVER_PLANNING_ENGINE_RULE_CATALOG` for DB FK integrity; the new engine
+never emits them.
+
+### Policy
+
+`pdThreshold?: number` added to `AuditPolicy` (default **30** in
+`createDefaultAuditPolicy`). Passed to the engine via the standard
+`resolveFunctionPolicy` path.
+
+### Mapping source (optional, over-planning only)
+
+`RunAuditDto.mappingSource` (`MappingSourceDto`) accepts:
+
+| `type`                | Behaviour                                                    |
+| --------------------- | ------------------------------------------------------------ |
+| `none`                | Skip; fall through to Manager Directory (default)            |
+| `master_data_version` | Read completed master-data run's issues for manager→email    |
+| `uploaded_file`       | Read another uploaded over-planning file for manager→email   |
+
+Guard: `uploadId === auditFileId` → `BadRequestException`. Emails resolved
+from the mapping source are stamped on issues **before**
+`resolveIssueEmailsFromDirectory` runs, so the directory acts as a fallback.
+
+`allowUnresolvedFallback` (default `true`): when `false`, unresolved names
+are surfaced in `summary.overplanning.unresolvedManagerNames` but issues are
+still created (non-blocking).
+
+### Escalation reuse
+
+Same `resolveIssueEmailsFromDirectory → reconcileAfterAudit` pipeline as
+every other engine. No new mechanism was added.
+
+### Non-regression guarantee
+
+The master-data engine, all `RUL-MD-*` rules, and the missing-plan engine
+are **unchanged** by this change.

--- a/packages/domain/src/auditPolicy.ts
+++ b/packages/domain/src/auditPolicy.ts
@@ -14,6 +14,7 @@ export function createDefaultAuditPolicy(now = new Date().toISOString()): AuditP
     inPlanningEffortEnabled: true,
     onHoldEffortEnabled: true,
     onHoldEffortThreshold: 200,
+    pdThreshold: 30,
     updatedAt: now,
   };
 }

--- a/packages/domain/src/auditRules.ts
+++ b/packages/domain/src/auditRules.ts
@@ -2,6 +2,7 @@ import type { IssueCategory, Severity } from './types';
 import type { FunctionId } from './functions';
 import { MASTER_DATA_RULE_CATALOG } from './functions-audit/master-data/rules';
 import { MISSING_PLAN_RULE_CATALOG } from './functions-audit/missing-plan/rules';
+import { OVER_PLANNING_ENGINE_RULE_CATALOG as OVER_PLANNING_RULE_CATALOG_IMPORT } from './functions-audit/over-planning/rules';
 
 export interface RuleCatalogEntry {
   ruleCode: string;
@@ -20,82 +21,8 @@ export interface RuleCatalogEntry {
   paramsSchema: Record<string, unknown>;
 }
 
-export const OVER_PLANNING_RULE_CATALOG: RuleCatalogEntry[] = [
-  {
-    ruleCode: 'RUL-EFFORT-OVERPLAN-HIGH',
-    name: 'Overplanned effort',
-    category: 'Overplanning',
-    defaultSeverity: 'High',
-    description: 'Effort exceeds the configured overplanning threshold.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: { highEffortThreshold: { type: 'number' } }, required: ['highEffortThreshold'] },
-  },
-  {
-    ruleCode: 'RUL-EFFORT-OVERPLAN-LOW',
-    name: 'Low effort range',
-    category: 'Effort Threshold',
-    defaultSeverity: 'Low',
-    description: 'Effort falls inside the low tracking range.',
-    version: 1,
-    isEnabledDefault: false,
-    paramsSchema: {
-      type: 'object',
-      properties: { lowEffortMin: { type: 'number' }, lowEffortMax: { type: 'number' } },
-      required: ['lowEffortMin', 'lowEffortMax'],
-    },
-  },
-  {
-    ruleCode: 'RUL-EFFORT-MISSING',
-    name: 'Missing effort',
-    category: 'Missing Planning',
-    defaultSeverity: 'High',
-    description: 'Active project has no effort value.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
-  },
-  {
-    ruleCode: 'RUL-EFFORT-ZERO',
-    name: 'Zero effort',
-    category: 'Missing Planning',
-    defaultSeverity: 'Medium',
-    description: 'Effort is explicitly zero.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
-  },
-  {
-    ruleCode: 'RUL-MGR-MISSING',
-    name: 'Missing project manager',
-    category: 'Missing Data',
-    defaultSeverity: 'High',
-    description: 'No project manager is assigned.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
-  },
-  {
-    ruleCode: 'RUL-STATE-ONHOLD-EFFORT',
-    name: 'On Hold with effort',
-    category: 'Planning Risk',
-    defaultSeverity: 'High',
-    description: 'Project is On Hold while still carrying effort.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: { onHoldEffortThreshold: { type: 'number' } }, required: ['onHoldEffortThreshold'] },
-  },
-  {
-    ruleCode: 'RUL-STATE-INPLAN-EFFORT',
-    name: 'In Planning with effort',
-    category: 'Planning Risk',
-    defaultSeverity: 'Medium',
-    description: 'Project is in planning while already carrying effort.',
-    version: 1,
-    isEnabledDefault: true,
-    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
-  },
-];
+// Sourced from the dedicated over-planning module so there is one source of truth.
+export const OVER_PLANNING_RULE_CATALOG: RuleCatalogEntry[] = OVER_PLANNING_RULE_CATALOG_IMPORT;
 
 // Per-function rule catalog. Every rule must live under exactly one function
 // key — this is the structural guarantee the product needs: Master Data

--- a/packages/domain/src/functions-audit/index.ts
+++ b/packages/domain/src/functions-audit/index.ts
@@ -2,6 +2,7 @@ import type { AuditPolicy, AuditResult, WorkbookFile } from '../types';
 import { FUNCTION_IDS, type FunctionId } from '../functions';
 import { masterDataAuditEngine } from './master-data';
 import { missingPlanAuditEngine } from './missing-plan';
+import { overPlanningAuditEngine } from './over-planning';
 import { createLegacyEngine } from './legacy-engine';
 import type { FunctionAuditEngine, FunctionAuditOptions } from './types';
 
@@ -9,7 +10,7 @@ import type { FunctionAuditEngine, FunctionAuditOptions } from './types';
 // mix them. To swap an engine for a function, register the new one here.
 export const FUNCTION_AUDIT_ENGINES: Record<FunctionId, FunctionAuditEngine> = {
   'master-data': masterDataAuditEngine,
-  'over-planning': createLegacyEngine('over-planning'),
+  'over-planning': overPlanningAuditEngine,
   'missing-plan': missingPlanAuditEngine,
   'function-rate': createLegacyEngine('function-rate'),
   'internal-cost-rate': createLegacyEngine('internal-cost-rate'),
@@ -51,8 +52,17 @@ export {
   MISSING_PLAN_RULE_CATALOG,
   MISSING_PLAN_RULES_BY_CODE,
   MP_EFFORT_ZERO_RULE_CODE,
+  MP_EFFORT_MISSING_RULE_CODE,
   MP_EFFORT_ALIASES,
 } from './missing-plan';
+export {
+  OVER_PLANNING_ENGINE_RULE_CATALOG,
+  OVER_PLANNING_RULES_BY_CODE,
+  OP_MONTH_PD_HIGH_RULE_CODE,
+  detectPdColumns,
+  isPdColumn,
+  DEFAULT_PD_THRESHOLD,
+} from './over-planning';
 export {
   normalizeProcessPolicies,
   createDefaultProcessPolicies,

--- a/packages/domain/src/functions-audit/missing-plan/engine.ts
+++ b/packages/domain/src/functions-audit/missing-plan/engine.ts
@@ -1,5 +1,5 @@
 import { createIssueKey } from '../../auditEngine';
-import type { AuditIssue, AuditResult, WorkbookFile } from '../../types';
+import type { AuditIssue, AuditPolicy, AuditResult, WorkbookFile } from '../../types';
 import type { FunctionAuditEngine, FunctionAuditOptions, RowObject } from '../types';
 import {
   MP_EFFORT_ALIASES,
@@ -11,7 +11,7 @@ import {
   readCell,
   readEffortValue,
 } from './columns';
-import { MISSING_PLAN_RULES_BY_CODE, MP_EFFORT_ZERO_RULE_CODE } from './rules';
+import { MISSING_PLAN_RULES_BY_CODE, MP_EFFORT_MISSING_RULE_CODE, MP_EFFORT_ZERO_RULE_CODE } from './rules';
 
 function isBlankRow(row: unknown[]): boolean {
   return row.every((cell) => String(cell ?? '').trim() === '');
@@ -60,12 +60,15 @@ function pushIssue(
     sheetName: string;
     rowIndex: number;
     row: RowObject;
-    effortValue: number;
+    effortValue: number | null;
+    ruleCode: string;
+    reason: string;
+    thresholdLabel: string;
     options: FunctionAuditOptions;
   },
 ): void {
-  const { file, sheetName, rowIndex, row, effortValue, options } = args;
-  const rule = MISSING_PLAN_RULES_BY_CODE.get(MP_EFFORT_ZERO_RULE_CODE);
+  const { file, sheetName, rowIndex, row, effortValue, ruleCode, reason, thresholdLabel, options } = args;
+  const rule = MISSING_PLAN_RULES_BY_CODE.get(ruleCode);
   if (!rule) return;
 
   const projectNo = textValue(row, MP_PROJECT_NO_ALIASES, `Row ${rowIndex + 1}`);
@@ -74,17 +77,15 @@ function pushIssue(
   const projectState = textValue(row, MP_STATE_ALIASES, 'Unknown');
   const email = textValue(row, MP_EMAIL_ALIASES, '');
 
-  const reason = `Effort (H) is 0 — no planned effort recorded for this project.`;
-
   issues.push({
-    id: `${file.id}-${sheetName}-${rowIndex}-${MP_EFFORT_ZERO_RULE_CODE}`,
+    id: `${file.id}-${sheetName}-${rowIndex}-${ruleCode}`,
     ...(options.issueScope
       ? {
           issueKey: createIssueKey(options.issueScope, {
             projectNo,
             sheetName,
             rowIndex,
-            ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+            ruleCode,
           }),
         }
       : {}),
@@ -94,19 +95,19 @@ function pushIssue(
     severity: rule.defaultSeverity,
     projectManager,
     projectState,
-    effort: effortValue,
-    auditStatus: MP_EFFORT_ZERO_RULE_CODE,
+    effort: effortValue ?? 0,
+    auditStatus: ruleCode,
     notes: reason,
     rowIndex,
     email,
-    ruleId: MP_EFFORT_ZERO_RULE_CODE,
-    ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+    ruleId: ruleCode,
+    ruleCode,
     ruleVersion: rule.version,
     ruleName: rule.name,
     auditRunCode: options.runCode,
     category: rule.category,
     reason,
-    thresholdLabel: '= 0',
+    thresholdLabel,
     recommendedAction:
       'Enter the planned effort hours for this project in the source system and re-run the audit.',
   });
@@ -119,17 +120,36 @@ function auditRow(args: {
   row: RowObject;
   options: FunctionAuditOptions;
   issues: AuditIssue[];
+  zeroEffortEnabled: boolean;
+  missingEffortEnabled: boolean;
 }): boolean {
-  const { file, sheetName, rowIndex, row, options, issues } = args;
+  const { file, sheetName, rowIndex, row, options, issues, zeroEffortEnabled, missingEffortEnabled } = args;
   const effortValue = readEffortValue(row, MP_EFFORT_ALIASES);
 
-  // Blank / non-numeric cells are not flagged — they indicate the effort
-  // column is simply absent or not yet entered, which is a different concern
-  // from a deliberate zero entry.
-  if (effortValue === null) return false;
+  if (effortValue === null) {
+    if (missingEffortEnabled) {
+      pushIssue(issues, {
+        file, sheetName, rowIndex, row,
+        effortValue: null,
+        ruleCode: MP_EFFORT_MISSING_RULE_CODE,
+        reason: 'Effort (H) is absent — no planned effort recorded for this project.',
+        thresholdLabel: 'missing',
+        options,
+      });
+      return true;
+    }
+    return false;
+  }
 
-  if (effortValue === 0) {
-    pushIssue(issues, { file, sheetName, rowIndex, row, effortValue, options });
+  if (effortValue === 0 && zeroEffortEnabled) {
+    pushIssue(issues, {
+      file, sheetName, rowIndex, row,
+      effortValue,
+      ruleCode: MP_EFFORT_ZERO_RULE_CODE,
+      reason: 'Effort (H) is 0 — no planned effort recorded for this project.',
+      thresholdLabel: '= 0',
+      options,
+    });
     return true;
   }
 
@@ -138,7 +158,12 @@ function auditRow(args: {
 
 export const missingPlanAuditEngine: FunctionAuditEngine = {
   functionId: 'missing-plan',
-  run(file, _policy, options) {
+  run(file, policy, options) {
+    // Cast the generic AuditPolicy to read the toggles that control this engine.
+    const p = policy as AuditPolicy | undefined;
+    const zeroEffortEnabled = p?.zeroEffortEnabled !== false;
+    const missingEffortEnabled = p?.missingEffortEnabled !== false;
+
     const issues: AuditIssue[] = [];
     const sheetResults = file.sheets
       .filter((sheet) => sheet.status === 'valid' && sheet.isSelected)
@@ -157,6 +182,8 @@ export const missingPlanAuditEngine: FunctionAuditEngine = {
             row,
             options,
             issues,
+            zeroEffortEnabled,
+            missingEffortEnabled,
           });
           if (flagged) flaggedCount += 1;
         });

--- a/packages/domain/src/functions-audit/missing-plan/index.ts
+++ b/packages/domain/src/functions-audit/missing-plan/index.ts
@@ -3,5 +3,6 @@ export {
   MISSING_PLAN_RULE_CATALOG,
   MISSING_PLAN_RULES_BY_CODE,
   MP_EFFORT_ZERO_RULE_CODE,
+  MP_EFFORT_MISSING_RULE_CODE,
 } from './rules';
 export { MP_EFFORT_ALIASES } from './columns';

--- a/packages/domain/src/functions-audit/missing-plan/rules.ts
+++ b/packages/domain/src/functions-audit/missing-plan/rules.ts
@@ -6,6 +6,7 @@ import type { RuleCatalogEntry } from '../../auditRules';
 // the missing-plan namespace isolated from over-planning (RUL-EFFORT-*) and
 // master-data (RUL-MD-*) rules.
 export const MP_EFFORT_ZERO_RULE_CODE = 'RUL-MP-EFFORT-ZERO';
+export const MP_EFFORT_MISSING_RULE_CODE = 'RUL-MP-EFFORT-MISSING';
 
 export const MISSING_PLAN_RULE_CATALOG: RuleCatalogEntry[] = [
   {
@@ -19,8 +20,19 @@ export const MISSING_PLAN_RULE_CATALOG: RuleCatalogEntry[] = [
     isEnabledDefault: true,
     paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
   },
+  {
+    ruleCode: MP_EFFORT_MISSING_RULE_CODE,
+    name: 'Missing effort',
+    category: 'Missing Planning',
+    defaultSeverity: 'High',
+    description:
+      'Project has no Effort (H) value recorded. An absent effort entry indicates the project has not been planned.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
 ];
 
-export const MISSING_PLAN_RULES_BY_CODE = new Map(
+export const MISSING_PLAN_RULES_BY_CODE = new Map<string, (typeof MISSING_PLAN_RULE_CATALOG)[number]>(
   MISSING_PLAN_RULE_CATALOG.map((rule) => [rule.ruleCode, rule]),
 );

--- a/packages/domain/src/functions-audit/over-planning/columns.ts
+++ b/packages/domain/src/functions-audit/over-planning/columns.ts
@@ -1,0 +1,148 @@
+import type { RowObject } from '../types';
+
+export const OP_PROJECT_NO_ALIASES: readonly string[] = [
+  'Project No.',
+  'Project No',
+  'Project Number',
+  'projectNo',
+  'Project ID',
+];
+export const OP_PROJECT_NAME_ALIASES: readonly string[] = [
+  'Project',
+  'Project Name',
+  'projectName',
+  'Name',
+];
+export const OP_STATE_ALIASES: readonly string[] = ['Project State', 'projectState', 'State'];
+export const OP_MANAGER_ALIASES: readonly string[] = [
+  'Project Manager',
+  'projectManager',
+  'Manager',
+];
+export const OP_EMAIL_ALIASES: readonly string[] = [
+  'Project Manager Email',
+  'Manager Email',
+  'email',
+  'Email',
+];
+
+export function readCell(row: RowObject, aliases: readonly string[]): unknown {
+  for (const alias of aliases) {
+    if (Object.prototype.hasOwnProperty.call(row, alias)) {
+      const value = row[alias];
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+const MONTH_SHORT = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+const MONTH_LONG = [
+  'january', 'february', 'march', 'april', 'may', 'june', 'july', 'august',
+  'september', 'october', 'november', 'december',
+];
+const ALL_MONTHS = [...MONTH_SHORT, ...MONTH_LONG];
+
+export function normalizeForPdMatch(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// A column is a PD column if it contains the word "pd" AND a month/year indicator.
+// The month indicator can be a short/long month name, a numeric month (01-12), or a 4-digit year.
+export function isPdColumn(header: string): boolean {
+  const n = normalizeForPdMatch(header);
+  if (!/\bpd\b/.test(n)) return false;
+  return (
+    ALL_MONTHS.some((m) => n.includes(m)) ||
+    /\b(0?[1-9]|1[0-2])\b/.test(n) ||
+    /\b(19|20)\d{2}\b/.test(n)
+  );
+}
+
+// Column index + display label for a detected PD column.
+// colIndex is the 0-based column position in the raw rows, used for direct
+// value lookup via rawRows[rowIndex][colIndex] regardless of header key names.
+export interface PdColumnInfo {
+  colIndex: number;
+  label: string;
+}
+
+// Scan rawRows for PD columns using two strategies; return PdColumnInfo[] so
+// the engine can look up values by column index rather than header key name.
+// This correctly handles files where the data header row has blank PD cells
+// (e.g. SAP/SAC exports with a two-row Effort PD / month sub-header).
+//
+// Strategy A: find the single header row (within the first maxHeaderScan rows)
+//   that has the most cells matching isPdColumn.
+//
+// Strategy B: for each consecutive pair (i, i+1), merge cells column-by-column
+//   and check if the merged label matches isPdColumn (handles "Effort PD" +
+//   "Mar 31 2026" two-row layouts).
+//
+// Strategy B is preferred on ties (equal count) because it produces unique,
+// descriptive labels per month rather than repeated generic labels.
+export function detectPdColumns(rawRows: unknown[][], maxHeaderScan = 3): PdColumnInfo[] {
+  if (rawRows.length === 0) return [];
+
+  let bestSingleRow: PdColumnInfo[] = [];
+  let bestSingleCount = 0;
+  let bestMerged: PdColumnInfo[] = [];
+  let bestMergedCount = 0;
+
+  const scanLimit = Math.min(maxHeaderScan, rawRows.length);
+
+  for (let i = 0; i < scanLimit; i++) {
+    const row = rawRows[i] ?? [];
+    const cols: PdColumnInfo[] = [];
+    for (let c = 0; c < row.length; c++) {
+      const h = String(row[c] ?? '').trim();
+      if (isPdColumn(h)) cols.push({ colIndex: c, label: h });
+    }
+    if (cols.length > bestSingleCount) {
+      bestSingleCount = cols.length;
+      bestSingleRow = cols;
+    }
+  }
+
+  for (let i = 0; i < scanLimit - 1 && i + 1 < rawRows.length; i++) {
+    const rowI = rawRows[i] ?? [];
+    const rowI1 = rawRows[i + 1] ?? [];
+    const cols: PdColumnInfo[] = [];
+    for (let c = 0; c < rowI.length; c++) {
+      const top = String(rowI[c] ?? '').trim();
+      const bottom = String(rowI1[c] ?? '').trim();
+      const merged = bottom ? `${top} ${bottom}`.trim() : top;
+      if (isPdColumn(merged)) cols.push({ colIndex: c, label: merged });
+    }
+    if (cols.length > bestMergedCount) {
+      bestMergedCount = cols.length;
+      bestMerged = cols;
+    }
+  }
+
+  // Prefer Strategy B on ties: produces unique month labels vs repeated generic ones.
+  if (bestMergedCount >= bestSingleCount && bestMergedCount > 0) {
+    return bestMerged;
+  }
+  return bestSingleRow;
+}
+
+// Read manager name with First Name + Last Name fallback for files that store
+// the manager identity across two separate columns rather than a single one.
+export function readManagerName(row: RowObject): string {
+  const mgr = readCell(row, OP_MANAGER_ALIASES);
+  if (mgr !== undefined && String(mgr).trim()) return String(mgr).trim();
+  const first = String(readCell(row, ['First Name', 'firstName']) ?? '').trim();
+  const last = String(readCell(row, ['Last Name', 'lastName']) ?? '').trim();
+  return [first, last].filter(Boolean).join(' ');
+}
+
+export function readPdValue(row: RowObject, columnName: string): number | null {
+  const raw = row[columnName];
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'number') return isFinite(raw) ? raw : null;
+  const text = String(raw).trim();
+  if (text === '') return null;
+  const parsed = Number(text);
+  return isFinite(parsed) ? parsed : null;
+}

--- a/packages/domain/src/functions-audit/over-planning/engine.ts
+++ b/packages/domain/src/functions-audit/over-planning/engine.ts
@@ -1,0 +1,204 @@
+import { createIssueKey } from '../../auditEngine';
+import type { AuditIssue, AuditPolicy, AuditResult, WorkbookFile } from '../../types';
+import type { FunctionAuditEngine, FunctionAuditOptions, RowObject } from '../types';
+import {
+  detectPdColumns,
+  OP_EMAIL_ALIASES,
+  OP_MANAGER_ALIASES,
+  OP_PROJECT_NAME_ALIASES,
+  OP_PROJECT_NO_ALIASES,
+  OP_STATE_ALIASES,
+  readCell,
+  readManagerName,
+  type PdColumnInfo,
+} from './columns';
+import { OP_MONTH_PD_HIGH_RULE_CODE, OVER_PLANNING_RULES_BY_CODE } from './rules';
+
+export const DEFAULT_PD_THRESHOLD = 30;
+
+function isBlankRow(row: unknown[]): boolean {
+  return row.every((cell) => String(cell ?? '').trim() === '');
+}
+
+function rowsToObjects(
+  rows: unknown[][],
+  headerRowIndex: number,
+  normalizedHeaders?: string[],
+): Array<{ row: RowObject; rowIndex: number }> {
+  const originalHeaders = (rows[headerRowIndex] ?? []).map((cell) => String(cell ?? '').trim());
+  const headers = normalizedHeaders?.length ? normalizedHeaders : originalHeaders;
+  return rows
+    .slice(headerRowIndex + 1)
+    .map((row, index) => ({ cells: row, rowIndex: headerRowIndex + 1 + index }))
+    .filter(({ cells }) => !isBlankRow(cells))
+    .map(({ cells, rowIndex }) => {
+      const row: RowObject = {};
+      headers.forEach((header, index) => {
+        const originalHeader = originalHeaders[index];
+        const cell = cells[index];
+        const canonicalKey = String(header ?? '').trim();
+        const originalKey = String(originalHeader ?? '').trim();
+        if (canonicalKey && !canonicalKey.startsWith('column') && row[canonicalKey] === undefined) {
+          row[canonicalKey] = cell;
+        }
+        if (originalKey && row[originalKey] === undefined) {
+          row[originalKey] = cell;
+        }
+      });
+      return { row, rowIndex };
+    });
+}
+
+function textValue(row: RowObject, aliases: readonly string[], fallback = ''): string {
+  const raw = readCell(row, aliases);
+  if (raw === null || raw === undefined) return fallback;
+  const text = String(raw).trim();
+  return text || fallback;
+}
+
+function pushIssue(
+  issues: AuditIssue[],
+  args: {
+    file: WorkbookFile;
+    sheetName: string;
+    rowIndex: number;
+    row: RowObject;
+    worstPd: number;
+    worstCol: string;
+    pdThreshold: number;
+    options: FunctionAuditOptions;
+  },
+): void {
+  const { file, sheetName, rowIndex, row, worstPd, worstCol, pdThreshold, options } = args;
+  const rule = OVER_PLANNING_RULES_BY_CODE.get(OP_MONTH_PD_HIGH_RULE_CODE);
+  if (!rule) return;
+
+  const projectNo = textValue(row, OP_PROJECT_NO_ALIASES, `Row ${rowIndex + 1}`);
+  const projectName = textValue(row, OP_PROJECT_NAME_ALIASES, 'Unnamed project');
+  const projectManager = readManagerName(row) || 'Unassigned';
+  const projectState = textValue(row, OP_STATE_ALIASES, 'Unknown');
+  const email = textValue(row, OP_EMAIL_ALIASES, '');
+
+  const reason = `${worstCol}: ${worstPd} PD exceeds threshold of ${pdThreshold} PD.`;
+
+  issues.push({
+    id: `${file.id}-${sheetName}-${rowIndex}-${OP_MONTH_PD_HIGH_RULE_CODE}`,
+    ...(options.issueScope
+      ? {
+          issueKey: createIssueKey(options.issueScope, {
+            projectNo,
+            sheetName,
+            rowIndex,
+            ruleCode: OP_MONTH_PD_HIGH_RULE_CODE,
+          }),
+        }
+      : {}),
+    projectNo,
+    projectName,
+    sheetName,
+    severity: rule.defaultSeverity,
+    projectManager,
+    projectState,
+    effort: worstPd,
+    auditStatus: OP_MONTH_PD_HIGH_RULE_CODE,
+    notes: reason,
+    rowIndex,
+    email,
+    ruleId: OP_MONTH_PD_HIGH_RULE_CODE,
+    ruleCode: OP_MONTH_PD_HIGH_RULE_CODE,
+    ruleVersion: rule.version,
+    ruleName: rule.name,
+    auditRunCode: options.runCode,
+    category: rule.category,
+    reason,
+    thresholdLabel: `>${pdThreshold} PD`,
+    recommendedAction:
+      'Review monthly capacity planning and reduce or redistribute PD for this project.',
+  });
+}
+
+function parsePdRaw(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'number') return isFinite(val) ? val : null;
+  const text = String(val).trim();
+  if (text === '') return null;
+  const parsed = Number(text);
+  return isFinite(parsed) ? parsed : null;
+}
+
+function auditRow(args: {
+  file: WorkbookFile;
+  sheetName: string;
+  rowIndex: number;
+  row: RowObject;
+  rawRows: unknown[][];
+  pdColumns: PdColumnInfo[];
+  pdThreshold: number;
+  options: FunctionAuditOptions;
+  issues: AuditIssue[];
+}): boolean {
+  const { file, sheetName, rowIndex, row, rawRows, pdColumns, pdThreshold, options, issues } = args;
+  if (pdColumns.length === 0) return false;
+
+  let worstPd = -Infinity;
+  let worstCol = '';
+  for (const col of pdColumns) {
+    const pd = parsePdRaw(rawRows[rowIndex]?.[col.colIndex]);
+    if (pd !== null && pd > worstPd) {
+      worstPd = pd;
+      worstCol = col.label;
+    }
+  }
+
+  if (worstPd > pdThreshold) {
+    pushIssue(issues, { file, sheetName, rowIndex, row, worstPd, worstCol, pdThreshold, options });
+    return true;
+  }
+  return false;
+}
+
+export const overPlanningAuditEngine: FunctionAuditEngine = {
+  functionId: 'over-planning',
+  run(file: WorkbookFile, policy: AuditPolicy | undefined, options: FunctionAuditOptions) {
+    const pdThreshold =
+      (policy as (AuditPolicy & { pdThreshold?: number }) | undefined)?.pdThreshold ??
+      DEFAULT_PD_THRESHOLD;
+    const issues: AuditIssue[] = [];
+    const sheetResults = file.sheets
+      .filter((sheet) => sheet.status === 'valid' && sheet.isSelected)
+      .map((sheet) => {
+        const rawRows = file.rawData[sheet.name] ?? [];
+        const pdColumns = detectPdColumns(rawRows);
+        const rows = rowsToObjects(rawRows, sheet.headerRowIndex ?? 0, sheet.normalizedHeaders);
+        let flaggedCount = 0;
+        rows.forEach(({ row, rowIndex }) => {
+          if (
+            auditRow({
+              file,
+              sheetName: sheet.name,
+              rowIndex,
+              row,
+              rawRows,
+              pdColumns,
+              pdThreshold,
+              options,
+              issues,
+            })
+          ) {
+            flaggedCount += 1;
+          }
+        });
+        return { sheetName: sheet.name, rowCount: rows.length, flaggedCount };
+      });
+
+    const result: AuditResult = {
+      fileId: file.id,
+      runAt: new Date().toISOString(),
+      scannedRows: sheetResults.reduce((sum, s) => sum + s.rowCount, 0),
+      flaggedRows: sheetResults.reduce((sum, s) => sum + s.flaggedCount, 0),
+      issues,
+      sheets: sheetResults,
+    };
+    return result;
+  },
+};

--- a/packages/domain/src/functions-audit/over-planning/index.ts
+++ b/packages/domain/src/functions-audit/over-planning/index.ts
@@ -1,0 +1,7 @@
+export { overPlanningAuditEngine, DEFAULT_PD_THRESHOLD } from './engine';
+export {
+  OVER_PLANNING_ENGINE_RULE_CATALOG,
+  OVER_PLANNING_RULES_BY_CODE,
+  OP_MONTH_PD_HIGH_RULE_CODE,
+} from './rules';
+export { detectPdColumns, isPdColumn, normalizeForPdMatch, type PdColumnInfo } from './columns';

--- a/packages/domain/src/functions-audit/over-planning/rules.ts
+++ b/packages/domain/src/functions-audit/over-planning/rules.ts
@@ -1,0 +1,108 @@
+import type { RuleCatalogEntry } from '../../auditRules';
+
+export const OP_MONTH_PD_HIGH_RULE_CODE = 'RUL-OP-MONTH-PD-HIGH';
+
+// The 7 legacy rules are kept verbatim for DB FK integrity — existing AuditIssue
+// rows may reference them. The new engine only produces RUL-OP-MONTH-PD-HIGH.
+export const OVER_PLANNING_ENGINE_RULE_CATALOG: RuleCatalogEntry[] = [
+  {
+    ruleCode: OP_MONTH_PD_HIGH_RULE_CODE,
+    name: 'Monthly PD overplanned',
+    category: 'Overplanning',
+    defaultSeverity: 'High',
+    description: 'A monthly Effort PD column exceeds the configured threshold.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: {
+      type: 'object',
+      properties: { pdThreshold: { type: 'number' } },
+      required: ['pdThreshold'],
+    },
+  },
+  {
+    ruleCode: 'RUL-EFFORT-OVERPLAN-HIGH',
+    name: 'Overplanned effort',
+    category: 'Overplanning',
+    defaultSeverity: 'High',
+    description: 'Effort exceeds the configured overplanning threshold.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: {
+      type: 'object',
+      properties: { highEffortThreshold: { type: 'number' } },
+      required: ['highEffortThreshold'],
+    },
+  },
+  {
+    ruleCode: 'RUL-EFFORT-OVERPLAN-LOW',
+    name: 'Low effort range',
+    category: 'Effort Threshold',
+    defaultSeverity: 'Low',
+    description: 'Effort falls inside the low tracking range.',
+    version: 1,
+    isEnabledDefault: false,
+    paramsSchema: {
+      type: 'object',
+      properties: { lowEffortMin: { type: 'number' }, lowEffortMax: { type: 'number' } },
+      required: ['lowEffortMin', 'lowEffortMax'],
+    },
+  },
+  {
+    ruleCode: 'RUL-EFFORT-MISSING',
+    name: 'Missing effort',
+    category: 'Missing Planning',
+    defaultSeverity: 'High',
+    description: 'Active project has no effort value.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    ruleCode: 'RUL-EFFORT-ZERO',
+    name: 'Zero effort',
+    category: 'Missing Planning',
+    defaultSeverity: 'Medium',
+    description: 'Effort is explicitly zero.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    ruleCode: 'RUL-MGR-MISSING',
+    name: 'Missing project manager',
+    category: 'Missing Data',
+    defaultSeverity: 'High',
+    description: 'No project manager is assigned.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    ruleCode: 'RUL-STATE-ONHOLD-EFFORT',
+    name: 'On Hold with effort',
+    category: 'Planning Risk',
+    defaultSeverity: 'High',
+    description: 'Project is On Hold while still carrying effort.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: {
+      type: 'object',
+      properties: { onHoldEffortThreshold: { type: 'number' } },
+      required: ['onHoldEffortThreshold'],
+    },
+  },
+  {
+    ruleCode: 'RUL-STATE-INPLAN-EFFORT',
+    name: 'In Planning with effort',
+    category: 'Planning Risk',
+    defaultSeverity: 'Medium',
+    description: 'Project is in planning while already carrying effort.',
+    version: 1,
+    isEnabledDefault: true,
+    paramsSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+];
+
+export const OVER_PLANNING_RULES_BY_CODE = new Map(
+  OVER_PLANNING_ENGINE_RULE_CATALOG.map((r) => [r.ruleCode, r]),
+);

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -39,6 +39,8 @@ export interface AuditPolicy {
   inPlanningEffortEnabled: boolean;
   onHoldEffortEnabled: boolean;
   onHoldEffortThreshold: number;
+  /** Per-month PD threshold for the over-planning engine (default 30). */
+  pdThreshold?: number;
   updatedAt: string;
 }
 

--- a/packages/domain/src/workbook.ts
+++ b/packages/domain/src/workbook.ts
@@ -72,7 +72,7 @@ function detectHeader(rows: unknown[][]): HeaderCandidate | null {
     const candidate = rowHeaderScore(row);
     if (!best || candidate.score > best.score) best = { ...candidate, headerRowIndex: index };
   }
-  if (!best || best.score < 5 || !CORE_COLUMNS.some((column) => best.matchedColumns.has(column))) return null;
+  if (!best || best.score < 4 || !CORE_COLUMNS.some((column) => best.matchedColumns.has(column))) return null;
   return best;
 }
 

--- a/packages/domain/test/missing-plan-audit.test.ts
+++ b/packages/domain/test/missing-plan-audit.test.ts
@@ -7,6 +7,7 @@ import {
   getFunctionAuditEngine,
   MP_EFFORT_ALIASES,
   MP_EFFORT_ZERO_RULE_CODE,
+  MP_EFFORT_MISSING_RULE_CODE,
   MISSING_PLAN_RULE_CATALOG,
   runFunctionAudit,
 } from '../src/functions-audit/index.js';
@@ -61,7 +62,7 @@ async function buildWorkbook(
     const projectNoIndex = headers.indexOf('Project No.');
     if (projectNoIndex >= 0) base[projectNoIndex] = `FILL-${i}`;
     const effortIndex = headers.findIndex((h) =>
-      ['Effort (H)', 'Effort H', 'effort', 'hours', 'planned effort'].includes(h.toLowerCase()),
+      ['effort (h)', 'effort h', 'effort', 'hours', 'planned effort'].includes(h.toLowerCase()),
     );
     if (effortIndex >= 0) base[effortIndex] = 40; // non-zero filler so they don't pollute issue counts
     const stateIndex = headers.indexOf('Project State');
@@ -155,20 +156,40 @@ test('does not flag row with effort = 0.5', async () => {
   assert.equal(result.issues.length, 0);
 });
 
-// ─── Blank effort not flagged ────────────────────────────────────────────────
+// ─── Missing effort (blank/absent) flagged when missingEffortEnabled ─────────
 
-test('does not flag row with blank effort cell', async () => {
+test('flags row with blank effort cell (missingEffortEnabled=true by default)', async () => {
   const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': '' })]);
   const result = runFunctionAudit('missing-plan', file, undefined);
 
-  assert.equal(result.issues.length, 0, 'blank effort should not produce a zero-effort finding');
+  assert.equal(result.issues.length, 1, 'blank effort should produce a missing-effort finding');
+  assert.equal(result.issues[0]!.ruleCode, 'RUL-MP-EFFORT-MISSING');
 });
 
-test('does not flag row with undefined effort cell', async () => {
+test('flags row with undefined effort cell (missingEffortEnabled=true by default)', async () => {
   const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': undefined })]);
   const result = runFunctionAudit('missing-plan', file, undefined);
 
-  assert.equal(result.issues.length, 0);
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.ruleCode, 'RUL-MP-EFFORT-MISSING');
+});
+
+test('does NOT flag blank effort when missingEffortEnabled=false', async () => {
+  const { normalizeAuditPolicy } = await import('../src/auditPolicy.js');
+  const policy = normalizeAuditPolicy({ missingEffortEnabled: false });
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': '' })]);
+  const result = runFunctionAudit('missing-plan', file, policy);
+
+  assert.equal(result.issues.length, 0, 'blank effort should NOT be flagged when missingEffortEnabled=false');
+});
+
+test('does NOT flag zero effort when zeroEffortEnabled=false', async () => {
+  const { normalizeAuditPolicy } = await import('../src/auditPolicy.js');
+  const policy = normalizeAuditPolicy({ zeroEffortEnabled: false });
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Effort (H)': 0 })]);
+  const result = runFunctionAudit('missing-plan', file, policy);
+
+  assert.equal(result.issues.length, 0, 'zero effort should NOT be flagged when zeroEffortEnabled=false');
 });
 
 // ─── Engine registration ─────────────────────────────────────────────────────
@@ -257,19 +278,19 @@ test('end-to-end: zero-effort row produces issue with IKY- issueKey', async () =
   assert.equal(issue.effort, 0);
 });
 
-test('end-to-end: mixed rows — only zero-effort rows flagged', async () => {
+test('end-to-end: mixed rows — zero-effort and blank-effort rows flagged', async () => {
   const rows = [
-    makeRow({ 'Project No.': 'P001', 'Effort (H)': 0 }),
-    makeRow({ 'Project No.': 'P002', 'Effort (H)': 100 }),
-    makeRow({ 'Project No.': 'P003', 'Effort (H)': 0 }),
-    makeRow({ 'Project No.': 'P004', 'Effort (H)': 50 }),
-    makeRow({ 'Project No.': 'P005', 'Effort (H)': '' }),
+    makeRow({ 'Project No.': 'P001', 'Effort (H)': 0 }),    // zero → RUL-MP-EFFORT-ZERO
+    makeRow({ 'Project No.': 'P002', 'Effort (H)': 100 }),   // positive → not flagged
+    makeRow({ 'Project No.': 'P003', 'Effort (H)': 0 }),    // zero → RUL-MP-EFFORT-ZERO
+    makeRow({ 'Project No.': 'P004', 'Effort (H)': 50 }),    // positive → not flagged
+    makeRow({ 'Project No.': 'P005', 'Effort (H)': '' }),    // blank → RUL-MP-EFFORT-MISSING
   ];
   const file = await buildWorkbook(BASE_HEADERS, rows);
   const result = runFunctionAudit('missing-plan', file, undefined, { issueScope: 'PRC-TEST' });
 
-  assert.equal(result.flaggedRows, 2, 'only the two zero-effort rows should be flagged');
-  assert.equal(result.issues.length, 2);
+  assert.equal(result.flaggedRows, 3, 'two zero-effort and one blank-effort row should be flagged');
+  assert.equal(result.issues.length, 3);
   const flaggedNos = result.issues.map((i) => i.projectNo).sort();
-  assert.deepEqual(flaggedNos, ['P001', 'P003']);
+  assert.deepEqual(flaggedNos, ['P001', 'P003', 'P005']);
 });

--- a/packages/domain/test/over-planning-audit.test.ts
+++ b/packages/domain/test/over-planning-audit.test.ts
@@ -1,0 +1,268 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ExcelJS from 'exceljs';
+import { parseWorkbook } from '../src/workbook.js';
+import { RULE_CATALOG_BY_FUNCTION, getRuleCatalogForFunction } from '../src/auditRules.js';
+import {
+  DEFAULT_PD_THRESHOLD,
+  detectPdColumns,
+  getFunctionAuditEngine,
+  isPdColumn,
+  OP_MONTH_PD_HIGH_RULE_CODE,
+  OVER_PLANNING_ENGINE_RULE_CATALOG,
+  runFunctionAudit,
+} from '../src/functions-audit/index.js';
+import { normalizeAuditPolicy } from '../src/auditPolicy.js';
+import type { WorkbookFile } from '../src/types.js';
+
+class TestFile extends Blob {
+  name: string;
+  lastModified: number;
+
+  constructor(parts: BlobPart[], name: string) {
+    super(parts);
+    this.name = name;
+    this.lastModified = Date.now();
+  }
+}
+
+// Headers for a valid over-planning workbook. The workbook parser needs at
+// least projectNo + projectManager + projectState + one more to score ≥5.
+// We add PD columns for the engine to detect.
+const BASE_HEADERS = [
+  'Project No.',
+  'Project',
+  'Project State',
+  'Project Manager',
+  'Project Manager Email',
+  'Jan 2025 PD',
+  'Feb 2025 PD',
+  'Mar 2025 PD',
+];
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}): unknown[] {
+  const defaults: Record<string, unknown> = {
+    'Project No.': '90032101',
+    Project: 'Digital Core SAP S4',
+    'Project State': 'Opened',
+    'Project Manager': 'Wagner, Anna',
+    'Project Manager Email': 'anna.wagner@example.com',
+    'Jan 2025 PD': 0,
+    'Feb 2025 PD': 0,
+    'Mar 2025 PD': 0,
+  };
+  const merged = { ...defaults, ...overrides };
+  return BASE_HEADERS.map((h) => merged[h] ?? '');
+}
+
+async function buildWorkbook(
+  headers: string[],
+  dataRows: unknown[][],
+  fileName = 'overplanning.xlsx',
+): Promise<WorkbookFile> {
+  const workbook = new ExcelJS.Workbook();
+  const filler = Array.from({ length: Math.max(0, 5 - dataRows.length) }, (_, i) => {
+    const base = headers.map(() => '');
+    const projectNoIndex = headers.indexOf('Project No.');
+    if (projectNoIndex >= 0) base[projectNoIndex] = `FILL-${i}`;
+    const stateIndex = headers.indexOf('Project State');
+    if (stateIndex >= 0) base[stateIndex] = 'Opened';
+    const mgrIndex = headers.indexOf('Project Manager');
+    if (mgrIndex >= 0) base[mgrIndex] = 'Filler Manager';
+    return base;
+  });
+  workbook.addWorksheet('Effort').addRows([headers, ...dataRows, ...filler]);
+  const buffer = await workbook.xlsx.writeBuffer();
+  return parseWorkbook(new TestFile([buffer], fileName) as File);
+}
+
+// ─── isPdColumn unit tests ─────────────────────────────────────────────────
+
+test('isPdColumn: positive cases', () => {
+  const positives = ['Jan PD', 'Feb 2024 PD', 'PD Jan', 'EFFORT PD March', '2024-01 PD', '03 PD'];
+  for (const header of positives) {
+    assert.ok(isPdColumn(header), `expected "${header}" to be a PD column`);
+  }
+});
+
+test('isPdColumn: negative cases', () => {
+  const negatives = ['Effort (H)', 'Project Manager', 'PD', 'Product Development', 'SPD'];
+  for (const header of negatives) {
+    assert.ok(!isPdColumn(header), `expected "${header}" NOT to be a PD column`);
+  }
+});
+
+// ─── detectPdColumns ────────────────────────────────────────────────────────
+
+test('detectPdColumns: returns only PD columns from a mixed header row', () => {
+  // Single header row — no data row to accidentally merge with.
+  const rawRows = [
+    ['Project No.', 'Project', 'Project Manager', 'Jan 2025 PD', 'Feb 2025 PD', 'Effort (H)'],
+  ];
+  const cols = detectPdColumns(rawRows);
+  const labels = cols.map((c) => c.label);
+  assert.ok(labels.includes('Jan 2025 PD'), 'expected Jan 2025 PD');
+  assert.ok(labels.includes('Feb 2025 PD'), 'expected Feb 2025 PD');
+  assert.ok(!labels.includes('Project No.'), 'expected Project No. excluded');
+  assert.ok(!labels.includes('Effort (H)'), 'expected Effort (H) excluded');
+  assert.equal(cols[0]?.colIndex, 3, 'Jan 2025 PD should be at colIndex 3');
+  assert.equal(cols[1]?.colIndex, 4, 'Feb 2025 PD should be at colIndex 4');
+});
+
+test('detectPdColumns: two-row merge detects "Effort (PD)" + "Mar 31 2026"', () => {
+  const rawRows = [
+    ['Project No.', 'Project', 'Effort (PD)'],
+    ['', '', 'Mar 31 2026'],
+  ];
+  const cols = detectPdColumns(rawRows);
+  assert.ok(cols.length >= 1, `expected at least one PD column detected via two-row merge, got ${cols.length}`);
+  assert.equal(cols[0]?.colIndex, 2, 'merged PD column should be at colIndex 2');
+  assert.match(cols[0]?.label ?? '', /Effort \(PD\).*Mar/i, 'merged label should contain both parts');
+});
+
+// ─── Threshold comparison (strictly greater, not ≥) ──────────────────────
+
+test('flags row when worst PD 31 > threshold 30', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': 31 })]);
+  const result = runFunctionAudit('over-planning', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.equal(result.flaggedRows, 1);
+  assert.equal(result.issues.length, 1);
+  const issue = result.issues[0]!;
+  assert.equal(issue.ruleCode, OP_MONTH_PD_HIGH_RULE_CODE);
+  assert.equal(issue.effort, 31);
+  assert.equal(issue.category, 'Overplanning');
+  assert.equal(issue.severity, 'High');
+});
+
+test('does NOT flag row when worst PD = threshold (30 == 30)', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': 30 })]);
+  const result = runFunctionAudit('over-planning', file, undefined);
+  assert.equal(result.issues.length, 0);
+  assert.equal(result.flaggedRows, 0);
+});
+
+test('does NOT flag row when worst PD 15 < threshold 30', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': 15 })]);
+  const result = runFunctionAudit('over-planning', file, undefined);
+  assert.equal(result.issues.length, 0);
+});
+
+// ─── Blank PD cell ──────────────────────────────────────────────────────────
+
+test('does NOT flag row when all PD cells are blank', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': '', 'Feb 2025 PD': '', 'Mar 2025 PD': '' })]);
+  const result = runFunctionAudit('over-planning', file, undefined);
+  assert.equal(result.issues.length, 0, 'blank PD cells must not produce a finding');
+});
+
+// ─── String coercion ────────────────────────────────────────────────────────
+
+test('coerces string PD "35" and flags it', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': '35' })]);
+  const result = runFunctionAudit('over-planning', file, undefined, { issueScope: 'PRC-TEST' });
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.effort, 35);
+});
+
+// ─── Custom threshold ────────────────────────────────────────────────────────
+
+test('custom pdThreshold=10: PD=15 is flagged', async () => {
+  const policy = normalizeAuditPolicy({ pdThreshold: 10 });
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': 15 })]);
+  const result = runFunctionAudit('over-planning', file, policy, { issueScope: 'PRC-TEST' });
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.effort, 15);
+  assert.match(result.issues[0]!.reason ?? '', /threshold of 10/);
+});
+
+// ─── Multiple PD columns: worst wins ─────────────────────────────────────────
+
+test('worst column name appears in the reason string', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [
+    makeRow({ 'Jan 2025 PD': 20, 'Feb 2025 PD': 45, 'Mar 2025 PD': 10 }),
+  ]);
+  const result = runFunctionAudit('over-planning', file, undefined, { issueScope: 'PRC-TEST' });
+  assert.equal(result.issues.length, 1);
+  assert.equal(result.issues[0]!.effort, 45);
+  assert.match(result.issues[0]!.reason ?? '', /Feb 2025 PD/);
+});
+
+// ─── Rule isolation ─────────────────────────────────────────────────────────
+
+test('RUL-OP-MONTH-PD-HIGH appears only under over-planning in RULE_CATALOG_BY_FUNCTION', () => {
+  const entries = Object.entries(RULE_CATALOG_BY_FUNCTION) as Array<[string, typeof OVER_PLANNING_ENGINE_RULE_CATALOG]>;
+  for (const [functionId, rules] of entries) {
+    if (functionId === 'over-planning') continue;
+    for (const rule of rules) {
+      assert.ok(
+        rule.ruleCode !== OP_MONTH_PD_HIGH_RULE_CODE,
+        `found ${OP_MONTH_PD_HIGH_RULE_CODE} under "${functionId}" — rule codes must be function-owned`,
+      );
+    }
+  }
+});
+
+test('no ruleCode appears in more than one function catalog', () => {
+  const seen = new Map<string, string>();
+  const entries = Object.entries(RULE_CATALOG_BY_FUNCTION) as Array<[string, typeof OVER_PLANNING_ENGINE_RULE_CATALOG]>;
+  for (const [functionId, rules] of entries) {
+    for (const rule of rules) {
+      if (seen.has(rule.ruleCode)) {
+        assert.fail(
+          `ruleCode "${rule.ruleCode}" appears under both "${seen.get(rule.ruleCode)}" and "${functionId}"`,
+        );
+      }
+      seen.set(rule.ruleCode, functionId);
+    }
+  }
+});
+
+// ─── End-to-end with issueKey ─────────────────────────────────────────────────
+
+test('end-to-end: over-planning PD=31 produces issue with IKY- issueKey', async () => {
+  const file = await buildWorkbook(BASE_HEADERS, [makeRow({ 'Jan 2025 PD': 31 })]);
+  const result = runFunctionAudit('over-planning', file, undefined, { issueScope: 'PRC-TEST' });
+
+  assert.equal(result.issues.length, 1);
+  const issue = result.issues[0]!;
+  assert.ok(issue.issueKey, 'issueKey must be present when issueScope is provided');
+  assert.match(issue.issueKey!, /^IKY-/, 'issueKey must start with IKY-');
+  assert.equal(issue.ruleCode, OP_MONTH_PD_HIGH_RULE_CODE);
+  assert.equal(issue.effort, 31);
+  assert.equal(issue.category, 'Overplanning');
+  assert.ok(issue.projectNo, 'projectNo must be populated');
+  assert.ok(issue.projectManager, 'projectManager must be populated');
+  assert.equal(issue.severity, 'High');
+  assert.ok(issue.thresholdLabel?.startsWith('>'), 'thresholdLabel must start with >');
+  assert.ok(issue.recommendedAction, 'recommendedAction must be populated');
+});
+
+// ─── Engine registration ─────────────────────────────────────────────────────
+
+test('over-planning routes to the dedicated engine', () => {
+  const engine = getFunctionAuditEngine('over-planning');
+  assert.equal(engine.functionId, 'over-planning');
+});
+
+test('DEFAULT_PD_THRESHOLD is 30', () => {
+  assert.equal(DEFAULT_PD_THRESHOLD, 30);
+});
+
+test('over-planning catalog contains RUL-OP-MONTH-PD-HIGH and the 7 legacy rules', () => {
+  const catalog = getRuleCatalogForFunction('over-planning');
+  assert.ok(catalog.length >= 8, `expected at least 8 rules, got ${catalog.length}`);
+  const codes = new Set(catalog.map((r) => r.ruleCode));
+  assert.ok(codes.has(OP_MONTH_PD_HIGH_RULE_CODE), 'RUL-OP-MONTH-PD-HIGH must be in catalog');
+  for (const legacyCode of [
+    'RUL-EFFORT-OVERPLAN-HIGH',
+    'RUL-EFFORT-OVERPLAN-LOW',
+    'RUL-EFFORT-MISSING',
+    'RUL-EFFORT-ZERO',
+    'RUL-MGR-MISSING',
+    'RUL-STATE-ONHOLD-EFFORT',
+    'RUL-STATE-INPLAN-EFFORT',
+  ]) {
+    assert.ok(codes.has(legacyCode), `legacy rule ${legacyCode} must be retained for FK integrity`);
+  }
+});


### PR DESCRIPTION
This branch introduces a dedicated Overplanning audit flow that flags projects when monthly Effort (PD) exceeds a configurable threshold (default 30), replacing legacy generic behavior for this function. It adds robust PD column detection (including multi-row headers), function-specific Overplanning settings (threshold-only), and mapping-source support (Master Data version or uploaded mapping file reference) while reusing the existing escalation pipeline. Master Data and Missing Plan engines remain functionally isolated and unaffected.