### PR TITLE
Add email/password signup and login

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
     "prisma:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:e2e": "TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts"
+    "test:e2e": "TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts test/auth.e2e-spec.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.0",
@@ -24,6 +24,7 @@
     "@prisma/client": "^6.8.2",
     "@ses/domain": "file:../../packages/domain",
     "@socket.io/redis-adapter": "^8.3.0",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
@@ -40,6 +41,7 @@
     "ulid": "^3.0.1"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.1",
     "@types/jsonwebtoken": "^9.0.9",

--- a/apps/api/prisma/migrations/20260425120000_add_user_password_hash/migration.sql
+++ b/apps/api/prisma/migrations/20260425120000_add_user_password_hash/migration.sql
@@ -1,0 +1,2 @@
+-- Add password hash column for email/password authentication.
+ALTER TABLE "User" ADD COLUMN "passwordHash" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   email          String            @unique
   displayName    String
   ssoSubject     String?           @unique
+  passwordHash   String?
   role           String            @default("auditor")
   isActive       Boolean           @default(true)
   lastLoginAt    DateTime?

--- a/apps/api/src/auth.controller.ts
+++ b/apps/api/src/auth.controller.ts
@@ -13,12 +13,26 @@ import type { Response } from 'express';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
 import { CurrentUser } from './common/current-user';
-import { DevLoginDto } from './dto/auth.dto';
+import { DevLoginDto, LoginDto, SignupDto } from './dto/auth.dto';
 
 @Controller('auth')
 @SkipThrottle({ default: true })
 export class AuthController {
   constructor(@Inject(AuthService) private readonly authService: AuthService) {}
+
+  @Post('signup')
+  @SkipThrottle({ default: false })
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  async signup(@Body() body: SignupDto, @Res({ passthrough: true }) response: Response) {
+    return { user: await this.authService.signup(response, body) };
+  }
+
+  @Post('login')
+  @SkipThrottle({ default: false })
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  async login(@Body() body: LoginDto, @Res({ passthrough: true }) response: Response) {
+    return { user: await this.authService.login(response, body) };
+  }
 
   @Post('dev-login')
   @SkipThrottle({ default: false })
@@ -41,11 +55,6 @@ export class AuthController {
   @UseGuards(AuthGuard)
   me(@CurrentUser() user: unknown) {
     return { user };
-  }
-
-  @Post('login')
-  loginStub() {
-    return { ok: false, message: 'OIDC login is not configured in this environment. Use /auth/dev-login for Phase 1.' };
   }
 
   @Get('callback')

--- a/apps/api/src/auth.service.ts
+++ b/apps/api/src/auth.service.ts
@@ -1,4 +1,6 @@
 import {
+  BadRequestException,
+  ConflictException,
   ForbiddenException,
   Inject,
   Injectable,
@@ -6,13 +8,15 @@ import {
   OnModuleInit,
   UnauthorizedException,
 } from '@nestjs/common';
+import bcrypt from 'bcryptjs';
 import type { Request, Response } from 'express';
 import jwt, { type JwtPayload } from 'jsonwebtoken';
 import type { SessionUser } from '@ses/domain';
-import { tenantManagerDirectoryEnabled } from '@ses/domain';
+import { createId, tenantManagerDirectoryEnabled } from '@ses/domain';
 import { DEFAULT_TENANT_ID } from './common/default-tenant';
 import { PrismaService } from './common/prisma.service';
 import { requestContext } from './common/request-context';
+import type { LoginDto, SignupDto } from './dto/auth.dto';
 
 type TokenPayload = {
   sub: string;
@@ -55,7 +59,6 @@ export class AuthService implements OnModuleInit {
 
   private async resolveSessionTenantContext(
     userId: string,
-    role: SessionUser['role'],
   ): Promise<{ tenantId: string; tenantDisplayCode: string; managerDirectoryEnabled: boolean }> {
     const member = await this.prisma.processMember.findFirst({
       where: { userId },
@@ -70,18 +73,18 @@ export class AuthService implements OnModuleInit {
         managerDirectoryEnabled: tenantManagerDirectoryEnabled(null),
       };
     }
-    if (role === 'admin') {
-      const t = await this.prisma.tenant.findUnique({ where: { id: DEFAULT_TENANT_ID } });
-      if (!t) {
-        throw new UnauthorizedException('Default tenant is not provisioned');
-      }
-      return {
-        tenantId: t.id,
-        tenantDisplayCode: t.name,
-        managerDirectoryEnabled: tenantManagerDirectoryEnabled(null),
-      };
+    // Fallback to the default tenant for any role without a process membership.
+    // Per-process authorization is enforced separately by processMember lookups,
+    // so this fallback only governs initial tenant binding for fresh accounts.
+    const t = await this.prisma.tenant.findUnique({ where: { id: DEFAULT_TENANT_ID } });
+    if (!t) {
+      throw new InternalServerErrorException('Default tenant is not provisioned');
     }
-    throw new ForbiddenException('No process membership; cannot resolve tenant');
+    return {
+      tenantId: t.id,
+      tenantDisplayCode: t.name,
+      managerDirectoryEnabled: tenantManagerDirectoryEnabled(null),
+    };
   }
 
   private async buildSessionUser(user: {
@@ -92,7 +95,7 @@ export class AuthService implements OnModuleInit {
     role: string;
   }): Promise<SessionUser> {
     const role = (user.role as SessionUser['role']) || 'auditor';
-    const ctx = await this.resolveSessionTenantContext(user.id, role);
+    const ctx = await this.resolveSessionTenantContext(user.id);
     return {
       id: user.id,
       displayCode: user.displayCode,
@@ -200,6 +203,74 @@ export class AuthService implements OnModuleInit {
       role: (user.role as TokenPayload['role']) || 'auditor',
     };
     const token = this.sign(payload);
+    this.setCookie(response, token);
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+    requestContext.setUser({ userId: user.id, userCode: user.displayCode, userEmail: user.email });
+    return await this.buildSessionUser(user);
+  }
+
+  async signup(response: Response, payload: SignupDto): Promise<SessionUser> {
+    const email = payload.email.trim().toLowerCase();
+    const role = payload.role;
+    if (role !== 'admin' && role !== 'auditor') {
+      throw new BadRequestException('Invalid role');
+    }
+    const existing = await this.prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      throw new ConflictException('Email already registered');
+    }
+    const passwordHash = await bcrypt.hash(payload.password, 10);
+    const id = createId();
+    const displayCode = `USR-${createId().slice(-8).toUpperCase()}`;
+    const user = await this.prisma.user.create({
+      data: {
+        id,
+        displayCode,
+        email,
+        displayName: payload.displayName.trim(),
+        role,
+        passwordHash,
+        isActive: true,
+        lastLoginAt: new Date(),
+      },
+    });
+    const token = this.sign({
+      sub: user.id,
+      displayCode: user.displayCode,
+      email: user.email,
+      displayName: user.displayName,
+      role: (user.role as TokenPayload['role']) || 'auditor',
+    });
+    this.setCookie(response, token);
+    requestContext.setUser({ userId: user.id, userCode: user.displayCode, userEmail: user.email });
+    return await this.buildSessionUser(user);
+  }
+
+  async login(response: Response, payload: LoginDto): Promise<SessionUser> {
+    const email = payload.email.trim().toLowerCase();
+    const user = await this.prisma.user.findFirst({
+      where: { email, isActive: true },
+    });
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+    if (!user.passwordHash) {
+      throw new UnauthorizedException('Password login not enabled for this account');
+    }
+    const ok = await bcrypt.compare(payload.password, user.passwordHash);
+    if (!ok) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+    const token = this.sign({
+      sub: user.id,
+      displayCode: user.displayCode,
+      email: user.email,
+      displayName: user.displayName,
+      role: (user.role as TokenPayload['role']) || 'auditor',
+    });
     this.setCookie(response, token);
     await this.prisma.user.update({
       where: { id: user.id },

--- a/apps/api/src/dto/auth.dto.ts
+++ b/apps/api/src/dto/auth.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsEmail, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class DevLoginDto {
   @IsOptional()
@@ -18,4 +18,34 @@ export class DevLoginDto {
   @MinLength(1)
   @MaxLength(64)
   displayCode?: string;
+}
+
+export class SignupDto {
+  @IsEmail()
+  @MaxLength(320)
+  email!: string;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(120)
+  displayName!: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(200)
+  password!: string;
+
+  @IsIn(['admin', 'auditor'])
+  role!: 'admin' | 'auditor';
+}
+
+export class LoginDto {
+  @IsEmail()
+  @MaxLength(320)
+  email!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  password!: string;
 }

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -1,0 +1,153 @@
+import 'reflect-metadata';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import '../src/load-env';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { createRequestId, requestContext } from '../src/common/request-context';
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+async function createApp(): Promise<INestApplication> {
+  process.env.SES_ALLOW_DEV_LOGIN = 'true';
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+  const app = await NestFactory.create(AppModule, { logger: false });
+  app.use(cookieParser(process.env.SES_AUTH_SECRET || 'ses-dev-secret'));
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const requestId = createRequestId(req.headers['x-request-id']);
+    res.setHeader('X-Request-ID', requestId);
+    requestContext.run({ requestId }, next);
+  });
+  app.setGlobalPrefix('api/v1');
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
+  await app.init();
+  return app;
+}
+
+function uniqueEmail(label: string): string {
+  return `e2e-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@ses.test`;
+}
+
+type SignedUpUser = { id: string; email: string; displayName: string; role: string; tenantId: string };
+
+describe('auth API e2e', { skip: !hasDb }, () => {
+  let app: INestApplication;
+
+  before(async () => {
+    app = await createApp();
+  });
+
+  after(async () => {
+    await app?.close();
+  });
+
+  it('signup success → returns user and sets ses_auth cookie', async () => {
+    const email = uniqueEmail('signup-ok');
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'Signup OK', password: 'pw12345678', role: 'auditor' })
+      .expect(201);
+    const user = (res.body as { user: SignedUpUser }).user;
+    assert.ok(user.id);
+    assert.equal(user.email, email);
+    assert.equal(user.role, 'auditor');
+    assert.ok(user.tenantId, 'tenantId should be populated for memberless signup');
+    const setCookie = res.headers['set-cookie'];
+    const cookieHeader = Array.isArray(setCookie) ? setCookie.join(';') : String(setCookie ?? '');
+    assert.match(cookieHeader, /ses_auth=/);
+  });
+
+  it('signup duplicate email → 409', async () => {
+    const email = uniqueEmail('dup');
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'First', password: 'pw12345678', role: 'auditor' })
+      .expect(201);
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'Second', password: 'pw12345678', role: 'auditor' })
+      .expect(409);
+  });
+
+  it('signup with invalid role → 400', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email: uniqueEmail('viewer'), displayName: 'No', password: 'pw12345678', role: 'viewer' })
+      .expect(400);
+  });
+
+  it('signup with short password → 400', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email: uniqueEmail('short'), displayName: 'Short', password: 'short', role: 'auditor' })
+      .expect(400);
+  });
+
+  it('login with correct credentials → 201, returns user', async () => {
+    const email = uniqueEmail('login-ok');
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'Login OK', password: 'pw12345678', role: 'auditor' })
+      .expect(201);
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'pw12345678' })
+      .expect(201);
+    const user = (res.body as { user: SignedUpUser }).user;
+    assert.equal(user.email, email);
+  });
+
+  it('login with wrong password → 401', async () => {
+    const email = uniqueEmail('wrong-pw');
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'Wrong PW', password: 'pw12345678', role: 'auditor' })
+      .expect(201);
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'not-the-password' })
+      .expect(401);
+  });
+
+  it('login with unknown email → 401', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email: uniqueEmail('unknown'), password: 'pw12345678' })
+      .expect(401);
+  });
+
+  it('round-trip: signup → logout → login → /auth/me with no memberships', async () => {
+    const email = uniqueEmail('round-trip');
+    const agent = request.agent(app.getHttpServer());
+    const signupRes = await agent
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: 'Round Trip', password: 'pw12345678', role: 'auditor' })
+      .expect(201);
+    const signupUserId = (signupRes.body as { user: SignedUpUser }).user.id;
+
+    await agent.post('/api/v1/auth/logout').expect(201);
+
+    await agent
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'pw12345678' })
+      .expect(201);
+
+    const meRes = await agent.get('/api/v1/auth/me').expect(200);
+    const meUser = (meRes.body as { user: SignedUpUser }).user;
+    assert.equal(meUser.id, signupUserId);
+    assert.ok(meUser.tenantId);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import { PageHeaderProvider } from './components/layout/PageHeaderContext';
 import { Dashboard } from './pages/Dashboard';
 import { Debug } from './pages/Debug';
 import { Login } from './pages/Login';
+import { Signup } from './pages/Signup';
 import { ManagerResponse } from './pages/ManagerResponse';
 import { AdminDirectory } from './pages/AdminDirectory';
 import { EscalationCenter } from './pages/EscalationCenter';
@@ -129,6 +130,7 @@ function buildRouter() {
     createRoutesFromElements(
       <>
         <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
         <Route path="/respond/:token" element={<ManagerResponse />} />
         <Route
           path="/admin/templates"

--- a/apps/web/src/lib/api/authApi.ts
+++ b/apps/web/src/lib/api/authApi.ts
@@ -1,0 +1,36 @@
+import type { SessionUser } from '@ses/domain';
+import { JSON_HEADERS, parseApiError } from './client';
+
+export type SignupPayload = {
+  email: string;
+  displayName: string;
+  password: string;
+  role: 'admin' | 'auditor';
+};
+
+export type LoginPayload = {
+  email: string;
+  password: string;
+};
+
+export async function signupOnApi(payload: SignupPayload): Promise<{ user: SessionUser }> {
+  const res = await fetch('/api/v1/auth/signup', {
+    method: 'POST',
+    credentials: 'include',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw await parseApiError(res, 'Signup failed');
+  return (await res.json()) as { user: SessionUser };
+}
+
+export async function loginOnApi(payload: LoginPayload): Promise<{ user: SessionUser }> {
+  const res = await fetch('/api/v1/auth/login', {
+    method: 'POST',
+    credentials: 'include',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw await parseApiError(res, 'Login failed');
+  return (await res.json()) as { user: SessionUser };
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,25 +1,10 @@
 import { FormEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { applySessionUserForLocalWorkspace } from '../lib/sessionWorkspace';
 import { BrandMark } from '../components/shared/BrandMark';
 import { Button } from '../components/shared/Button';
-
-/**
- * Minimal dev-login page.
- *
- * This exists so a developer (or a tester on a fresh install) can get an
- * authenticated cookie without running OIDC. It calls /api/v1/auth/dev-login
- * which the backend only honours when dev login is explicitly enabled.
- *
- * The page deliberately lists the two seeded users with one-click buttons so
- * you can open two browser profiles / incognito windows and be logged in as
- * two different users in under 30 seconds. That's the setup required to see
- * the realtime collaboration features work.
- *
- * When OIDC is wired up later, this page becomes a fallback and the real
- * login form replaces the email input.
- */
+import { loginOnApi } from '../lib/api/authApi';
 
 const SEEDED_USERS = [
   { email: 'admin@ses.local', label: 'SES Admin', role: 'admin' },
@@ -29,30 +14,21 @@ const SEEDED_USERS = [
 export function Login() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [devSubmitting, setDevSubmitting] = useState(false);
 
-  async function loginAs(identifier: string) {
-    if (!identifier.trim()) {
-      toast.error('Enter an email address first.');
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed || !password) {
+      toast.error('Enter your email and password.');
       return;
     }
     setSubmitting(true);
     try {
-      const res = await fetch('/api/v1/auth/dev-login', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ identifier: identifier.trim() }),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ message: 'Login failed' }));
-        // 403 → SES_ALLOW_DEV_LOGIN is not true on the server.
-        // 401 → unknown identifier.
-        toast.error(err.message ?? `Login failed (${res.status})`);
-        return;
-      }
-      const data = (await res.json()) as { user: { displayName: string; email: string } };
-      applySessionUserForLocalWorkspace(data.user.email ?? identifier.trim());
+      const data = await loginOnApi({ email: trimmed, password });
+      applySessionUserForLocalWorkspace(data.user.email);
       toast.success(`Signed in as ${data.user.displayName}`);
       void navigate('/');
     } catch (err) {
@@ -62,10 +38,32 @@ export function Login() {
     }
   }
 
-  function onSubmit(event: FormEvent) {
-    event.preventDefault();
-    void loginAs(email);
+  async function devLoginAs(identifier: string) {
+    setDevSubmitting(true);
+    try {
+      const res = await fetch('/api/v1/auth/dev-login', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: identifier.trim() }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ message: 'Dev login failed' }));
+        toast.error(err.message ?? `Dev login failed (${res.status})`);
+        return;
+      }
+      const data = (await res.json()) as { user: { displayName: string; email: string } };
+      applySessionUserForLocalWorkspace(data.user.email ?? identifier.trim());
+      toast.success(`Signed in as ${data.user.displayName}`);
+      void navigate('/');
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setDevSubmitting(false);
+    }
   }
+
+  const busy = submitting || devSubmitting;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10 dark:bg-gray-950">
@@ -75,37 +73,68 @@ export function Login() {
         </div>
         <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Sign in</h1>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Development environment — pick a seeded user or enter an email.
+          Use your email and password.
         </p>
 
         <form className="mt-5 space-y-3" onSubmit={onSubmit}>
-          <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
-            Email
-          </label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
-            className="w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-            autoComplete="email"
-          />
-          <Button type="submit" disabled={submitting || !email.trim()}>
+          <div>
+            <label htmlFor="login-email" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Email
+            </label>
+            <input
+              id="login-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="email"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="login-password" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Password
+            </label>
+            <input
+              id="login-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="current-password"
+              required
+            />
+          </div>
+          <Button type="submit" disabled={busy || !email.trim() || !password}>
             {submitting ? 'Signing in…' : 'Sign in'}
           </Button>
         </form>
 
-        <div className="mt-6 border-t border-gray-200 pt-5 dark:border-gray-700">
-          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-            Quick login (seeded users)
+        <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          Don&apos;t have an account?{' '}
+          <Link to="/signup" className="font-medium text-brand hover:underline">
+            Sign up
+          </Link>
+        </p>
+
+        <details className="mt-6 border-t border-gray-200 pt-5 dark:border-gray-700">
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Dev fallback (seeded users)
+          </summary>
+          <p className="mt-2 text-[11px] text-gray-400">
+            For local development only. Requires{' '}
+            <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">SES_ALLOW_DEV_LOGIN=true</code>{' '}
+            on the server.
           </p>
           <div className="mt-3 space-y-2">
             {SEEDED_USERS.map((user) => (
               <button
                 key={user.email}
                 type="button"
-                onClick={() => loginAs(user.email)}
-                disabled={submitting}
+                onClick={() => void devLoginAs(user.email)}
+                disabled={busy}
                 className="block w-full rounded-lg border border-gray-200 px-3 py-2 text-left text-sm hover:border-brand hover:bg-brand/5 disabled:opacity-50 dark:border-gray-700 dark:hover:border-brand dark:hover:bg-brand/10"
               >
                 <div className="font-medium text-gray-900 dark:text-gray-100">{user.label}</div>
@@ -115,12 +144,7 @@ export function Login() {
               </button>
             ))}
           </div>
-        </div>
-
-        <p className="mt-5 text-[11px] text-gray-400">
-          Dev login requires <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">SES_ALLOW_DEV_LOGIN=true</code>{' '}
-          on the server, or the Docker demo stack override.
-        </p>
+        </details>
       </div>
     </div>
   );

--- a/apps/web/src/pages/Signup.tsx
+++ b/apps/web/src/pages/Signup.tsx
@@ -1,0 +1,167 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { applySessionUserForLocalWorkspace } from '../lib/sessionWorkspace';
+import { BrandMark } from '../components/shared/BrandMark';
+import { Button } from '../components/shared/Button';
+import { signupOnApi } from '../lib/api/authApi';
+
+type Role = 'admin' | 'auditor';
+
+export function Signup() {
+  const navigate = useNavigate();
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [role, setRole] = useState<Role>('auditor');
+  const [submitting, setSubmitting] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    const trimmedDisplayName = displayName.trim();
+    const trimmedEmail = email.trim();
+
+    if (trimmedDisplayName.length < 2) {
+      setValidationError('Display name must be at least 2 characters.');
+      return;
+    }
+    if (password.length < 8) {
+      setValidationError('Password must be at least 8 characters.');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setValidationError('Passwords do not match.');
+      return;
+    }
+    setValidationError(null);
+    setSubmitting(true);
+    try {
+      const data = await signupOnApi({
+        email: trimmedEmail,
+        displayName: trimmedDisplayName,
+        password,
+        role,
+      });
+      applySessionUserForLocalWorkspace(data.user.email);
+      toast.success(`Account created — signed in as ${data.user.displayName}`);
+      void navigate('/');
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10 dark:bg-gray-950">
+      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6">
+          <BrandMark />
+        </div>
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Create account</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Sign up with your email and a password.
+        </p>
+
+        <form className="mt-5 space-y-3" onSubmit={onSubmit} noValidate>
+          <div>
+            <label htmlFor="signup-displayName" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Display name
+            </label>
+            <input
+              id="signup-displayName"
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Jane Doe"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="name"
+              minLength={2}
+              maxLength={120}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="signup-email" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Email
+            </label>
+            <input
+              id="signup-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="email"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="signup-role" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Role
+            </label>
+            <select
+              id="signup-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value as Role)}
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
+              <option value="auditor">Auditor</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="signup-password" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Password
+            </label>
+            <input
+              id="signup-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="At least 8 characters"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="new-password"
+              minLength={8}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="signup-confirm" className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Confirm password
+            </label>
+            <input
+              id="signup-confirm"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Re-enter your password"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              autoComplete="new-password"
+              required
+            />
+          </div>
+
+          {validationError ? (
+            <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+              {validationError}
+            </p>
+          ) : null}
+
+          <Button type="submit" disabled={submitting}>
+            {submitting ? 'Creating account…' : 'Create account'}
+          </Button>
+        </form>
+
+        <p className="mt-5 text-sm text-gray-500 dark:text-gray-400">
+          Already have an account?{' '}
+          <Link to="/login" className="font-medium text-brand hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/__tests__/Signup.test.tsx
+++ b/apps/web/src/pages/__tests__/Signup.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Signup } from '../Signup';
+
+const signupOnApi = vi.fn();
+const navigate = vi.fn();
+
+vi.mock('../../lib/api/authApi', () => ({
+  signupOnApi: (...args: unknown[]) => signupOnApi(...args),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/sessionWorkspace', () => ({
+  applySessionUserForLocalWorkspace: vi.fn(),
+}));
+
+function renderSignup() {
+  const router = createMemoryRouter(
+    [
+      { path: '/signup', element: <Signup /> },
+      { path: '/login', element: <div>Login</div> },
+      { path: '/', element: <div>Home</div> },
+    ],
+    { initialEntries: ['/signup'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+function fillForm(opts: { displayName?: string; email?: string; password?: string; confirmPassword?: string }) {
+  fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: opts.displayName ?? 'Test User' } });
+  fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: opts.email ?? 'test@example.com' } });
+  fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: opts.password ?? 'pw12345678' } });
+  fireEvent.change(screen.getByLabelText(/confirm password/i), {
+    target: { value: opts.confirmPassword ?? 'pw12345678' },
+  });
+}
+
+describe('Signup', () => {
+  beforeEach(() => {
+    signupOnApi.mockReset();
+    navigate.mockReset();
+  });
+
+  it('blocks submit and shows validation message when passwords do not match', () => {
+    renderSignup();
+    fillForm({ password: 'pw12345678', confirmPassword: 'different-pw' });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(signupOnApi).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/do not match/i);
+  });
+
+  it('calls signupOnApi with the entered values when the form is valid', async () => {
+    signupOnApi.mockResolvedValue({ user: { displayName: 'Test User', email: 'test@example.com' } });
+    renderSignup();
+    fillForm({ displayName: '  Test User  ', email: '  test@example.com  ' });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => {
+      expect(signupOnApi).toHaveBeenCalledTimes(1);
+    });
+    expect(signupOnApi).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      displayName: 'Test User',
+      password: 'pw12345678',
+      role: 'auditor',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@prisma/client": "^6.8.2",
         "@ses/domain": "file:../../packages/domain",
         "@socket.io/redis-adapter": "^8.3.0",
+        "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
@@ -48,6 +49,7 @@
         "ulid": "^3.0.1"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.1",
         "@types/jsonwebtoken": "^9.0.9",
@@ -1710,6 +1712,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2677,6 +2686,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",


### PR DESCRIPTION
Adds /auth/signup and real /auth/login alongside the existing /auth/dev-login flow. Passwords are stored as bcryptjs hashes on a new nullable User.passwordHash column. New routes share the existing JWT cookie session, throttling, and validation pipe.

Broadens resolveSessionTenantContext to fall back to the default tenant for any role without a process membership (previously admin-only) so fresh accounts have a usable session at signup, login, and /auth/me. Per-process authorization is still gated by processMember lookups elsewhere.

Web Login is rebuilt around an email+password form; seeded users move into a labeled dev-fallback section. New Signup page enforces password length and confirm-password match client-side. Adds Signup component test and an auth e2e spec covering signup/login/round-trip.