### PR TITLE
Render escalation Compose preview as a structured, per-engine email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,43 @@
-# Copy to .env in the repo root (or export in your shell) for local development.
+# # Copy to .env in the repo root (or export in your shell) for local development.
 
-# PostgreSQL (matches docker-compose.yml defaults)
-DATABASE_URL=postgresql://ses:ses@127.0.0.1:5432/ses
+# # PostgreSQL (matches docker-compose.yml defaults)
+# DATABASE_URL=postgresql://ses:ses@127.0.0.1:5432/ses
 
-# Redis — Socket.IO adapter / BullMQ when wired
+# # Redis — Socket.IO adapter / BullMQ when wired
+# REDIS_URL=redis://127.0.0.1:6380
+
+# # API auth cookie signing (change in any shared environment). If unset, dev uses
+# # a built-in fallback. When set, the value must be ≥ 32 characters or the API
+# # refuses to start (avoids accidentally deploying a weak secret).
+# SES_AUTH_SECRET=ses-local-dev-placeholder-secret-change-me
+
+# # Comma-separated browser origins for CORS (defaults to local Vite if unset)
+# # SES_CORS_ORIGINS=http://127.0.0.1:3210,http://localhost:3210
+
+# # Production: set SES_COOKIE_SECURE=true behind HTTPS. In NODE_ENV=production,
+# # SES_AUTH_SECRET is required and must be at least 32 characters.
+
+# # Cookie SameSite policy: lax (default), strict, or none (requires Secure)
+# # SES_COOKIE_SAMESITE=strict
+
+# # Never enable in production unless intentional:
+# # SES_ALLOW_DEV_LOGIN=true
+
+# # Outbound escalation sends (Issue #72). Without these, POST .../send returns 503.
+# # SES_SMTP_URL=smtps://user:pass@smtp.example.com:465
+# # SES_MAIL_FROM="SES <noreply@example.com>"
+# # SES_TEAMS_INCOMING_WEBHOOK_URL=https://outlook.office.com/webhook/...
+
+# # --- Frontend (@ses/web) — set in `apps/web/.env` or export before `vite build` ---
+# # Tile dashboard + `/processes/...` URLs (default). Set to `false` for legacy-primary `/workspace/...` routing.
+# # VITE_FEATURE_TILES_DASHBOARD=false
+# # Per-tile Tracking (Kanban) tab in workspace (default off). Set to `true` for one release cycle of legacy behavior.
+# # VITE_FEATURE_LEGACY_TILE_TRACKING_TAB=true
+SES_BASE_URL=http://192.168.68.127:3210
+SES_CORS_ORIGINS=http://192.168.68.127:3210
+SES_COOKIE_SECURE=false
+SES_COOKIE_SAMESITE=lax
+SES_ALLOW_DEV_LOGIN=false
+SES_ALLOW_DEMO_DEV_LOGIN=false
+SES_AUTH_SECRET=981a6407277ed4527be3c77a1099aaa7e2536436bac7c0b34f3f698814472bcb
 REDIS_URL=redis://127.0.0.1:6380
-
-# API auth cookie signing (change in any shared environment). If unset, dev uses
-# a built-in fallback. When set, the value must be ≥ 32 characters or the API
-# refuses to start (avoids accidentally deploying a weak secret).
-SES_AUTH_SECRET=ses-local-dev-placeholder-secret-change-me
-
-# Comma-separated browser origins for CORS (defaults to local Vite if unset)
-# SES_CORS_ORIGINS=http://127.0.0.1:3210,http://localhost:3210
-
-# Production: set SES_COOKIE_SECURE=true behind HTTPS. In NODE_ENV=production,
-# SES_AUTH_SECRET is required and must be at least 32 characters.
-
-# Cookie SameSite policy: lax (default), strict, or none (requires Secure)
-# SES_COOKIE_SAMESITE=strict
-
-# Never enable in production unless intentional:
-# SES_ALLOW_DEV_LOGIN=true
-
-# Outbound escalation sends (Issue #72). Without these, POST .../send returns 503.
-# SES_SMTP_URL=smtps://user:pass@smtp.example.com:465
-# SES_MAIL_FROM="SES <noreply@example.com>"
-# SES_TEAMS_INCOMING_WEBHOOK_URL=https://outlook.office.com/webhook/...
-
-# --- Frontend (@ses/web) — set in `apps/web/.env` or export before `vite build` ---
-# Tile dashboard + `/processes/...` URLs (default). Set to `false` for legacy-primary `/workspace/...` routing.
-# VITE_FEATURE_TILES_DASHBOARD=false
-# Per-tile Tracking (Kanban) tab in workspace (default off). Set to `true` for one release cycle of legacy behavior.
-# VITE_FEATURE_LEGACY_TILE_TRACKING_TAB=true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
     "prisma:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:e2e": "TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts test/auth.e2e-spec.ts test/process-scope-rbac.e2e-spec.ts"
+    "test:e2e": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts test/auth.e2e-spec.ts test/process-scope-rbac.e2e-spec.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
     "prisma:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:e2e": "TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts test/auth.e2e-spec.ts"
+    "test:e2e": "TS_NODE_TRANSPILE_ONLY=false node --require ts-node/register --test test/files.e2e-spec.ts test/directory.e2e-spec.ts test/auth.e2e-spec.ts test/process-scope-rbac.e2e-spec.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.0",

--- a/apps/api/prisma/migrations/20260426090000_add_process_member_scope_permissions/migration.sql
+++ b/apps/api/prisma/migrations/20260426090000_add_process_member_scope_permissions/migration.sql
@@ -1,0 +1,51 @@
+-- ProcessMemberScopePermission: optional per-(member, scope) overrides
+-- layered on top of ProcessMember.permission. Absence of rows preserves
+-- legacy behavior (member.permission applies process-wide).
+CREATE TABLE "ProcessMemberScopePermission" (
+  "id"          TEXT NOT NULL,
+  "processId"   TEXT NOT NULL,
+  "memberId"    TEXT NOT NULL,
+  "scopeType"   TEXT NOT NULL,
+  "functionId"  TEXT,
+  "accessLevel" TEXT NOT NULL,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "ProcessMemberScopePermission_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "ProcessMemberScopePermission"
+  ADD CONSTRAINT "ProcessMemberScopePermission_processId_fkey"
+    FOREIGN KEY ("processId")  REFERENCES "Process"("id")        ON DELETE CASCADE  ON UPDATE CASCADE,
+  ADD CONSTRAINT "ProcessMemberScopePermission_memberId_fkey"
+    FOREIGN KEY ("memberId")   REFERENCES "ProcessMember"("id")  ON DELETE CASCADE  ON UPDATE CASCADE,
+  ADD CONSTRAINT "ProcessMemberScopePermission_functionId_fkey"
+    FOREIGN KEY ("functionId") REFERENCES "SystemFunction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Standard composite uniqueness (function rows have non-null functionId).
+CREATE UNIQUE INDEX "ProcessMemberScopePermission_memberId_scopeType_functionId_key"
+  ON "ProcessMemberScopePermission" ("memberId", "scopeType", "functionId");
+
+-- Partial uniqueness for null-function rows (Postgres treats NULL as distinct
+-- in standard unique indexes, so we need this to prevent duplicate
+-- 'all-functions' or 'escalation-center' rows per member).
+CREATE UNIQUE INDEX "ProcessMemberScopePermission_memberId_scopeType_null_function_key"
+  ON "ProcessMemberScopePermission" ("memberId", "scopeType")
+  WHERE "functionId" IS NULL;
+
+CREATE INDEX "ProcessMemberScopePermission_processId_idx"
+  ON "ProcessMemberScopePermission" ("processId");
+CREATE INDEX "ProcessMemberScopePermission_memberId_idx"
+  ON "ProcessMemberScopePermission" ("memberId");
+
+-- Defensive CHECKs mirroring service-layer validation.
+ALTER TABLE "ProcessMemberScopePermission"
+  ADD CONSTRAINT "ProcessMemberScopePermission_function_scope_consistent" CHECK (
+    ("scopeType" = 'function' AND "functionId" IS NOT NULL)
+    OR ("scopeType" <> 'function' AND "functionId" IS NULL)
+  ),
+  ADD CONSTRAINT "ProcessMemberScopePermission_scopeType_enum" CHECK (
+    "scopeType" IN ('all-functions', 'function', 'escalation-center')
+  ),
+  ADD CONSTRAINT "ProcessMemberScopePermission_accessLevel_enum" CHECK (
+    "accessLevel" IN ('viewer', 'editor')
+  );

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Process {
   processFunctions  ProcessFunction[]
   auditRequests     FunctionAuditRequest[]
   fileDrafts        FileDraft[]
+  scopePermissions  ProcessMemberScopePermission[]
 
   @@index([tenantId])
 }
@@ -157,10 +158,11 @@ model SystemFunction {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  processMap   ProcessFunction[]
-  files        WorkbookFile[]
-  fileDrafts   FileDraft[]
-  auditRules   AuditRule[]
+  processMap       ProcessFunction[]
+  files            WorkbookFile[]
+  fileDrafts       FileDraft[]
+  auditRules       AuditRule[]
+  scopePermissions ProcessMemberScopePermission[]
 }
 
 /// Enablement row per (process, function). Every new Process is seeded
@@ -207,8 +209,34 @@ model ProcessMember {
   addedAt    DateTime @default(now())
   process    Process  @relation(fields: [processId], references: [id], onDelete: Cascade)
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  scopePermissions ProcessMemberScopePermission[]
 
   @@unique([processId, userId])
+}
+
+/// Optional per-(member, scope) access overrides layered on top of ProcessMember.
+/// When a member has zero rows here, ProcessMember.permission applies process-wide
+/// (legacy behavior). When at least one row exists, the resolver matches by scope.
+model ProcessMemberScopePermission {
+  id          String   @id
+  processId   String
+  memberId    String
+  /// 'all-functions' | 'function' | 'escalation-center'
+  scopeType   String
+  /// Required iff scopeType='function'.
+  functionId  String?
+  /// 'viewer' | 'editor' (owner is never scoped)
+  accessLevel String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  process     Process         @relation(fields: [processId], references: [id], onDelete: Cascade)
+  member      ProcessMember   @relation(fields: [memberId],  references: [id], onDelete: Cascade)
+  function    SystemFunction? @relation(fields: [functionId], references: [id])
+
+  @@unique([memberId, scopeType, functionId])
+  @@index([processId])
+  @@index([memberId])
 }
 
 model WorkbookFile {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -77,7 +77,13 @@ import { SlaEngineService } from './sla-engine.service';
       {
         name: 'default',
         ttl: 60_000,
-        limit: 400,
+        // The e2e suite makes many signup / login / API calls in a tight
+        // loop against the in-process server, all from the same IP. The
+        // production limit (400/min) is reached late in the suite and
+        // surfaces as flaky 429s for the last couple of tests. Bump the
+        // ceiling under NODE_ENV=test so CI is deterministic; production
+        // and dev still see the regular cap.
+        limit: process.env.NODE_ENV === 'test' ? 10_000 : 400,
       },
     ]),
   ],

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -73,22 +73,19 @@ import { SlaEngineService } from './sla-engine.service';
 
 @Module({
   imports: [
-    // forRootAsync (not forRoot) so the limit reads NODE_ENV at module
-    // init — by the time the e2e harness has set NODE_ENV=test in
-    // createApp() — instead of capturing it at import time, when the
-    // test runner hasn't set it yet. The e2e suite hammers signup /
-    // login from a single IP; raising the cap under NODE_ENV=test stops
-    // the last couple of tests from flaking on 429s while leaving the
-    // production / dev limit unchanged.
-    ThrottlerModule.forRootAsync({
-      useFactory: () => [
-        {
-          name: 'default',
-          ttl: 60_000,
-          limit: process.env.NODE_ENV === 'test' ? 10_000 : 400,
-        },
-      ],
-    }),
+    // `limit` is a Resolvable function so NODE_ENV is read per-request
+    // instead of being captured at module init. Earlier fixes that read
+    // it once (forRoot at decoration time, then forRootAsync at module
+    // init) were still racing the e2e harness's NODE_ENV=test assignment
+    // in createApp() under `node --test`, so the last RBAC tests kept
+    // flaking on 429s. A per-request resolver removes the timing window.
+    ThrottlerModule.forRoot([
+      {
+        name: 'default',
+        ttl: 60_000,
+        limit: () => (process.env.NODE_ENV === 'test' ? 10_000 : 400),
+      },
+    ]),
   ],
   controllers: [
     HealthController,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -73,19 +73,22 @@ import { SlaEngineService } from './sla-engine.service';
 
 @Module({
   imports: [
-    ThrottlerModule.forRoot([
-      {
-        name: 'default',
-        ttl: 60_000,
-        // The e2e suite makes many signup / login / API calls in a tight
-        // loop against the in-process server, all from the same IP. The
-        // production limit (400/min) is reached late in the suite and
-        // surfaces as flaky 429s for the last couple of tests. Bump the
-        // ceiling under NODE_ENV=test so CI is deterministic; production
-        // and dev still see the regular cap.
-        limit: process.env.NODE_ENV === 'test' ? 10_000 : 400,
-      },
-    ]),
+    // forRootAsync (not forRoot) so the limit reads NODE_ENV at module
+    // init — by the time the e2e harness has set NODE_ENV=test in
+    // createApp() — instead of capturing it at import time, when the
+    // test runner hasn't set it yet. The e2e suite hammers signup /
+    // login from a single IP; raising the cap under NODE_ENV=test stops
+    // the last couple of tests from flaking on 429s while leaving the
+    // production / dev limit unchanged.
+    ThrottlerModule.forRootAsync({
+      useFactory: () => [
+        {
+          name: 'default',
+          ttl: 60_000,
+          limit: process.env.NODE_ENV === 'test' ? 10_000 : 400,
+        },
+      ],
+    }),
   ],
   controllers: [
     HealthController,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { AccessScopeService } from './common/access-scope.service';
 import { ActivityLogService } from './common/activity-log.service';
 import { FunctionAccessGuard } from './common/function-access.guard';
 import { IdentifierService } from './common/identifier.service';
@@ -114,6 +115,7 @@ import { SlaEngineService } from './sla-engine.service';
     { provide: APP_GUARD, useClass: ThrottlerGuard },
     PrismaService,
     ProcessAccessService,
+    AccessScopeService,
     IdentifierService,
     ActivityLogService,
     AuthService,
@@ -156,6 +158,7 @@ import { SlaEngineService } from './sla-engine.service';
   exports: [
     PrismaService,
     ProcessAccessService,
+    AccessScopeService,
     IdentifierService,
     ActivityLogService,
     AuthService,

--- a/apps/api/src/audits.controller.ts
+++ b/apps/api/src/audits.controller.ts
@@ -1,21 +1,52 @@
-import { Body, Controller, Get, Param, Post, Query, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, Post, Query, Res, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
-import type { SessionUser } from '@ses/domain';
+import { isFunctionId, type SessionUser } from '@ses/domain';
 import { AuthGuard } from './auth.guard';
+import { AccessScopeService } from './common/access-scope.service';
 import { CurrentUser } from './common/current-user';
 import { attachmentContentDisposition } from './common/http';
+import { PrismaService } from './common/prisma.service';
+import { ProcessAccessService } from './common/process-access.service';
 import { RunAuditDto } from './dto/audits.dto';
 import { AuditsService } from './audits.service';
 
 @Controller()
 @UseGuards(AuthGuard)
 export class AuditsController {
-  constructor(private readonly auditsService: AuditsService) {}
+  constructor(
+    private readonly auditsService: AuditsService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   @Post('processes/:idOrCode/audit/run')
   @Throttle({ default: { limit: 20, ttl: 60_000 } })
-  run(@Param('idOrCode') idOrCode: string, @Body() body: RunAuditDto, @CurrentUser() user: SessionUser) {
+  async run(@Param('idOrCode') idOrCode: string, @Body() body: RunAuditDto, @CurrentUser() user: SessionUser) {
+    // Pre-flight scope check. The audits service still does its legacy
+    // `findAccessibleProcessOrThrow(..., 'editor')` check, but that consults
+    // only the base ProcessMember.permission — a function-viewer who is base
+    // editor would slip through. Resolve the file's function and require
+    // edit on that function scope before delegating.
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
+    const file = await this.prisma.workbookFile.findFirst({
+      where: {
+        processId: process.id,
+        OR: [{ id: body.fileIdOrCode }, { displayCode: body.fileIdOrCode }],
+      },
+      select: { id: true, functionId: true },
+    });
+    if (!file) throw new NotFoundException(`File ${body.fileIdOrCode} not found`);
+    if (isFunctionId(file.functionId)) {
+      await this.accessScope.require(process.id, user, {
+        kind: 'function',
+        functionId: file.functionId,
+        action: 'edit',
+      });
+    } else {
+      await this.accessScope.require(process.id, user, { kind: 'all-functions', action: 'edit' });
+    }
     return this.auditsService.run(idOrCode, body, user);
   }
 

--- a/apps/api/src/audits.service.ts
+++ b/apps/api/src/audits.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import type { Prisma } from '@prisma/client';
 import type { AuditIssue, AuditResult, SessionUser, WorkbookFile as DomainWorkbookFile } from '@ses/domain';
@@ -142,6 +142,12 @@ function serializeRun(run: {
   };
 }
 
+type PersistedAuditIssue = AuditIssue & {
+  persistedId: string;
+  displayCode: string;
+  issueKey: string;
+};
+
 @Injectable()
 export class AuditsService {
   constructor(
@@ -205,6 +211,43 @@ export class AuditsService {
       medium: issues.filter((issue) => issue.severity === 'Medium').length,
       low: issues.filter((issue) => issue.severity === 'Low').length,
     };
+  }
+
+  private prepareIssuesForPersistence(
+    issues: AuditIssue[],
+    processDisplayCode: string,
+    displayCodes: string[],
+  ): PersistedAuditIssue[] {
+    return issues.map((issue, index) => ({
+      ...issue,
+      persistedId: createId(),
+      displayCode: displayCodes[index]!,
+      issueKey: createIssueKey(processDisplayCode, {
+        projectNo: issue.projectNo,
+        sheetName: issue.sheetName,
+        rowIndex: issue.rowIndex,
+        ruleCode: issue.ruleCode,
+      }),
+    }));
+  }
+
+  private assertKnownRuleCodes(
+    issues: Array<{ persistedId: string; ruleCode?: string | null; ruleId?: string | null }>,
+    validRuleCodes: Set<string>,
+  ): void {
+    for (const issue of issues) {
+      const resolvedRuleCode = issue.ruleCode ?? issue.ruleId;
+      if (!resolvedRuleCode) {
+        throw new InternalServerErrorException(
+          `Audit engine returned issue ${issue.persistedId} without a ruleCode.`,
+        );
+      }
+      if (!validRuleCodes.has(resolvedRuleCode)) {
+        throw new BadRequestException(
+          `Audit produced unsupported rule code "${resolvedRuleCode}". Refresh audit rules and try again.`,
+        );
+      }
+    }
   }
 
   async run(processIdOrCode: string, body: { fileIdOrCode: string; mappingSource?: MappingSourceDto }, user: SessionUser) {
@@ -317,16 +360,14 @@ export class AuditsService {
         result.issues,
       );
 
-      const issuesWithCodes = await Promise.all(result.issues.map(async (issue) => ({
-        ...issue,
-        displayCode: await this.identifiers.nextIssueCode(tx, runCode),
-        issueKey: createIssueKey(process.displayCode, {
-          projectNo: issue.projectNo,
-          sheetName: issue.sheetName,
-          rowIndex: issue.rowIndex,
-          ruleCode: issue.ruleCode,
-        }),
-      })));
+      const issueDisplayCodes = await Promise.all(
+        result.issues.map(async () => this.identifiers.nextIssueCode(tx, runCode)),
+      );
+      const issuesWithCodes = this.prepareIssuesForPersistence(
+        result.issues,
+        process.displayCode,
+        issueDisplayCodes,
+      );
       const summary = {
         severity: this.severitySummary(issuesWithCodes),
         sheets: result.sheets,
@@ -364,18 +405,20 @@ export class AuditsService {
           : {}),
       };
 
+      const validRuleCodes = new Set(
+        (
+          await tx.auditRule.findMany({
+            select: { ruleCode: true },
+          })
+        ).map((rule) => rule.ruleCode),
+      );
+      this.assertKnownRuleCodes(issuesWithCodes, validRuleCodes);
+
       for (const issue of issuesWithCodes) {
-        // Every engine must emit a ruleCode that exists in AUDIT_RULE_CATALOG
-        // so the AuditIssue → AuditRule FK holds. We never silently coerce
-        // a Master Data finding into an effort-engine rule, so fail loud
-        // if an engine ever returns an issue without one.
         const resolvedRuleCode = issue.ruleCode ?? issue.ruleId;
-        if (!resolvedRuleCode) {
-          throw new Error(`Audit engine returned issue ${issue.id} without a ruleCode.`);
-        }
         await tx.auditIssue.create({
           data: {
-            id: issue.id,
+            id: issue.persistedId,
             displayCode: issue.displayCode!,
             issueKey: issue.issueKey!,
             auditRunId: createdRun.id,

--- a/apps/api/src/audits.service.ts
+++ b/apps/api/src/audits.service.ts
@@ -208,7 +208,11 @@ export class AuditsService {
   }
 
   async run(processIdOrCode: string, body: { fileIdOrCode: string; mappingSource?: MappingSourceDto }, user: SessionUser) {
-    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'editor');
+    // Scope-aware edit enforcement happens at the controller boundary. By the
+    // time we reach the service we only need to confirm the caller can see the
+    // process, otherwise a scoped editor (base viewer) is rejected here even
+    // though they were correctly authorized for this function.
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'viewer');
     const file = await this.prisma.workbookFile.findFirst({
       where: {
         processId: process.id,
@@ -463,6 +467,8 @@ export class AuditsService {
     this.realtime.emitToProcess(process.displayCode, 'audit.completed', {
       runCode: result.displayCode,
       runId: result.id,
+      fileId: file.id,
+      fileCode: file.displayCode,
       flaggedRows: result.flaggedRows,
       scannedRows: result.scannedRows,
     }, { actor });

--- a/apps/api/src/auth.controller.ts
+++ b/apps/api/src/auth.controller.ts
@@ -15,6 +15,17 @@ import { AuthGuard } from './auth.guard';
 import { CurrentUser } from './common/current-user';
 import { DevLoginDto, LoginDto, SignupDto } from './dto/auth.dto';
 
+// Auth endpoints get a tight per-IP throttle for anti-bot protection,
+// but the e2e suite makes 100+ rapid signup/login calls from a single
+// IP — so the limit is a Resolvable function that lifts the cap under
+// NODE_ENV=test. Production keeps the real 10/min cap.
+const AUTH_THROTTLE = {
+  default: {
+    limit: () => (process.env.NODE_ENV === 'test' ? 10_000 : 10),
+    ttl: 60_000,
+  },
+};
+
 @Controller('auth')
 @SkipThrottle({ default: true })
 export class AuthController {
@@ -22,21 +33,21 @@ export class AuthController {
 
   @Post('signup')
   @SkipThrottle({ default: false })
-  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @Throttle(AUTH_THROTTLE)
   async signup(@Body() body: SignupDto, @Res({ passthrough: true }) response: Response) {
     return { user: await this.authService.signup(response, body) };
   }
 
   @Post('login')
   @SkipThrottle({ default: false })
-  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @Throttle(AUTH_THROTTLE)
   async login(@Body() body: LoginDto, @Res({ passthrough: true }) response: Response) {
     return { user: await this.authService.login(response, body) };
   }
 
   @Post('dev-login')
   @SkipThrottle({ default: false })
-  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @Throttle(AUTH_THROTTLE)
   async devLogin(@Body() body: DevLoginDto, @Res({ passthrough: true }) response: Response) {
     const identifier = body.identifier ?? body.email ?? body.displayCode;
     if (identifier === undefined || identifier === null || String(identifier).trim() === '') {

--- a/apps/api/src/common/access-scope.service.ts
+++ b/apps/api/src/common/access-scope.service.ts
@@ -1,0 +1,206 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+import { createId } from '@ses/domain';
+import type { FunctionId, SessionUser } from '@ses/domain';
+import { PrismaService } from './prisma.service';
+import type { ProcessPermission } from './process-access.service';
+
+export type ScopeKind = 'all-functions' | 'function' | 'escalation-center';
+export type ScopeAccessLevel = 'viewer' | 'editor';
+export type ScopeAction = 'view' | 'edit';
+
+export interface ScopeContext {
+  kind: ScopeKind;
+  /** Required when kind === 'function'. */
+  functionId?: FunctionId;
+  action: ScopeAction;
+}
+
+export interface ScopeRow {
+  scopeType: ScopeKind;
+  functionId: string | null;
+  accessLevel: ScopeAccessLevel;
+}
+
+export interface ScopeWriteInput {
+  scopeType: ScopeKind;
+  functionId?: string | null;
+  accessLevel: ScopeAccessLevel;
+}
+
+const baseRank: Record<ProcessPermission, number> = {
+  viewer: 1,
+  editor: 2,
+  owner: 3,
+};
+
+const accessRank: Record<ScopeAccessLevel, number> = {
+  viewer: 1,
+  editor: 2,
+};
+
+export type LoadedMemberContext = {
+  member: { id: string; permission: ProcessPermission };
+  scopes: ScopeRow[];
+};
+
+@Injectable()
+export class AccessScopeService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Single round trip: returns the user's ProcessMember row plus their scope
+   * permissions, or null if the user is not a member of the process.
+   */
+  async loadMemberContext(processId: string, userId: string): Promise<LoadedMemberContext | null> {
+    const member = await this.prisma.processMember.findFirst({
+      where: { processId, userId },
+      include: {
+        scopePermissions: {
+          select: { scopeType: true, functionId: true, accessLevel: true },
+        },
+      },
+    });
+    if (!member) return null;
+    if (
+      member.permission !== 'viewer' &&
+      member.permission !== 'editor' &&
+      member.permission !== 'owner'
+    ) {
+      return null;
+    }
+    return {
+      member: { id: member.id, permission: member.permission },
+      scopes: member.scopePermissions.map((s) => ({
+        scopeType: s.scopeType as ScopeKind,
+        functionId: s.functionId,
+        accessLevel: s.accessLevel as ScopeAccessLevel,
+      })),
+    };
+  }
+
+  /**
+   * Pure resolver — no DB access. Given the loaded member + scope rows and a
+   * request scope context, decides whether to allow.
+   *
+   * Resolution:
+   *   1. owner => allow.
+   *   2. zero scope rows => fall back to ProcessMember.permission (legacy).
+   *   3. otherwise match by ctx.kind:
+   *      - 'function': exact function row + any 'all-functions' row.
+   *      - 'escalation-center': exact escalation row only.
+   *      - 'all-functions' (process-wide non-function routes): view is allowed
+   *        if any scope row exists; edit requires an 'all-functions' row.
+   *      Choose the most permissive matching accessLevel.
+   */
+  resolve(args: {
+    member: { permission: ProcessPermission };
+    scopes: ScopeRow[];
+    ctx: ScopeContext;
+  }): { allowed: boolean; reason?: string } {
+    const { member, scopes, ctx } = args;
+    if (member.permission === 'owner') return { allowed: true };
+
+    const required = ctx.action === 'view' ? 1 : 2;
+
+    if (scopes.length === 0) {
+      const ok = baseRank[member.permission] >= required;
+      return { allowed: ok, reason: ok ? undefined : 'insufficient permission' };
+    }
+
+    const candidates: ScopeAccessLevel[] = [];
+
+    if (ctx.kind === 'function') {
+      if (!ctx.functionId) {
+        return { allowed: false, reason: 'function scope requires functionId' };
+      }
+      const exact = scopes.find(
+        (s) => s.scopeType === 'function' && s.functionId === ctx.functionId,
+      );
+      if (exact) candidates.push(exact.accessLevel);
+      const all = scopes.find((s) => s.scopeType === 'all-functions');
+      if (all) candidates.push(all.accessLevel);
+    } else if (ctx.kind === 'escalation-center') {
+      const esc = scopes.find((s) => s.scopeType === 'escalation-center');
+      if (esc) candidates.push(esc.accessLevel);
+    } else {
+      // 'all-functions' = process-wide non-function route.
+      if (ctx.action === 'view') return { allowed: true };
+      const all = scopes.find((s) => s.scopeType === 'all-functions');
+      if (all) candidates.push(all.accessLevel);
+    }
+
+    if (candidates.length === 0) {
+      return { allowed: false, reason: 'no scope grants this access' };
+    }
+    const best = Math.max(...candidates.map((c) => accessRank[c]));
+    return best >= required
+      ? { allowed: true }
+      : { allowed: false, reason: 'scope grant below required level' };
+  }
+
+  /** Convenience wrapper used by the guard. Throws ForbiddenException on deny. */
+  async require(processId: string, user: SessionUser, ctx: ScopeContext): Promise<void> {
+    const ctxLoaded = await this.loadMemberContext(processId, user.id);
+    if (!ctxLoaded) {
+      throw new ForbiddenException('Not a member of this process');
+    }
+    const { allowed, reason } = this.resolve({
+      member: ctxLoaded.member,
+      scopes: ctxLoaded.scopes,
+      ctx,
+    });
+    if (!allowed) {
+      throw new ForbiddenException(reason ?? 'Insufficient scope permission');
+    }
+  }
+
+  /** Used by GET /processes/:id/members to attach scopes per member. */
+  async listScopesForProcess(processId: string): Promise<Map<string, ScopeRow[]>> {
+    const rows = await this.prisma.processMemberScopePermission.findMany({
+      where: { processId },
+      select: { memberId: true, scopeType: true, functionId: true, accessLevel: true },
+    });
+    const out = new Map<string, ScopeRow[]>();
+    for (const r of rows) {
+      const list = out.get(r.memberId) ?? [];
+      list.push({
+        scopeType: r.scopeType as ScopeKind,
+        functionId: r.functionId,
+        accessLevel: r.accessLevel as ScopeAccessLevel,
+      });
+      out.set(r.memberId, list);
+    }
+    return out;
+  }
+
+  /**
+   * Replace-all writer used by add/update endpoints. Runs inside the caller's
+   * existing prisma transaction. An empty `scopes` list deletes any existing
+   * rows for the member (i.e., reverts to legacy "unrestricted" behavior).
+   */
+  async replaceMemberScopes(
+    tx: Prisma.TransactionClient,
+    args: { processId: string; memberId: string; scopes: ScopeWriteInput[] },
+  ): Promise<void> {
+    const { processId, memberId, scopes } = args;
+    // Defensive dedup: collapse by (scopeType, functionId|null), last write wins.
+    const seen = new Map<string, ScopeWriteInput>();
+    for (const s of scopes) {
+      const key = `${s.scopeType}::${s.functionId ?? ''}`;
+      seen.set(key, s);
+    }
+    await tx.processMemberScopePermission.deleteMany({ where: { memberId } });
+    if (seen.size === 0) return;
+    await tx.processMemberScopePermission.createMany({
+      data: [...seen.values()].map((s) => ({
+        id: createId(),
+        processId,
+        memberId,
+        scopeType: s.scopeType,
+        functionId: s.scopeType === 'function' ? s.functionId ?? null : null,
+        accessLevel: s.accessLevel,
+      })),
+    });
+  }
+}

--- a/apps/api/src/common/function-access.guard.ts
+++ b/apps/api/src/common/function-access.guard.ts
@@ -5,10 +5,18 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { isFunctionId } from '@ses/domain';
+import { Reflector } from '@nestjs/core';
+import { isFunctionId, type FunctionId } from '@ses/domain';
 import { FunctionsService } from '../functions.service';
+import {
+  AccessScopeService,
+  type ScopeAction,
+  type ScopeContext,
+  type ScopeKind,
+} from './access-scope.service';
 import { PrismaService } from './prisma.service';
 import { ProcessAccessService } from './process-access.service';
+import { REQUIRES_SCOPE_KEY, type RequiresScopeOptions } from './requires-scope.decorator';
 
 function requestPathUrl(request: { path?: string; originalUrl?: string; url?: string }): string {
   const raw = request.originalUrl ?? request.url ?? request.path ?? '';
@@ -25,6 +33,9 @@ function requestPathUrl(request: { path?: string; originalUrl?: string; url?: st
  *    `findAccessibleProcessOrThrow` (membership + optional min permission via callers).
  * 4. If the route includes `:functionId` / `:fid`, require that function to be enabled
  *    for the process.
+ * 5. After the above pass, consult `AccessScopeService` so that members with
+ *    `ProcessMemberScopePermission` rows are confined to the scopes they were
+ *    granted. Members without any scope rows behave exactly as before.
  */
 @Injectable()
 export class FunctionAccessGuard implements CanActivate {
@@ -32,6 +43,8 @@ export class FunctionAccessGuard implements CanActivate {
     private readonly prisma: PrismaService,
     private readonly processAccess: ProcessAccessService,
     private readonly functions: FunctionsService,
+    private readonly accessScope: AccessScopeService,
+    private readonly reflector: Reflector,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -47,6 +60,7 @@ export class FunctionAccessGuard implements CanActivate {
     const isBareFilesPath = pathUrl.includes('/files/') && !isProcessScoped;
 
     let processIdForFunctionCheck: string | undefined;
+    let resolvedFileFunctionId: FunctionId | undefined;
 
     if (isBareFilesPath) {
       const fileKey = params.fileIdOrCode ?? params.idOrCode;
@@ -64,6 +78,9 @@ export class FunctionAccessGuard implements CanActivate {
           throw new ForbiddenException(`Function ${file.functionId} is not enabled for this process`);
         }
         processIdForFunctionCheck = file.processId;
+        if (isFunctionId(file.functionId)) {
+          resolvedFileFunctionId = file.functionId;
+        }
       }
     } else if (isProcessScoped) {
       const processParam = params.pid ?? params.processIdOrCode ?? params.idOrCode;
@@ -86,6 +103,42 @@ export class FunctionAccessGuard implements CanActivate {
       }
     }
 
+    if (processIdForFunctionCheck) {
+      const ctx = this.deriveScopeContext({
+        request,
+        params,
+        explicit: this.reflector.getAllAndOverride<RequiresScopeOptions | undefined>(
+          REQUIRES_SCOPE_KEY,
+          [context.getHandler(), context.getClass()],
+        ),
+        routeFunctionId: isFunctionId(fid ?? '') ? (fid as FunctionId) : resolvedFileFunctionId,
+      });
+      await this.accessScope.require(processIdForFunctionCheck, user, ctx);
+    }
+
     return true;
+  }
+
+  private deriveScopeContext(args: {
+    request: { method?: string };
+    params: Record<string, string | undefined>;
+    explicit: RequiresScopeOptions | undefined;
+    routeFunctionId: FunctionId | undefined;
+  }): ScopeContext {
+    const method = (args.request.method ?? 'GET').toUpperCase();
+    const defaultAction: ScopeAction = method === 'GET' || method === 'HEAD' ? 'view' : 'edit';
+
+    if (args.explicit) {
+      const kind: ScopeKind = args.explicit.kind;
+      const action: ScopeAction = args.explicit.action ?? defaultAction;
+      return kind === 'function'
+        ? { kind, action, functionId: args.routeFunctionId }
+        : { kind, action };
+    }
+
+    if (args.routeFunctionId) {
+      return { kind: 'function', functionId: args.routeFunctionId, action: defaultAction };
+    }
+    return { kind: 'all-functions', action: defaultAction };
   }
 }

--- a/apps/api/src/common/requires-scope.decorator.ts
+++ b/apps/api/src/common/requires-scope.decorator.ts
@@ -1,0 +1,13 @@
+import { SetMetadata } from '@nestjs/common';
+import type { ScopeAction, ScopeKind } from './access-scope.service';
+
+export const REQUIRES_SCOPE_KEY = 'requiresScope';
+
+export interface RequiresScopeOptions {
+  kind: ScopeKind;
+  /** Overrides the HTTP-method default (GET/HEAD => 'view', else 'edit'). */
+  action?: ScopeAction;
+}
+
+export const RequiresScope = (opts: RequiresScopeOptions) =>
+  SetMetadata(REQUIRES_SCOPE_KEY, opts);

--- a/apps/api/src/dto/process-members.dto.ts
+++ b/apps/api/src/dto/process-members.dto.ts
@@ -1,0 +1,72 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsEmail,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export type ScopeAccessLevel = 'viewer' | 'editor';
+export type ScopeType = 'all-functions' | 'function' | 'escalation-center';
+export type AccessMode = 'unrestricted' | 'scoped';
+
+export class ScopeEntryDto {
+  @IsIn(['all-functions', 'function', 'escalation-center'])
+  scopeType!: ScopeType;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  functionId?: string;
+
+  @IsIn(['viewer', 'editor'])
+  accessLevel!: ScopeAccessLevel;
+}
+
+export class AddProcessMemberDto {
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(320)
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  userCode?: string;
+
+  @IsOptional()
+  @IsIn(['viewer', 'editor', 'owner'])
+  permission?: 'viewer' | 'editor' | 'owner';
+
+  @IsOptional()
+  @IsIn(['unrestricted', 'scoped'])
+  accessMode?: AccessMode;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(32)
+  @ValidateNested({ each: true })
+  @Type(() => ScopeEntryDto)
+  scopes?: ScopeEntryDto[];
+}
+
+export class UpdateProcessMemberDto {
+  @IsOptional()
+  @IsIn(['viewer', 'editor', 'owner'])
+  permission?: 'viewer' | 'editor' | 'owner';
+
+  @IsOptional()
+  @IsIn(['unrestricted', 'scoped'])
+  accessMode?: AccessMode;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(32)
+  @ValidateNested({ each: true })
+  @Type(() => ScopeEntryDto)
+  scopes?: ScopeEntryDto[];
+}

--- a/apps/api/src/issues.controller.ts
+++ b/apps/api/src/issues.controller.ts
@@ -1,14 +1,47 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
-import type { SessionUser } from '@ses/domain';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { isFunctionId, type SessionUser } from '@ses/domain';
 import { AuthGuard } from './auth.guard';
+import { AccessScopeService } from './common/access-scope.service';
 import { CurrentUser } from './common/current-user';
+import { PrismaService } from './common/prisma.service';
+import { ProcessAccessService } from './common/process-access.service';
 import { AddIssueCommentDto, SaveAcknowledgmentDto, SaveCorrectionDto } from './dto/issues.dto';
 import { IssuesService } from './issues.service';
 
 @Controller()
 @UseGuards(AuthGuard)
 export class IssuesController {
-  constructor(private readonly issuesService: IssuesService) {}
+  constructor(
+    private readonly issuesService: IssuesService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Issue mutations are scoped to the function that owns the issue's audit
+   * run. A function-viewer who is base 'editor' must not be able to comment,
+   * correct, or acknowledge on a function they are scoped down on. We resolve
+   * `issueKey -> auditRun.file.functionId` and require function:edit. If the
+   * issue can't be resolved (orphan key), fall back to all-functions:edit.
+   */
+  private async requireFunctionEditForIssue(
+    processIdOrCode: string,
+    issueKey: string,
+    user: SessionUser,
+  ): Promise<void> {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'viewer');
+    const issue = await this.prisma.auditIssue.findFirst({
+      where: { issueKey, auditRun: { processId: process.id } },
+      select: { auditRun: { select: { file: { select: { functionId: true } } } } },
+    });
+    const functionId = issue?.auditRun.file.functionId;
+    if (functionId && isFunctionId(functionId)) {
+      await this.accessScope.require(process.id, user, { kind: 'function', functionId, action: 'edit' });
+    } else {
+      await this.accessScope.require(process.id, user, { kind: 'all-functions', action: 'edit' });
+    }
+  }
 
   @Get('processes/:idOrCode/comments')
   listAllComments(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
@@ -25,17 +58,26 @@ export class IssuesController {
   }
 
   @Post('processes/:idOrCode/issues/:issueKey/comments')
-  addComment(
+  async addComment(
     @Param('idOrCode') idOrCode: string,
     @Param('issueKey') issueKey: string,
     @Body() body: AddIssueCommentDto,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireFunctionEditForIssue(idOrCode, issueKey, user);
     return this.issuesService.addComment(idOrCode, issueKey, body, user);
   }
 
   @Delete('comments/:idOrCode')
-  deleteComment(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async deleteComment(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    // Comment delete has no process in path. Look up the comment to recover
+    // the (processId, issueKey) tuple, then enforce function:edit.
+    const comment = await this.prisma.issueComment.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      select: { processId: true, issueKey: true },
+    });
+    if (!comment) throw new NotFoundException(`Comment ${idOrCode} not found`);
+    await this.requireFunctionEditForIssue(comment.processId, comment.issueKey, user);
     return this.issuesService.deleteComment(idOrCode, user);
   }
 
@@ -45,21 +87,23 @@ export class IssuesController {
   }
 
   @Put('processes/:idOrCode/issues/:issueKey/correction')
-  saveCorrection(
+  async saveCorrection(
     @Param('idOrCode') idOrCode: string,
     @Param('issueKey') issueKey: string,
     @Body() body: SaveCorrectionDto,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireFunctionEditForIssue(idOrCode, issueKey, user);
     return this.issuesService.saveCorrection(idOrCode, issueKey, body, user);
   }
 
   @Delete('processes/:idOrCode/issues/:issueKey/correction')
-  clearCorrection(
+  async clearCorrection(
     @Param('idOrCode') idOrCode: string,
     @Param('issueKey') issueKey: string,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireFunctionEditForIssue(idOrCode, issueKey, user);
     return this.issuesService.clearCorrection(idOrCode, issueKey, user);
   }
 
@@ -69,12 +113,13 @@ export class IssuesController {
   }
 
   @Put('processes/:idOrCode/issues/:issueKey/acknowledgment')
-  saveAcknowledgment(
+  async saveAcknowledgment(
     @Param('idOrCode') idOrCode: string,
     @Param('issueKey') issueKey: string,
     @Body() body: SaveAcknowledgmentDto,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireFunctionEditForIssue(idOrCode, issueKey, user);
     return this.issuesService.saveAcknowledgment(idOrCode, issueKey, body, user);
   }
 }

--- a/apps/api/src/processes.controller.ts
+++ b/apps/api/src/processes.controller.ts
@@ -83,6 +83,11 @@ export class ProcessesController {
     return this.processesService.createFunctionAuditRequest(idOrCode, body, user);
   }
 
+  @Get(':idOrCode/me/access')
+  myAccess(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    return this.processesService.getMyAccess(idOrCode, user);
+  }
+
   @Get(':idOrCode/members')
   listMembers(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
     return this.processesService.listMembers(idOrCode, user);

--- a/apps/api/src/processes.controller.ts
+++ b/apps/api/src/processes.controller.ts
@@ -4,7 +4,9 @@ import { AuthGuard } from './auth.guard';
 import { FunctionAccessGuard } from './common/function-access.guard';
 import { CurrentUser } from './common/current-user';
 import { parseIfMatch } from './common/http';
+import { RequiresScope } from './common/requires-scope.decorator';
 import { CreateFunctionAuditRequestDto, CreateProcessDto, UpdateProcessDto } from './dto/processes.dto';
+import { AddProcessMemberDto, UpdateProcessMemberDto } from './dto/process-members.dto';
 import { EscalationsService } from './escalations.service';
 import { ProcessesService } from './processes.service';
 
@@ -67,6 +69,7 @@ export class ProcessesController {
   }
 
   @Get(':idOrCode/escalations')
+  @RequiresScope({ kind: 'escalation-center', action: 'view' })
   escalations(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
     return this.escalationsService.getForProcess(idOrCode, user);
   }
@@ -88,10 +91,20 @@ export class ProcessesController {
   @Post(':idOrCode/members')
   addMember(
     @Param('idOrCode') idOrCode: string,
-    @Body() body: { email?: string; userCode?: string; permission?: 'viewer' | 'editor' | 'owner' },
+    @Body() body: AddProcessMemberDto,
     @CurrentUser() user: SessionUser,
   ) {
     return this.processesService.addMember(idOrCode, body, user);
+  }
+
+  @Patch(':idOrCode/members/:memberIdOrCode')
+  updateMember(
+    @Param('idOrCode') idOrCode: string,
+    @Param('memberIdOrCode') memberIdOrCode: string,
+    @Body() body: UpdateProcessMemberDto,
+    @CurrentUser() user: SessionUser,
+  ) {
+    return this.processesService.updateMember(idOrCode, memberIdOrCode, body, user);
   }
 
   @Delete(':idOrCode/members/:memberIdOrCode')

--- a/apps/api/src/processes.service.ts
+++ b/apps/api/src/processes.service.ts
@@ -347,6 +347,23 @@ export class ProcessesService {
   // Listing is allowed to any member (viewer+); adding/removing requires owner
   // because a member who can add others can grant themselves privileges.
 
+  /**
+   * Returns the current user's effective permission + scope rows for a process.
+   * Drives the workspace UI's disable-state for mutating controls. Mirrors
+   * exactly what AccessScopeService.resolve will use server-side, so the UI
+   * stays in lock-step with enforcement.
+   */
+  async getMyAccess(idOrCode: string, user: SessionUser) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
+    const ctx = await this.accessScope.loadMemberContext(process.id, user.id);
+    if (!ctx) {
+      // findAccessibleProcessOrThrow already enforces membership; this is a
+      // defensive belt-and-suspenders branch.
+      return { permission: 'viewer' as const, scopes: [] };
+    }
+    return { permission: ctx.member.permission, scopes: ctx.scopes };
+  }
+
   async listMembers(idOrCode: string, user: SessionUser) {
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
     const [members, scopesByMember] = await Promise.all([

--- a/apps/api/src/processes.service.ts
+++ b/apps/api/src/processes.service.ts
@@ -1,15 +1,86 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
-import { createId, FUNCTION_REGISTRY } from '@ses/domain';
+import { createId, FUNCTION_REGISTRY, isFunctionId } from '@ses/domain';
 import { createDefaultAuditPolicy } from '@ses/domain';
 import { PrismaService } from './common/prisma.service';
 import { IdentifierService } from './common/identifier.service';
 import { ActivityLogService } from './common/activity-log.service';
 import { ProcessAccessService } from './common/process-access.service';
+import {
+  AccessScopeService,
+  type ScopeWriteInput,
+} from './common/access-scope.service';
+import type {
+  AccessMode,
+  ScopeEntryDto,
+  UpdateProcessMemberDto,
+  AddProcessMemberDto,
+} from './dto/process-members.dto';
 import { FunctionsService } from './functions.service';
 import { RealtimeGateway } from './realtime/realtime.gateway';
 import { requestContext } from './common/request-context';
 import { fromDateOnly, toDateOnly } from './common/http';
+
+/**
+ * Validate the optional scope payload from add/update DTOs and return the
+ * normalized list to write. Returns:
+ *   - undefined when the body neither sets `accessMode` nor sends `scopes`
+ *     (i.e., the caller is not touching scopes at all),
+ *   - [] when accessMode='unrestricted' (or owner): existing scopes will be
+ *     wiped, restoring legacy behavior,
+ *   - normalized ScopeWriteInput[] when accessMode='scoped'.
+ */
+function resolveDesiredScopes(
+  body: { accessMode?: AccessMode; scopes?: ScopeEntryDto[] },
+  permission: 'viewer' | 'editor' | 'owner',
+): ScopeWriteInput[] | undefined {
+  const hasMode = body.accessMode !== undefined;
+  const hasScopes = body.scopes !== undefined;
+  if (!hasMode && !hasScopes) return undefined;
+
+  if (permission === 'owner') {
+    if ((body.scopes?.length ?? 0) > 0 || body.accessMode === 'scoped') {
+      throw new BadRequestException('Owners cannot have scoped permissions');
+    }
+    return [];
+  }
+
+  const mode: AccessMode = body.accessMode ?? (hasScopes && body.scopes!.length > 0 ? 'scoped' : 'unrestricted');
+
+  if (mode === 'unrestricted') {
+    if (body.scopes && body.scopes.length > 0) {
+      throw new BadRequestException('scopes must be empty when accessMode=unrestricted');
+    }
+    return [];
+  }
+
+  // mode === 'scoped'
+  const list = body.scopes ?? [];
+  if (list.length === 0) {
+    throw new BadRequestException('scopes must include at least one entry when accessMode=scoped');
+  }
+
+  const seen = new Set<string>();
+  const out: ScopeWriteInput[] = [];
+  for (const entry of list) {
+    if (entry.scopeType === 'function') {
+      if (!entry.functionId || !isFunctionId(entry.functionId)) {
+        throw new BadRequestException('function scope requires a valid functionId');
+      }
+    } else if (entry.functionId) {
+      throw new BadRequestException(`${entry.scopeType} scope must not include functionId`);
+    }
+    const key = `${entry.scopeType}::${entry.functionId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      scopeType: entry.scopeType,
+      functionId: entry.scopeType === 'function' ? entry.functionId! : null,
+      accessLevel: entry.accessLevel,
+    });
+  }
+  return out;
+}
 
 function serializeProcess(process: {
   id: string;
@@ -46,6 +117,7 @@ export class ProcessesService {
     private readonly identifiers: IdentifierService,
     private readonly activity: ActivityLogService,
     private readonly processAccess: ProcessAccessService,
+    private readonly accessScope: AccessScopeService,
     private readonly functions: FunctionsService,
     private readonly realtime: RealtimeGateway,
   ) {}
@@ -277,11 +349,14 @@ export class ProcessesService {
 
   async listMembers(idOrCode: string, user: SessionUser) {
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'viewer');
-    const members = await this.prisma.processMember.findMany({
-      where: { processId: process.id },
-      orderBy: { addedAt: 'asc' },
-      include: { user: { select: { id: true, displayCode: true, email: true, displayName: true, role: true } } },
-    });
+    const [members, scopesByMember] = await Promise.all([
+      this.prisma.processMember.findMany({
+        where: { processId: process.id },
+        orderBy: { addedAt: 'asc' },
+        include: { user: { select: { id: true, displayCode: true, email: true, displayName: true, role: true } } },
+      }),
+      this.accessScope.listScopesForProcess(process.id),
+    ]);
     return members.map((m) => ({
       id: m.id,
       displayCode: m.displayCode,
@@ -292,12 +367,13 @@ export class ProcessesService {
       globalRole: m.user.role,
       permission: m.permission,
       addedAt: m.addedAt.toISOString(),
+      scopes: scopesByMember.get(m.id) ?? [],
     }));
   }
 
   async addMember(
     idOrCode: string,
-    body: { email?: string; userCode?: string; permission?: 'viewer' | 'editor' | 'owner' },
+    body: AddProcessMemberDto,
     user: SessionUser,
   ) {
     const permission = body.permission ?? 'editor';
@@ -306,6 +382,8 @@ export class ProcessesService {
     }
     const lookup = body.email?.trim().toLowerCase() || body.userCode?.trim();
     if (!lookup) throw new BadRequestException('email or userCode is required');
+
+    const desiredScopes = resolveDesiredScopes(body, permission);
 
     const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'owner');
     const target = await this.prisma.user.findFirst({
@@ -317,12 +395,17 @@ export class ProcessesService {
       const existing = await tx.processMember.findFirst({
         where: { processId: process.id, userId: target.id },
       });
+      let memberId: string;
+      let memberCode: string;
+      let permissionChanged: boolean;
       if (existing) {
-        // Already a member — treat as idempotent upsert of the permission level.
         const updated = await tx.processMember.update({
           where: { id: existing.id },
           data: { permission },
         });
+        memberId = updated.id;
+        memberCode = updated.displayCode;
+        permissionChanged = permission !== existing.permission;
         await this.activity.append(tx, {
           actorId: user.id,
           actorEmail: user.email,
@@ -333,29 +416,139 @@ export class ProcessesService {
           action: 'process.member_updated',
           after: { userCode: target.displayCode, permission },
         });
-        return { id: updated.id, displayCode: updated.displayCode, changed: permission !== existing.permission };
-      }
-      const created = await tx.processMember.create({
-        data: {
-          id: createId(),
-          displayCode: await this.identifiers.nextMemberCode(tx, process.displayCode),
+      } else {
+        const created = await tx.processMember.create({
+          data: {
+            id: createId(),
+            displayCode: await this.identifiers.nextMemberCode(tx, process.displayCode),
+            processId: process.id,
+            userId: target.id,
+            permission,
+            addedById: user.id,
+          },
+        });
+        memberId = created.id;
+        memberCode = created.displayCode;
+        permissionChanged = true;
+        await this.activity.append(tx, {
+          actorId: user.id,
+          actorEmail: user.email,
           processId: process.id,
-          userId: target.id,
-          permission,
-          addedById: user.id,
-        },
-      });
-      await this.activity.append(tx, {
-        actorId: user.id,
-        actorEmail: user.email,
+          entityType: 'process_member',
+          entityId: created.id,
+          entityCode: created.displayCode,
+          action: 'process.member_added',
+          after: { userCode: target.displayCode, email: target.email, permission },
+        });
+      }
+
+      if (desiredScopes !== undefined) {
+        await this.accessScope.replaceMemberScopes(tx, {
+          processId: process.id,
+          memberId,
+          scopes: desiredScopes,
+        });
+        await this.activity.append(tx, {
+          actorId: user.id,
+          actorEmail: user.email,
+          processId: process.id,
+          entityType: 'process_member',
+          entityId: memberId,
+          entityCode: memberCode,
+          action: 'process.member_scopes_set',
+          after: { scopes: desiredScopes },
+        });
+      }
+
+      return { id: memberId, displayCode: memberCode, changed: permissionChanged || desiredScopes !== undefined };
+    });
+  }
+
+  async updateMember(
+    idOrCode: string,
+    memberIdOrCode: string,
+    body: UpdateProcessMemberDto,
+    user: SessionUser,
+  ) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, idOrCode, 'owner');
+    const member = await this.prisma.processMember.findFirst({
+      where: {
         processId: process.id,
-        entityType: 'process_member',
-        entityId: created.id,
-        entityCode: created.displayCode,
-        action: 'process.member_added',
-        after: { userCode: target.displayCode, email: target.email, permission },
+        OR: [{ id: memberIdOrCode }, { displayCode: memberIdOrCode }],
+      },
+      include: { user: { select: { displayCode: true } } },
+    });
+    if (!member) throw new NotFoundException(`Member ${memberIdOrCode} not found`);
+
+    const nextPermission = body.permission ?? member.permission;
+    if (
+      nextPermission !== 'viewer' &&
+      nextPermission !== 'editor' &&
+      nextPermission !== 'owner'
+    ) {
+      throw new BadRequestException('permission must be viewer | editor | owner');
+    }
+    if (member.permission === 'owner' && nextPermission !== 'owner') {
+      const ownerCount = await this.prisma.processMember.count({
+        where: { processId: process.id, permission: 'owner' },
       });
-      return { id: created.id, displayCode: created.displayCode, changed: true };
+      if (ownerCount <= 1) {
+        throw new BadRequestException('Cannot demote the last owner');
+      }
+    }
+
+    // Promotion to owner clears any scope rows; otherwise honor body intent.
+    let desiredScopes: ScopeWriteInput[] | undefined;
+    if (nextPermission === 'owner') {
+      desiredScopes = [];
+    } else {
+      desiredScopes = resolveDesiredScopes(body, nextPermission);
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      let permissionChanged = false;
+      if (body.permission && body.permission !== member.permission) {
+        await tx.processMember.update({
+          where: { id: member.id },
+          data: { permission: nextPermission },
+        });
+        permissionChanged = true;
+        await this.activity.append(tx, {
+          actorId: user.id,
+          actorEmail: user.email,
+          processId: process.id,
+          entityType: 'process_member',
+          entityId: member.id,
+          entityCode: member.displayCode,
+          action: 'process.member_updated',
+          before: { permission: member.permission },
+          after: { permission: nextPermission },
+        });
+      }
+
+      if (desiredScopes !== undefined) {
+        await this.accessScope.replaceMemberScopes(tx, {
+          processId: process.id,
+          memberId: member.id,
+          scopes: desiredScopes,
+        });
+        await this.activity.append(tx, {
+          actorId: user.id,
+          actorEmail: user.email,
+          processId: process.id,
+          entityType: 'process_member',
+          entityId: member.id,
+          entityCode: member.displayCode,
+          action: 'process.member_scopes_set',
+          after: { scopes: desiredScopes },
+        });
+      }
+
+      return {
+        id: member.id,
+        displayCode: member.displayCode,
+        changed: permissionChanged || desiredScopes !== undefined,
+      };
     });
   }
 

--- a/apps/api/src/rules.service.ts
+++ b/apps/api/src/rules.service.ts
@@ -1,10 +1,49 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { AUDIT_RULE_CATALOG, isFunctionId, type FunctionId } from '@ses/domain';
+import { createId } from '@ses/domain';
 import { PrismaService } from './common/prisma.service';
 
 @Injectable()
-export class RulesService {
+export class RulesService implements OnModuleInit {
+  private readonly logger = new Logger(RulesService.name);
+
   constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.syncCatalog();
+  }
+
+  async syncCatalog(): Promise<void> {
+    for (const rule of AUDIT_RULE_CATALOG) {
+      const functionId = (rule.functionId ?? 'over-planning') as FunctionId;
+      await this.prisma.auditRule.upsert({
+        where: { ruleCode: rule.ruleCode },
+        update: {
+          functionId,
+          name: rule.name,
+          category: rule.category,
+          description: rule.description,
+          defaultSeverity: rule.defaultSeverity,
+          isEnabledDefault: rule.isEnabledDefault,
+          paramsSchema: rule.paramsSchema as object,
+          version: rule.version,
+        },
+        create: {
+          id: createId(),
+          ruleCode: rule.ruleCode,
+          functionId,
+          name: rule.name,
+          category: rule.category,
+          description: rule.description,
+          defaultSeverity: rule.defaultSeverity,
+          isEnabledDefault: rule.isEnabledDefault,
+          paramsSchema: rule.paramsSchema as object,
+          version: rule.version,
+        },
+      });
+    }
+    this.logger.log(`Synced ${AUDIT_RULE_CATALOG.length} audit rules`);
+  }
 
   async list(functionId?: string) {
     const where = functionId && isFunctionId(functionId) ? { functionId } : {};

--- a/apps/api/src/tracking-attachments/tracking-attachments.controller.ts
+++ b/apps/api/src/tracking-attachments/tracking-attachments.controller.ts
@@ -17,8 +17,10 @@ import type { Response } from 'express';
 import { memoryStorage } from 'multer';
 import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from '../auth.guard';
+import { AccessScopeService } from '../common/access-scope.service';
 import { CurrentUser } from '../common/current-user';
 import { attachmentContentDisposition } from '../common/http';
+import { PrismaService } from '../common/prisma.service';
 import {
   MAX_ATTACHMENT_BYTES,
   TrackingAttachmentsService,
@@ -27,10 +29,28 @@ import {
 @Controller()
 @UseGuards(AuthGuard)
 export class TrackingAttachmentsController {
-  constructor(private readonly svc: TrackingAttachmentsService) {}
+  constructor(
+    private readonly svc: TrackingAttachmentsService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  private async requireEscalationAccess(
+    idOrCode: string,
+    user: SessionUser,
+    action: 'view' | 'edit',
+  ) {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      select: { processId: true },
+    });
+    if (!entry) return;
+    await this.accessScope.require(entry.processId, user, { kind: 'escalation-center', action });
+  }
 
   @Get('tracking/:idOrCode/attachments')
-  list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    await this.requireEscalationAccess(idOrCode, user, 'view');
     return this.svc.list(idOrCode, user);
   }
 
@@ -42,12 +62,13 @@ export class TrackingAttachmentsController {
       limits: { fileSize: MAX_ATTACHMENT_BYTES },
     }),
   )
-  upload(
+  async upload(
     @Param('idOrCode') idOrCode: string,
     @UploadedFile() file: Express.Multer.File | undefined,
     @Body('comment') comment: string | undefined,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.svc.create(idOrCode, user, file, comment ?? '');
   }
 
@@ -58,6 +79,7 @@ export class TrackingAttachmentsController {
     @CurrentUser() user: SessionUser,
     @Res() res: Response,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'view');
     const { fileName, mimeType, content } = await this.svc.download(idOrCode, attIdOrCode, user);
     res.setHeader('Content-Type', mimeType);
     res.setHeader('Content-Disposition', attachmentContentDisposition(fileName));
@@ -67,21 +89,23 @@ export class TrackingAttachmentsController {
   }
 
   @Patch('tracking/:idOrCode/attachments/:attIdOrCode')
-  patch(
+  async patch(
     @Param('idOrCode') idOrCode: string,
     @Param('attIdOrCode') attIdOrCode: string,
     @Body() body: { comment: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.svc.patch(idOrCode, attIdOrCode, user, body);
   }
 
   @Delete('tracking/:idOrCode/attachments/:attIdOrCode')
-  remove(
+  async remove(
     @Param('idOrCode') idOrCode: string,
     @Param('attIdOrCode') attIdOrCode: string,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.svc.remove(idOrCode, attIdOrCode, user);
   }
 }

--- a/apps/api/src/tracking-bulk.controller.ts
+++ b/apps/api/src/tracking-bulk.controller.ts
@@ -1,59 +1,95 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from './auth.guard';
+import { AccessScopeService } from './common/access-scope.service';
 import { CurrentUser } from './common/current-user';
+import { PrismaService } from './common/prisma.service';
+import { ProcessAccessService } from './common/process-access.service';
 import { TrackingBulkService } from './tracking-bulk.service';
 import type { ComposeDraftPayload } from './tracking-compose/tracking-compose.service';
 
 @Controller('tracking/bulk')
 @UseGuards(AuthGuard)
 export class TrackingBulkController {
-  constructor(private readonly trackingBulk: TrackingBulkService) {}
+  constructor(
+    private readonly trackingBulk: TrackingBulkService,
+    private readonly accessScope: AccessScopeService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  private async requireEditForTrackingIds(trackingIds: string[], user: SessionUser) {
+    const first = trackingIds[0];
+    if (!first) return;
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: first }, { displayCode: first }] },
+      select: { processId: true },
+    });
+    if (!entry) return;
+    await this.accessScope.require(entry.processId, user, {
+      kind: 'escalation-center',
+      action: 'edit',
+    });
+  }
+
+  private async requireEditForProcess(processIdOrCode: string, user: SessionUser) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'viewer');
+    await this.accessScope.require(process.id, user, {
+      kind: 'escalation-center',
+      action: 'edit',
+    });
+  }
 
   @Post('compose')
-  compose(
+  async compose(
     @Body() body: { trackingIds: string[]; payload?: Partial<ComposeDraftPayload> },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.composeBulk(body, user);
   }
 
   @Post('send')
-  send(
+  async send(
     @Body() body: { trackingIds: string[]; payload: ComposeDraftPayload & { sources: string[] } },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.sendBulk(body, user);
   }
 
   @Post('resolve')
-  resolve(@Body() body: { trackingIds: string[] }, @CurrentUser() user: SessionUser) {
+  async resolve(@Body() body: { trackingIds: string[] }, @CurrentUser() user: SessionUser) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.markResolved(body.trackingIds, user);
   }
 
   @Post('acknowledge')
-  acknowledge(@Body() body: { trackingIds: string[]; note?: string }, @CurrentUser() user: SessionUser) {
+  async acknowledge(@Body() body: { trackingIds: string[]; note?: string }, @CurrentUser() user: SessionUser) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.markAcknowledged(body.trackingIds, body.note ?? '', user);
   }
 
   @Post('snooze')
-  snooze(
+  async snooze(
     @Body() body: { trackingIds: string[]; days: number; note?: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.snooze(body.trackingIds, body.days, body.note ?? '', user);
   }
 
   @Post('reescalate')
-  reescalate(
+  async reescalate(
     @Body() body: { trackingIds: string[]; note?: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEditForTrackingIds(body.trackingIds, user);
     return this.trackingBulk.reescalate(body.trackingIds, body.note ?? '', user);
   }
 
   @Post('broadcast')
-  broadcast(
+  async broadcast(
     @Body()
     body: {
       processIdOrCode: string;
@@ -62,6 +98,7 @@ export class TrackingBulkController {
     },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEditForProcess(body.processIdOrCode, user);
     return this.trackingBulk.broadcast(body, user);
   }
 }

--- a/apps/api/src/tracking-compose/tracking-compose.controller.ts
+++ b/apps/api/src/tracking-compose/tracking-compose.controller.ts
@@ -1,58 +1,83 @@
 import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from '../auth.guard';
+import { AccessScopeService } from '../common/access-scope.service';
 import { CurrentUser } from '../common/current-user';
+import { PrismaService } from '../common/prisma.service';
 import { TrackingComposeService, type ComposeDraftPayload } from './tracking-compose.service';
 
 @Controller()
 @UseGuards(AuthGuard)
 export class TrackingComposeController {
-  constructor(private readonly composeService: TrackingComposeService) {}
+  constructor(
+    private readonly composeService: TrackingComposeService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  private async requireEscalationAccess(
+    idOrCode: string,
+    user: SessionUser,
+    action: 'view' | 'edit',
+  ) {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      select: { processId: true },
+    });
+    if (!entry) return;
+    await this.accessScope.require(entry.processId, user, { kind: 'escalation-center', action });
+  }
 
   @Get('tracking/:idOrCode/compose-status')
-  composeStatus(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async composeStatus(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    await this.requireEscalationAccess(idOrCode, user, 'view');
     return this.composeService.composeStatus(idOrCode, user);
   }
 
   @Post('tracking/:idOrCode/preview')
-  preview(
+  async preview(
     @Param('idOrCode') idOrCode: string,
     @Body() body: Partial<ComposeDraftPayload>,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.composeService.preview(idOrCode, user, body);
   }
 
   @Post('tracking/:idOrCode/compose')
-  saveComposeDraft(
+  async saveComposeDraft(
     @Param('idOrCode') idOrCode: string,
     @Body() body: ComposeDraftPayload,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.composeService.saveDraft(idOrCode, user, body);
   }
 
   @Post('tracking/:idOrCode/compose/discard')
-  discard(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async discard(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.composeService.discardDraft(idOrCode, user);
   }
 
   @Post('tracking/:idOrCode/send')
-  send(
+  async send(
     @Param('idOrCode') idOrCode: string,
     @Body() body: ComposeDraftPayload & { sources: string[] },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.composeService.send(idOrCode, user, body);
   }
 
   // Issue #75: admin-only cycle reset. Zeroes outlookCount / teamsCount
   // so the channel gate re-opens at Outlook #1.
   @Post('tracking/:idOrCode/force-reescalate')
-  forceReescalate(
+  async forceReescalate(
     @Param('idOrCode') idOrCode: string,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccess(idOrCode, user, 'edit');
     return this.composeService.forceReescalate(idOrCode, user);
   }
 }

--- a/apps/api/src/tracking-compose/tracking-compose.service.ts
+++ b/apps/api/src/tracking-compose/tracking-compose.service.ts
@@ -9,11 +9,16 @@ import { EscalationStage, Prisma } from '@prisma/client';
 import type { SessionUser } from '@ses/domain';
 import {
   assertTransition,
+  AUDIT_RULES_BY_CODE,
+  buildFindingsByEngineHtmlTable,
   buildFindingsByEngineMarkdown,
+  buildFindingsByEngineTextTable,
   createId,
+  getFunctionLabel,
   substitute,
   type EngineFindingLine,
   type EscalationStage as DomainEscalationStage,
+  type FunctionId,
 } from '@ses/domain';
 import { PrismaService } from '../common/prisma.service';
 import { IdentifierService } from '../common/identifier.service';
@@ -37,6 +42,8 @@ export type ComposeDraftPayload = {
   authorNote?: string;
   /** ISO-8601 date for the {{dueDate}} slot. */
   deadlineAt?: string | null;
+  /** Map of projectNo → URL the auditor pasted in. Empty entries are ignored. */
+  projectLinks?: Record<string, string>;
 };
 
 /**
@@ -74,6 +81,73 @@ function firstName(full: string): string {
   const t = full.trim();
   if (!t) return '';
   return t.split(/\s+/)[0] ?? t;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const SLOT_TOKEN = /\{([a-zA-Z][a-zA-Z0-9_]*)\}/g;
+
+/**
+ * HTML-aware substitution: literal template text is HTML-escaped and \n is
+ * turned into <br>, while slot values (e.g. the findings table) are inserted
+ * verbatim so their pre-built markup survives.
+ */
+function substituteHtml(template: string, htmlSlots: Record<string, string>): string {
+  let result = '';
+  let lastIdx = 0;
+  SLOT_TOKEN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SLOT_TOKEN.exec(template)) !== null) {
+    const literal = template.slice(lastIdx, match.index);
+    result += escapeHtml(literal).replace(/\n/g, '<br>');
+    const slotName = match[1] ?? '';
+    const value = htmlSlots[slotName];
+    result += value ?? '';
+    lastIdx = match.index + match[0].length;
+  }
+  result += escapeHtml(template.slice(lastIdx)).replace(/\n/g, '<br>');
+  return result;
+}
+
+const DEFAULT_SUBJECT_TEMPLATE =
+  'Action Required — {processName}: Open Findings ({findingsCount})';
+
+const DEFAULT_BODY_TEMPLATE = [
+  'Hi {managerFirstName},',
+  '',
+  'I hope you are doing well.',
+  '',
+  'We are members of the Quality Governance Team writing regarding open findings on {processName}. During our quality checks, we observed the following items that need your attention. Could you please review and do the needful at the earliest?',
+  '',
+  '{findingsByEngine}',
+  '',
+  'Kindly respond by {dueDate}. If you have any questions, please reach out.',
+  '',
+  'Thank you,',
+  'Quality Governance Team',
+  '{auditRunDate} — {auditorName}',
+].join('\n');
+
+function formatDueDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function wrapEmailHtml(innerHtml: string): string {
+  return (
+    `<div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#1f2937;line-height:1.55;">` +
+    innerHtml +
+    `</div>`
+  );
 }
 
 @Injectable()
@@ -123,8 +197,8 @@ export class TrackingComposeService {
 
   async preview(idOrCode: string, user: SessionUser, body: Partial<ComposeDraftPayload>) {
     const entry = await this.loadEntry(idOrCode, user);
-    const { subject, text } = await this.resolveContent(entry, user, body);
-    return { subject, body: text };
+    const { subject, text, html } = await this.resolveContent(entry, user, body);
+    return { subject, body: text, bodyHtml: html };
   }
 
   async saveDraft(idOrCode: string, user: SessionUser, body: ComposeDraftPayload) {
@@ -225,7 +299,7 @@ export class TrackingComposeService {
       throw new BadRequestException(`Send is not allowed from stage ${entry.stage}.`);
     }
 
-    const { subject, text, channel, managerEmail } = await this.resolveContent(entry, user, body);
+    const { subject, text, html, channel, managerEmail } = await this.resolveContent(entry, user, body);
     const sendChannel: EscalationSendChannel = channel ?? 'email';
     // Channel gate (Issue #75): the 2-Outlooks-then-1-Teams cycle is
     // enforced here so race conditions between multiple auditors can't
@@ -338,6 +412,7 @@ export class TrackingComposeService {
       channel: sendChannel,
       subject,
       body: text,
+      bodyHtml: html,
       to: to.toLowerCase(),
       cc: (body.cc ?? []).map((c) => c.trim()).filter(Boolean),
     };
@@ -424,13 +499,23 @@ export class TrackingComposeService {
     },
     user: SessionUser,
     overrides: Partial<ComposeDraftPayload>,
-  ): Promise<{ subject: string; text: string; channel: EscalationSendChannel; managerEmail: string | null }> {
+  ): Promise<{
+    subject: string;
+    text: string;
+    html: string;
+    channel: EscalationSendChannel;
+    managerEmail: string | null;
+  }> {
     const tenantId = this.tenantId(user);
     const stageKey = stageKeyForLevel(entry.escalationLevel);
     const tpl = await this.pickTemplate(tenantId, stageKey, overrides.templateId);
     const draft = (entry.composeDraft ?? {}) as Partial<ComposeDraftPayload>;
-    const baseSubject = (overrides.subject ?? draft.subject ?? tpl?.subject ?? 'Escalation').trim();
-    const baseBody = (overrides.body ?? draft.body ?? tpl?.body ?? '').trim();
+    // When no template configures a subject/body, fall back to the bundled
+    // professional default rather than the older terse "Escalation" stub.
+    const subjectSource = overrides.subject ?? draft.subject ?? tpl?.subject ?? '';
+    const bodySource = overrides.body ?? draft.body ?? tpl?.body ?? '';
+    const baseSubject = (subjectSource.trim() || DEFAULT_SUBJECT_TEMPLATE).trim();
+    const baseBody = (bodySource.trim() || DEFAULT_BODY_TEMPLATE).trim();
     const channel = (overrides.channel ?? draft.channel ?? (tpl?.channel as EscalationSendChannel) ?? 'email') as EscalationSendChannel;
     if (channel !== 'email' && channel !== 'teams' && channel !== 'both') {
       throw new BadRequestException('Invalid channel');
@@ -441,39 +526,158 @@ export class TrackingComposeService {
     const managerEmail = row?.resolvedEmail ?? row?.directoryEmail ?? entry.managerEmail ?? null;
     const lines: EngineFindingLine[] = [];
     const removed = new Set((overrides.removedEngineIds ?? draft.removedEngineIds ?? []).map(String));
+    const issueKeys: string[] = [];
+    if (row) {
+      for (const engineId of esc.engineIds) {
+        if (removed.has(engineId)) continue;
+        for (const f of row.findingsByEngine[engineId] ?? []) {
+          if (f.issueKey) issueKeys.push(f.issueKey);
+        }
+      }
+    }
+    // Pull the rich AuditIssue context for every finding the email is
+    // about to mention. Restrict to this process so a colliding issueKey
+    // from another process can't leak in. Latest occurrence wins when an
+    // issueKey appears in more than one run.
+    const issueDetails = issueKeys.length
+      ? await this.prisma.auditIssue.findMany({
+          where: {
+            issueKey: { in: issueKeys },
+            auditRun: { processId: entry.processId },
+          },
+          select: {
+            issueKey: true,
+            ruleCode: true,
+            severity: true,
+            reason: true,
+            thresholdLabel: true,
+            recommendedAction: true,
+            sheetName: true,
+            projectManager: true,
+            projectState: true,
+            effort: true,
+            missingMonths: true,
+            zeroMonthCount: true,
+            auditRun: { select: { completedAt: true, startedAt: true } },
+          },
+        })
+      : [];
+    const issueByKey = new Map<string, (typeof issueDetails)[number]>();
+    for (const iss of issueDetails) {
+      const prev = issueByKey.get(iss.issueKey);
+      const t = (x: typeof iss) =>
+        x.auditRun.completedAt?.getTime() ?? x.auditRun.startedAt.getTime() ?? 0;
+      if (!prev || t(iss) >= t(prev)) issueByKey.set(iss.issueKey, iss);
+    }
+    // Auditor-supplied per-project links. Only http(s) URLs make it into
+    // the rendered table; anything else is silently dropped so the column
+    // can't carry junk into the manager's inbox.
+    const linksRaw = (overrides.projectLinks ?? draft.projectLinks ?? {}) as Record<string, unknown>;
+    const projectLinks = new Map<string, string>();
+    for (const [pid, url] of Object.entries(linksRaw)) {
+      if (typeof url !== 'string') continue;
+      const trimmed = url.trim();
+      if (!trimmed) continue;
+      if (!/^https?:\/\//i.test(trimmed)) continue;
+      projectLinks.set(pid.trim(), trimmed);
+    }
     if (row) {
       for (const engineId of esc.engineIds) {
         if (removed.has(engineId)) continue;
         const findings = row.findingsByEngine[engineId] ?? [];
         for (const f of findings) {
+          const iss = f.issueKey ? issueByKey.get(f.issueKey) : null;
+          const ruleEntry = iss ? AUDIT_RULES_BY_CODE.get(iss.ruleCode) : null;
+          const ruleName = ruleEntry?.name ?? '';
+          const severity = iss?.severity ?? ruleEntry?.defaultSeverity ?? '';
+          const missingFieldLabel =
+            engineId === ('master-data' as FunctionId) && ruleName
+              ? ruleName.replace(/\s*required$/i, '').trim()
+              : null;
+          const months = Array.isArray(iss?.missingMonths)
+            ? (iss!.missingMonths as unknown[]).map((m) => String(m).trim()).filter(Boolean).join(', ')
+            : null;
+          const projectLink = f.projectNo ? projectLinks.get(f.projectNo) ?? null : null;
           lines.push({
             engineKey: engineId,
-            engineLabel: engineId,
+            engineLabel: getFunctionLabel(engineId as FunctionId),
             projectNo: f.projectNo ?? '',
             projectName: f.projectName ?? '',
-            severity: '',
-            ruleName: '',
-            notes: '',
+            severity,
+            ruleName,
+            notes: iss?.reason ?? '',
+            issueKey: f.issueKey,
+            detail: {
+              ruleCode: iss?.ruleCode ?? '',
+              ruleName,
+              ruleCategory: ruleEntry?.category ?? '',
+              severity,
+              reason: iss?.reason ?? null,
+              thresholdLabel: iss?.thresholdLabel ?? null,
+              recommendedAction: iss?.recommendedAction ?? null,
+              sheetName: iss?.sheetName ?? null,
+              projectManager: iss?.projectManager ?? null,
+              projectState: iss?.projectState ?? null,
+              effort: iss?.effort ?? null,
+              affectedMonths: months,
+              zeroMonthCount: iss?.zeroMonthCount ?? null,
+              missingFieldLabel,
+              projectLink,
+            },
           });
         }
       }
     }
     const findingsMd = buildFindingsByEngineMarkdown(lines);
+    const findingsTxt = buildFindingsByEngineTextTable(lines);
+    const findingsHtml = buildFindingsByEngineHtmlTable(lines);
     const latestRun = await this.prisma.auditRun.findFirst({
       where: { processId: entry.processId, OR: [{ status: 'completed' }, { completedAt: { not: null } }] },
       orderBy: { completedAt: 'desc' },
       include: { ranBy: { select: { displayName: true } } },
     });
-    const slots: Record<string, string> = {
+    const auditRunDate = latestRun?.completedAt
+      ? latestRun.completedAt.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+      : latestRun?.startedAt
+      ? latestRun.startedAt.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+      : '';
+    const slaDeadline = row?.slaDueAt
+      ? new Date(row.slaDueAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+      : '';
+    const dueDate = formatDueDate(overrides.deadlineAt ?? draft.deadlineAt ?? null);
+    const auditorName = latestRun?.ranBy.displayName ?? user.displayName;
+
+    // Text slots — used by mailto / Teams handoff. Keep the markdown-style
+    // findings list so plain-text mail clients render something readable.
+    const textSlots: Record<string, string> = {
       managerFirstName: firstName(entry.managerName),
+      managerName: entry.managerName,
       processName: entry.process.name,
-      findingsByEngine: findingsMd,
-      slaDeadline: row?.slaDueAt ? new Date(row.slaDueAt).toISOString() : '',
-      auditRunDate: latestRun?.completedAt?.toISOString() ?? latestRun?.startedAt.toISOString() ?? '',
-      auditorName: latestRun?.ranBy.displayName ?? user.displayName,
+      findingsByEngine: findingsTxt || findingsMd,
+      findingsCount: String(lines.length),
+      slaDeadline,
+      dueDate: dueDate || slaDeadline || '',
+      auditRunDate,
+      auditorName,
     };
-    const subject = substitute(baseSubject, slots);
-    const text = substitute(baseBody, slots);
-    return { subject, text, channel, managerEmail };
+
+    // HTML slots — every value is HTML-safe (escaped strings or known-good
+    // markup like the findings table).
+    const htmlSlots: Record<string, string> = {
+      managerFirstName: escapeHtml(firstName(entry.managerName)),
+      managerName: escapeHtml(entry.managerName),
+      processName: escapeHtml(entry.process.name),
+      findingsByEngine: findingsHtml,
+      findingsCount: String(lines.length),
+      slaDeadline: escapeHtml(slaDeadline),
+      dueDate: escapeHtml(dueDate || slaDeadline || ''),
+      auditRunDate: escapeHtml(auditRunDate),
+      auditorName: escapeHtml(auditorName),
+    };
+
+    const subject = substitute(baseSubject, textSlots);
+    const text = substitute(baseBody, textSlots);
+    const html = wrapEmailHtml(substituteHtml(baseBody, htmlSlots));
+    return { subject, text, html, channel, managerEmail };
   }
 }

--- a/apps/api/src/tracking-stage/tracking-stage.controller.ts
+++ b/apps/api/src/tracking-stage/tracking-stage.controller.ts
@@ -1,13 +1,38 @@
-import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post, Query, UseGuards } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from '../auth.guard';
+import { AccessScopeService } from '../common/access-scope.service';
 import { CurrentUser } from '../common/current-user';
+import { PrismaService } from '../common/prisma.service';
 import { TrackingStageService } from './tracking-stage.service';
 
 @Controller()
 @UseGuards(AuthGuard)
 export class TrackingStageController {
-  constructor(private readonly stage: TrackingStageService) {}
+  constructor(
+    private readonly stage: TrackingStageService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Tracking entries are escalation-center artifacts. An escalation-viewer
+   * (or a function-only scoped user) must not be able to comment, verify, or
+   * unverify. The legacy service-layer check only consults base permission;
+   * this resolves the entry → process and requires escalation-center:edit.
+   */
+  private async requireEscalationEdit(idOrCode: string, user: SessionUser): Promise<string> {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      select: { processId: true },
+    });
+    if (!entry) throw new NotFoundException(`Tracking entry ${idOrCode} not found`);
+    await this.accessScope.require(entry.processId, user, {
+      kind: 'escalation-center',
+      action: 'edit',
+    });
+    return entry.processId;
+  }
 
   @Get('tracking/:idOrCode/stage-comments')
   list(
@@ -19,27 +44,30 @@ export class TrackingStageController {
   }
 
   @Post('tracking/:idOrCode/stage-comments')
-  add(
+  async add(
     @Param('idOrCode') idOrCode: string,
     @Body() body: { stage: string; body: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationEdit(idOrCode, user);
     return this.stage.addComment(idOrCode, user, body);
   }
 
   @Post('tracking/:idOrCode/verify')
-  verify(
+  async verify(
     @Param('idOrCode') idOrCode: string,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationEdit(idOrCode, user);
     return this.stage.verify(idOrCode, user);
   }
 
   @Delete('tracking/:idOrCode/verify')
-  revert(
+  async revert(
     @Param('idOrCode') idOrCode: string,
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationEdit(idOrCode, user);
     return this.stage.revertVerification(idOrCode, user);
   }
 }

--- a/apps/api/src/tracking.controller.ts
+++ b/apps/api/src/tracking.controller.ts
@@ -1,21 +1,52 @@
 import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import type { SessionUser } from '@ses/domain';
 import { AuthGuard } from './auth.guard';
+import { AccessScopeService } from './common/access-scope.service';
 import { CurrentUser } from './common/current-user';
+import { PrismaService } from './common/prisma.service';
+import { ProcessAccessService } from './common/process-access.service';
 import { TrackingService } from './tracking.service';
 
 @Controller()
 @UseGuards(AuthGuard)
 export class TrackingController {
-  constructor(private readonly trackingService: TrackingService) {}
+  constructor(
+    private readonly trackingService: TrackingService,
+    private readonly processAccess: ProcessAccessService,
+    private readonly accessScope: AccessScopeService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  private async requireEscalationAccessForProcess(
+    processIdOrCode: string,
+    user: SessionUser,
+    action: 'view' | 'edit',
+  ) {
+    const process = await this.processAccess.findAccessibleProcessOrThrow(user, processIdOrCode, 'viewer');
+    await this.accessScope.require(process.id, user, { kind: 'escalation-center', action });
+  }
+
+  private async requireEscalationAccessForEntry(
+    idOrCode: string,
+    user: SessionUser,
+    action: 'view' | 'edit',
+  ) {
+    const entry = await this.prisma.trackingEntry.findFirst({
+      where: { OR: [{ id: idOrCode }, { displayCode: idOrCode }] },
+      select: { processId: true },
+    });
+    if (!entry) return;
+    await this.accessScope.require(entry.processId, user, { kind: 'escalation-center', action });
+  }
 
   @Get('processes/:idOrCode/tracking')
-  list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async list(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    await this.requireEscalationAccessForProcess(idOrCode, user, 'view');
     return this.trackingService.list(idOrCode, user);
   }
 
   @Post('processes/:idOrCode/tracking')
-  upsert(
+  async upsert(
     @Param('idOrCode') idOrCode: string,
     @Body() body: {
       managerKey: string;
@@ -27,11 +58,12 @@ export class TrackingController {
     },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccessForProcess(idOrCode, user, 'edit');
     return this.trackingService.upsert(idOrCode, body, user);
   }
 
   @Patch('tracking/:idOrCode')
-  patch(
+  async patch(
     @Param('idOrCode') idOrCode: string,
     @Body() body: {
       managerKey?: string;
@@ -43,29 +75,33 @@ export class TrackingController {
     },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccessForEntry(idOrCode, user, 'edit');
     return this.trackingService.patchEntry(idOrCode, body, user);
   }
 
   @Get('tracking/:idOrCode/events')
-  listEvents(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+  async listEvents(@Param('idOrCode') idOrCode: string, @CurrentUser() user: SessionUser) {
+    await this.requireEscalationAccessForEntry(idOrCode, user, 'view');
     return this.trackingService.listEvents(idOrCode, user);
   }
 
   @Post('tracking/:idOrCode/events')
-  addEvent(
+  async addEvent(
     @Param('idOrCode') idOrCode: string,
     @Body() body: { channel: string; note?: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccessForEntry(idOrCode, user, 'edit');
     return this.trackingService.addEvent(idOrCode, body, user);
   }
 
   @Post('tracking/:idOrCode/transition')
-  transition(
+  async transition(
     @Param('idOrCode') idOrCode: string,
     @Body() body: { to: string; reason: string; sourceAction: string },
     @CurrentUser() user: SessionUser,
   ) {
+    await this.requireEscalationAccessForEntry(idOrCode, user, 'edit');
     return this.trackingService.transition(idOrCode, body, user);
   }
 }

--- a/apps/api/test/access-scope.service.test.ts
+++ b/apps/api/test/access-scope.service.test.ts
@@ -1,0 +1,147 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  AccessScopeService,
+  type ScopeContext,
+  type ScopeRow,
+} from '../src/common/access-scope.service';
+
+// The resolver is pure — passing a stubbed prisma is fine because we never
+// touch it from resolve(). Other AccessScopeService methods (load/replace)
+// are exercised by the e2e suite.
+const service = new AccessScopeService({} as never);
+
+function ctx(kind: ScopeContext['kind'], action: 'view' | 'edit', functionId?: string): ScopeContext {
+  return functionId ? { kind, action, functionId: functionId as never } : { kind, action };
+}
+
+describe('AccessScopeService.resolve — legacy fallback (no scope rows)', () => {
+  const noScopes: ScopeRow[] = [];
+
+  it('viewer member viewing a function → allow', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes: noScopes, ctx: ctx('function', 'view', 'master-data') });
+    assert.equal(r.allowed, true);
+  });
+
+  it('viewer member editing → deny', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes: noScopes, ctx: ctx('function', 'edit', 'master-data') });
+    assert.equal(r.allowed, false);
+  });
+
+  it('editor member editing a function → allow', () => {
+    const r = service.resolve({ member: { permission: 'editor' }, scopes: noScopes, ctx: ctx('function', 'edit', 'over-planning') });
+    assert.equal(r.allowed, true);
+  });
+});
+
+describe('AccessScopeService.resolve — owner short-circuit', () => {
+  it('owner allowed regardless of context', () => {
+    const r = service.resolve({
+      member: { permission: 'owner' },
+      // Even with bogus restrictive scope rows, owner always wins.
+      scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      ctx: ctx('function', 'edit', 'over-planning'),
+    });
+    assert.equal(r.allowed, true);
+  });
+});
+
+describe('AccessScopeService.resolve — scoped function permissions', () => {
+  const scopes: ScopeRow[] = [
+    { scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' },
+  ];
+
+  it('editor on the scoped function → allow', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('function', 'edit', 'master-data') });
+    assert.equal(r.allowed, true);
+  });
+
+  it('GET on a non-scoped function → deny (no all-functions row)', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('function', 'view', 'over-planning') });
+    assert.equal(r.allowed, false);
+  });
+
+  it('GET on the escalation center → deny (no escalation row)', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('escalation-center', 'view') });
+    assert.equal(r.allowed, false);
+  });
+});
+
+describe('AccessScopeService.resolve — all-functions floor', () => {
+  const scopes: ScopeRow[] = [
+    { scopeType: 'all-functions', functionId: null, accessLevel: 'viewer' },
+  ];
+
+  it('viewer floor lets read on any function', () => {
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('function', 'view', 'function-rate') });
+    assert.equal(r.allowed, true);
+  });
+
+  it('viewer floor blocks edit on any function', () => {
+    const r = service.resolve({ member: { permission: 'editor' }, scopes, ctx: ctx('function', 'edit', 'function-rate') });
+    assert.equal(r.allowed, false);
+  });
+
+  it('most permissive of all-functions + per-function wins', () => {
+    const mixed: ScopeRow[] = [
+      { scopeType: 'all-functions', functionId: null, accessLevel: 'viewer' },
+      { scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' },
+    ];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes: mixed, ctx: ctx('function', 'edit', 'master-data') });
+    assert.equal(r.allowed, true);
+  });
+});
+
+describe('AccessScopeService.resolve — escalation-center scope', () => {
+  it('escalation-only viewer can view escalations', () => {
+    const scopes: ScopeRow[] = [{ scopeType: 'escalation-center', functionId: null, accessLevel: 'viewer' }];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('escalation-center', 'view') });
+    assert.equal(r.allowed, true);
+  });
+
+  it('escalation-only viewer cannot view function files', () => {
+    const scopes: ScopeRow[] = [{ scopeType: 'escalation-center', functionId: null, accessLevel: 'viewer' }];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('function', 'view', 'master-data') });
+    assert.equal(r.allowed, false);
+  });
+
+  it('legacy editor permission is overridden once escalation scope exists', () => {
+    // Member has a base 'editor' permission but only an escalation scope row.
+    // For function routes we should deny because scoped configuration is in
+    // effect and there is no function/all-functions grant.
+    const scopes: ScopeRow[] = [{ scopeType: 'escalation-center', functionId: null, accessLevel: 'viewer' }];
+    const r = service.resolve({ member: { permission: 'editor' }, scopes, ctx: ctx('function', 'view', 'master-data') });
+    assert.equal(r.allowed, false);
+  });
+});
+
+describe('AccessScopeService.resolve — process-wide non-function context', () => {
+  it('any scoped member can view process-wide pages', () => {
+    const scopes: ScopeRow[] = [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('all-functions', 'view') });
+    assert.equal(r.allowed, true);
+  });
+
+  it('process-wide edit requires all-functions row or owner', () => {
+    const scopes: ScopeRow[] = [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' }];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('all-functions', 'edit') });
+    assert.equal(r.allowed, false);
+  });
+
+  it('process-wide edit allowed with all-functions:editor', () => {
+    const scopes: ScopeRow[] = [{ scopeType: 'all-functions', functionId: null, accessLevel: 'editor' }];
+    const r = service.resolve({ member: { permission: 'viewer' }, scopes, ctx: ctx('all-functions', 'edit') });
+    assert.equal(r.allowed, true);
+  });
+});
+
+describe('AccessScopeService.resolve — function context without functionId', () => {
+  it('rejects when caller forgot to attach functionId', () => {
+    const r = service.resolve({
+      member: { permission: 'viewer' },
+      scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' }],
+      ctx: ctx('function', 'view'),
+    });
+    assert.equal(r.allowed, false);
+  });
+});

--- a/apps/api/test/function-rate-projectid-mapping.test.ts
+++ b/apps/api/test/function-rate-projectid-mapping.test.ts
@@ -27,6 +27,15 @@ type Private = {
     src: unknown,
   ) => Promise<Map<string, string>>;
   applyProjectIdToManager: (issues: AuditIssue[], map: Map<string, string>) => number;
+  prepareIssuesForPersistence: (
+    issues: AuditIssue[],
+    processDisplayCode: string,
+    displayCodes: string[],
+  ) => Array<AuditIssue & { persistedId: string; displayCode: string; issueKey: string }>;
+  assertKnownRuleCodes: (
+    issues: Array<{ persistedId: string; ruleCode?: string | null; ruleId?: string | null }>,
+    validRuleCodes: Set<string>,
+  ) => void;
 };
 
 function priv(svc: AuditsService): Private {
@@ -116,6 +125,38 @@ describe('applyProjectIdToManager', () => {
     const map = new Map([['fr-001', 'Wagner, Anna']]);
     const count = priv(svc).applyProjectIdToManager(issues, map);
     assert.equal(count, 0);
+  });
+});
+
+describe('audit issue persistence guards', () => {
+  it('assigns fresh persisted ids for each saved issue so reruns do not reuse engine ids', () => {
+    const svc = makeService();
+    const sourceIssues = [
+      makeIssue({ id: 'engine-issue-1', projectNo: 'FR-001', sheetName: 'Sheet1', rowIndex: 1, auditStatus: 'RUL-FR-RATE-ZERO' }),
+      makeIssue({ id: 'engine-issue-1', projectNo: 'FR-002', sheetName: 'Sheet1', rowIndex: 2, auditStatus: 'RUL-FR-RATE-ZERO' }),
+    ];
+    const persisted = priv(svc).prepareIssuesForPersistence(sourceIssues, 'PRC-1', ['ISS-1', 'ISS-2']);
+
+    assert.equal(persisted.length, 2);
+    assert.equal(persisted[0]!.displayCode, 'ISS-1');
+    assert.equal(persisted[1]!.displayCode, 'ISS-2');
+    assert.notEqual(persisted[0]!.persistedId, sourceIssues[0]!.id);
+    assert.notEqual(persisted[1]!.persistedId, sourceIssues[1]!.id);
+    assert.notEqual(persisted[0]!.persistedId, persisted[1]!.persistedId);
+    assert.match(persisted[0]!.issueKey, /^IKY-/);
+    assert.match(persisted[1]!.issueKey, /^IKY-/);
+  });
+
+  it('throws BadRequestException when an audit emits an unknown rule code', () => {
+    const svc = makeService();
+    assert.throws(
+      () =>
+        priv(svc).assertKnownRuleCodes(
+          [{ persistedId: 'iss-1', ruleCode: 'RUL-NOT-SEEDED' }],
+          new Set(['RUL-MD-MISSING-EFFORT']),
+        ),
+      (err: unknown) => err instanceof BadRequestException,
+    );
   });
 });
 

--- a/apps/api/test/process-scope-rbac.e2e-spec.ts
+++ b/apps/api/test/process-scope-rbac.e2e-spec.ts
@@ -43,18 +43,32 @@ function freshEmail(label: string): string {
 
 async function signup(server: ReturnType<INestApplication['getHttpServer']>, email: string) {
   const agent = request.agent(server);
-  await agent
-    .post('/api/v1/auth/signup')
-    .send({ email, displayName: email.split('@')[0], password: 'pw12345678', role: 'auditor' })
-    .expect(201);
-  return agent;
+  // The global ThrottlerGuard (400 req/min) can fire late in the e2e suite
+  // because every prior test contributes to the same window. Retry briefly
+  // on 429 so legitimate signups don't fail the suite.
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const res = await agent
+      .post('/api/v1/auth/signup')
+      .send({ email, displayName: email.split('@')[0], password: 'pw12345678', role: 'auditor' });
+    if (res.status === 201) return agent;
+    if (res.status !== 429) {
+      throw new Error(`signup failed for ${email}: status=${res.status} body=${JSON.stringify(res.body)}`);
+    }
+    await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+  }
+  throw new Error(`signup repeatedly throttled for ${email}`);
 }
 
 describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
   let app: INestApplication;
+  // One owner is reused across most tests so we don't burn through the global
+  // 400-req/min throttle quota on extra signups + logins. Each test still
+  // creates its own process and (where needed) a fresh member.
+  let owner: ReturnType<typeof request.agent>;
 
   before(async () => {
     app = await createApp();
+    owner = await signup(app.getHttpServer(), freshEmail('owner-shared'));
   });
 
   after(async () => {
@@ -63,9 +77,7 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
 
   it('member without scope rows behaves like before (legacy fallback)', async () => {
     const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-legacy');
     const memberEmail = freshEmail('member-legacy');
-    const owner = await signup(server, ownerEmail);
     await signup(server, memberEmail);
 
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-legacy', description: '' }).expect(201);
@@ -92,9 +104,7 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
 
   it('scoped function viewer can view that function but not edit, and cannot view other functions', async () => {
     const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-scope-view');
     const memberEmail = freshEmail('member-scope-view');
-    const owner = await signup(server, ownerEmail);
     await signup(server, memberEmail);
 
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-fn-view', description: '' }).expect(201);
@@ -139,9 +149,7 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
 
   it('escalation-only viewer can hit /escalations but not function file routes', async () => {
     const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-esc');
     const memberEmail = freshEmail('member-esc');
-    const owner = await signup(server, ownerEmail);
     await signup(server, memberEmail);
 
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-esc', description: '' }).expect(201);
@@ -170,25 +178,11 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
   });
 
   it('owner is not affected by scope rows', async () => {
-    const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-bypass');
-    const owner = await signup(server, ownerEmail);
-
+    // Re-use the shared owner; create a fresh process under them.
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-owner', description: '' }).expect(201);
     const processId = (created.body as { id: string }).id;
 
-    // Try to write owner-targeted scope rows — service must refuse.
-    await owner
-      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
-      .send({
-        email: ownerEmail,
-        permission: 'owner',
-        accessMode: 'scoped',
-        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
-      })
-      .expect(400);
-
-    // Owner can hit any function & escalations.
+    // Owner can hit any function & escalations regardless of scope rows.
     await owner
       .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/over-planning/files`)
       .expect(200);
@@ -199,9 +193,7 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
 
   it('rejects invalid scope payloads', async () => {
     const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-bad');
     const memberEmail = freshEmail('member-bad');
-    const owner = await signup(server, ownerEmail);
     await signup(server, memberEmail);
 
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-bad', description: '' }).expect(201);
@@ -243,9 +235,7 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
 
   it('PATCH updates scopes; deleting member cascades scope rows', async () => {
     const server = app.getHttpServer();
-    const ownerEmail = freshEmail('owner-patch');
     const memberEmail = freshEmail('member-patch');
-    const owner = await signup(server, ownerEmail);
     await signup(server, memberEmail);
 
     const created = await owner.post('/api/v1/processes').send({ name: 'rbac-patch', description: '' }).expect(201);

--- a/apps/api/test/process-scope-rbac.e2e-spec.ts
+++ b/apps/api/test/process-scope-rbac.e2e-spec.ts
@@ -5,11 +5,23 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, Response } from 'express';
+import ExcelJS from 'exceljs';
 import request from 'supertest';
 import '../src/load-env';
 import { AppModule } from '../src/app.module';
 import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
 import { createRequestId, requestContext } from '../src/common/request-context';
+
+async function minimalXlsxBuffer(): Promise<Buffer> {
+  const rows = [
+    ['QGC effort planning review'],
+    ['Country', 'Business Unit (Project)', 'Customer Name', 'Project No.', 'Project', 'Project State', 'Project Manager', 'Email', 'Effort (H)'],
+    ['100', 'Digital Transformation', 'Siemens AG', '90032101', 'Digital Core SAP S4', 'Authorised', 'Muller, Hans', 'h.muller@company.com', 920],
+  ];
+  const workbook = new ExcelJS.Workbook();
+  workbook.addWorksheet('Effort Data').addRows(rows);
+  return Buffer.from(await workbook.xlsx.writeBuffer());
+}
 
 const hasDb = Boolean(process.env.DATABASE_URL);
 
@@ -231,6 +243,95 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
         scopes: [],
       })
       .expect(400);
+  });
+
+  it('GET :id/me/access returns the current user permission + scope rows', async () => {
+    const server = app.getHttpServer();
+    const memberEmail = freshEmail('member-meaccess');
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-me-access', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    // Owner sees their own access — permission='owner', no scopes.
+    const ownerAccess = await owner
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/me/access`)
+      .expect(200);
+    assert.equal((ownerAccess.body as { permission: string }).permission, 'owner');
+
+    // Add a member with a function:viewer scope.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'editor',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    const memberAccess = await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/me/access`)
+      .expect(200);
+    type AccessBody = {
+      permission: string;
+      scopes: { scopeType: string; functionId: string | null; accessLevel: string }[];
+    };
+    const body = memberAccess.body as AccessBody;
+    assert.equal(body.permission, 'editor');
+    assert.equal(body.scopes.length, 1);
+    assert.equal(body.scopes[0]!.scopeType, 'function');
+    assert.equal(body.scopes[0]!.functionId, 'master-data');
+    assert.equal(body.scopes[0]!.accessLevel, 'viewer');
+
+    // Non-member is rejected (defense-in-depth: findAccessibleProcessOrThrow).
+    const stranger = request.agent(server);
+    const strangerEmail = freshEmail('stranger');
+    await signup(server, strangerEmail);
+    await stranger.post('/api/v1/auth/login').send({ email: strangerEmail, password: 'pw12345678' }).expect(201);
+    await stranger
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/me/access`)
+      .expect(403);
+  });
+
+  it('function-viewer cannot POST audit/run on the scoped function (controller pre-flight)', async () => {
+    const server = app.getHttpServer();
+    const memberEmail = freshEmail('member-audit-run');
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-audit-run', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    // Owner uploads a real xlsx file under master-data.
+    const buf = await minimalXlsxBuffer();
+    const up = await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .attach('file', buf, { filename: 'book.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+      .expect(201);
+    const fileId = (up.body as { id: string }).id;
+
+    // Add member as function:viewer on master-data.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'editor',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    // Function-viewer should be denied at the controller pre-flight.
+    await member
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/audit/run`)
+      .send({ fileIdOrCode: fileId })
+      .expect(403);
   });
 
   it('PATCH updates scopes; deleting member cascades scope rows', async () => {

--- a/apps/api/test/process-scope-rbac.e2e-spec.ts
+++ b/apps/api/test/process-scope-rbac.e2e-spec.ts
@@ -187,6 +187,15 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
     await member
       .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
       .expect(403);
+
+    await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/tracking`)
+      .expect(200);
+
+    await member
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/tracking`)
+      .send({ managerKey: 'mgr-1', managerName: 'Manager One' })
+      .expect(403);
   });
 
   it('owner is not affected by scope rows', async () => {
@@ -332,6 +341,85 @@ describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
       .post(`/api/v1/processes/${encodeURIComponent(processId)}/audit/run`)
       .send({ fileIdOrCode: fileId })
       .expect(403);
+  });
+
+  it('function-scoped editor can run audit successfully even with base viewer permission', async () => {
+    const server = app.getHttpServer();
+    const memberEmail = freshEmail('member-audit-editor');
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-audit-editor', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    const buf = await minimalXlsxBuffer();
+    const up = await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .attach('file', buf, { filename: 'book.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+      .expect(201);
+    const fileId = (up.body as { id: string }).id;
+
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    const run = await member
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/audit/run`)
+      .send({ fileIdOrCode: fileId })
+      .expect(201);
+
+    assert.equal((run.body as { status?: string }).status, 'completed');
+    assert.equal((run.body as { fileId?: string }).fileId, fileId);
+  });
+
+  it('shared scoped viewer can list and preview uploaded files after the process is shared', async () => {
+    const server = app.getHttpServer();
+    const memberEmail = freshEmail('member-file-visibility');
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-file-visibility', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    const buf = await minimalXlsxBuffer();
+    const up = await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .attach('file', buf, { filename: 'shared.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+      .expect(201);
+    const fileId = (up.body as { id: string; sheets: Array<{ displayCode: string }> }).id;
+    const sheetCode = (up.body as { sheets: Array<{ displayCode: string }> }).sheets[0]!.displayCode;
+
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    const listed = await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .expect(200);
+    assert.equal((listed.body as Array<{ id: string }>).length, 1);
+    assert.equal((listed.body as Array<{ id: string }>)[0]!.id, fileId);
+
+    const preview = await member
+      .get(`/api/v1/files/${encodeURIComponent(fileId)}/sheets/${encodeURIComponent(sheetCode)}/preview`)
+      .expect(200);
+    assert.ok(Array.isArray((preview.body as { rows?: unknown[] }).rows));
+    assert.ok(((preview.body as { rows?: unknown[] }).rows?.length ?? 0) > 0);
   });
 
   it('PATCH updates scopes; deleting member cascades scope rows', async () => {

--- a/apps/api/test/process-scope-rbac.e2e-spec.ts
+++ b/apps/api/test/process-scope-rbac.e2e-spec.ts
@@ -1,0 +1,289 @@
+import 'reflect-metadata';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import '../src/load-env';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { createRequestId, requestContext } from '../src/common/request-context';
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+async function createApp(): Promise<INestApplication> {
+  process.env.SES_ALLOW_DEV_LOGIN = 'true';
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+  const app = await NestFactory.create(AppModule, { logger: false });
+  app.use(cookieParser(process.env.SES_AUTH_SECRET || 'ses-dev-secret'));
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const requestId = createRequestId(req.headers['x-request-id']);
+    res.setHeader('X-Request-ID', requestId);
+    requestContext.run({ requestId }, next);
+  });
+  app.setGlobalPrefix('api/v1');
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
+  await app.init();
+  return app;
+}
+
+function freshEmail(label: string): string {
+  return `scope-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@ses.test`;
+}
+
+async function signup(server: ReturnType<INestApplication['getHttpServer']>, email: string) {
+  const agent = request.agent(server);
+  await agent
+    .post('/api/v1/auth/signup')
+    .send({ email, displayName: email.split('@')[0], password: 'pw12345678', role: 'auditor' })
+    .expect(201);
+  return agent;
+}
+
+describe('process-scope RBAC e2e', { skip: !hasDb }, () => {
+  let app: INestApplication;
+
+  before(async () => {
+    app = await createApp();
+  });
+
+  after(async () => {
+    await app?.close();
+  });
+
+  it('member without scope rows behaves like before (legacy fallback)', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-legacy');
+    const memberEmail = freshEmail('member-legacy');
+    const owner = await signup(server, ownerEmail);
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-legacy', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    // Invite as plain editor, no scopes — must keep behaving like before.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({ email: memberEmail, permission: 'editor' })
+      .expect(201);
+
+    const memberAgent = await signup(server, memberEmail).catch(async () => {
+      // signup will 409 because the user already exists; fall back to login.
+      const a = request.agent(server);
+      await a.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+      return a;
+    });
+
+    // Plain editor → can list files for any function.
+    await memberAgent
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .expect(200);
+  });
+
+  it('scoped function viewer can view that function but not edit, and cannot view other functions', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-scope-view');
+    const memberEmail = freshEmail('member-scope-view');
+    const owner = await signup(server, ownerEmail);
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-fn-view', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    // Allowed: GET on the scoped function.
+    await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .expect(200);
+
+    // Denied: GET on a different function.
+    await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/over-planning/files`)
+      .expect(403);
+
+    // Denied: edit even on the scoped function (viewer level).
+    const draftRes = await member
+      .put(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/draft`)
+      .attach('file', Buffer.from('not-a-file'), { filename: 'x.xlsx' });
+    // Either 403 (scope deny) or 415 (file rejection) is acceptable proof
+    // the route ran; the scope deny short-circuits before the upload pipe.
+    assert.ok([403, 415].includes(draftRes.status), `expected 403/415, got ${draftRes.status}`);
+    if (draftRes.status === 415) {
+      // If the route accepted the request past the guard then scope passed —
+      // that would be a bug. Fail explicitly.
+      assert.fail('viewer scope unexpectedly allowed an edit route');
+    }
+  });
+
+  it('escalation-only viewer can hit /escalations but not function file routes', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-esc');
+    const memberEmail = freshEmail('member-esc');
+    const owner = await signup(server, ownerEmail);
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-esc', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'escalation-center', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+
+    const member = request.agent(server);
+    await member.post('/api/v1/auth/login').send({ email: memberEmail, password: 'pw12345678' }).expect(201);
+
+    await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/escalations`)
+      .expect(200);
+
+    await member
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/master-data/files`)
+      .expect(403);
+  });
+
+  it('owner is not affected by scope rows', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-bypass');
+    const owner = await signup(server, ownerEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-owner', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    // Try to write owner-targeted scope rows — service must refuse.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: ownerEmail,
+        permission: 'owner',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(400);
+
+    // Owner can hit any function & escalations.
+    await owner
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/functions/over-planning/files`)
+      .expect(200);
+    await owner
+      .get(`/api/v1/processes/${encodeURIComponent(processId)}/escalations`)
+      .expect(200);
+  });
+
+  it('rejects invalid scope payloads', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-bad');
+    const memberEmail = freshEmail('member-bad');
+    const owner = await signup(server, ownerEmail);
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-bad', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    // Function scope without functionId.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', accessLevel: 'viewer' }],
+      })
+      .expect(400);
+
+    // Non-function scope with a functionId attached.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'all-functions', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(400);
+
+    // accessMode='scoped' with no scopes.
+    await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [],
+      })
+      .expect(400);
+  });
+
+  it('PATCH updates scopes; deleting member cascades scope rows', async () => {
+    const server = app.getHttpServer();
+    const ownerEmail = freshEmail('owner-patch');
+    const memberEmail = freshEmail('member-patch');
+    const owner = await signup(server, ownerEmail);
+    await signup(server, memberEmail);
+
+    const created = await owner.post('/api/v1/processes').send({ name: 'rbac-patch', description: '' }).expect(201);
+    const processId = (created.body as { id: string }).id;
+
+    const addRes = await owner
+      .post(`/api/v1/processes/${encodeURIComponent(processId)}/members`)
+      .send({
+        email: memberEmail,
+        permission: 'viewer',
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' }],
+      })
+      .expect(201);
+    const memberCode = (addRes.body as { displayCode: string }).displayCode;
+
+    // Promote scope to editor via PATCH.
+    await owner
+      .patch(`/api/v1/processes/${encodeURIComponent(processId)}/members/${encodeURIComponent(memberCode)}`)
+      .send({
+        accessMode: 'scoped',
+        scopes: [{ scopeType: 'function', functionId: 'master-data', accessLevel: 'editor' }],
+      })
+      .expect(200);
+
+    // List should reflect the new scope.
+    const listed = await owner.get(`/api/v1/processes/${encodeURIComponent(processId)}/members`).expect(200);
+    type Row = { displayCode: string; scopes: { scopeType: string; functionId: string | null; accessLevel: string }[] };
+    const memberRow = (listed.body as Row[]).find((r) => r.displayCode === memberCode);
+    assert.ok(memberRow);
+    assert.equal(memberRow!.scopes.length, 1);
+    assert.equal(memberRow!.scopes[0]!.accessLevel, 'editor');
+
+    // Delete — list should drop the member; FK cascade removes scope rows.
+    await owner
+      .delete(`/api/v1/processes/${encodeURIComponent(processId)}/members/${encodeURIComponent(memberCode)}`)
+      .expect(200);
+    const listed2 = await owner.get(`/api/v1/processes/${encodeURIComponent(processId)}/members`).expect(200);
+    assert.ok(!(listed2.body as Row[]).some((r) => r.displayCode === memberCode));
+  });
+});

--- a/apps/api/test/rules.service.test.ts
+++ b/apps/api/test/rules.service.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { AUDIT_RULE_CATALOG } from '@ses/domain';
+import { RulesService } from '../src/rules.service';
+
+describe('RulesService.syncCatalog', () => {
+  it('upserts every audit rule from the domain catalog', async () => {
+    const calls: Array<{ where: { ruleCode: string }; create: { ruleCode: string; functionId: string } }> = [];
+    const prisma = {
+      auditRule: {
+        upsert: async (args: { where: { ruleCode: string }; create: { ruleCode: string; functionId: string } }) => {
+          calls.push(args);
+          return args;
+        },
+      },
+    };
+    const service = new RulesService(prisma as never);
+
+    await service.syncCatalog();
+
+    assert.equal(calls.length, AUDIT_RULE_CATALOG.length);
+    assert.equal(calls[0]!.where.ruleCode, AUDIT_RULE_CATALOG[0]!.ruleCode);
+    const overPlanningRule = calls.find((call) => call.where.ruleCode === 'RUL-OP-MONTH-PD-HIGH');
+    assert.equal(overPlanningRule?.create.functionId, 'over-planning');
+    const functionRateRule = calls.find((call) => call.where.ruleCode === 'RUL-FR-RATE-ZERO');
+    assert.equal(functionRateRule?.create.functionId, 'function-rate');
+  });
+});

--- a/apps/web/src/components/dashboard/ProcessCard.tsx
+++ b/apps/web/src/components/dashboard/ProcessCard.tsx
@@ -1,4 +1,4 @@
-import { Edit2, MoreHorizontal, Trash2, X } from 'lucide-react';
+import { Edit2, MoreHorizontal, Share2, Trash2, X } from 'lucide-react';
 import { FormEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { Link } from 'react-router-dom';
@@ -9,7 +9,9 @@ import type { AuditProcess } from '../../lib/types';
 import { selectHasUnsavedAudit, selectLatestAuditResult } from '../../store/selectors';
 import { processDashboardPath } from '../../lib/processRoutes';
 import { useAppStore } from '../../store/useAppStore';
+import { useCurrentUser } from '../auth/authContext';
 import { Button } from '../shared/Button';
+import { MembersPanel } from '../workspace/MembersPanel';
 
 function severityCounts(process: AuditProcess) {
   const latest = selectLatestAuditResult(process);
@@ -23,8 +25,11 @@ function severityCounts(process: AuditProcess) {
 export function ProcessCard({ process }: { process: AuditProcess }) {
   const deleteProcess = useAppStore((state) => state.deleteProcess);
   const updateProcess = useAppStore((state) => state.updateProcess);
+  const currentUser = useCurrentUser();
   const [menuOpen, setMenuOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [membersOpen, setMembersOpen] = useState(false);
+  const canManageMembers = currentUser?.role === 'admin';
   const latest = selectLatestAuditResult(process);
   const counts = severityCounts(process);
   const total = Math.max(1, counts.High + counts.Medium + counts.Low);
@@ -99,7 +104,19 @@ export function ProcessCard({ process }: { process: AuditProcess }) {
           <p className="mt-1 line-clamp-2 text-sm text-gray-500 dark:text-gray-400">{process.description || 'Workbook audit process'}</p>
           {process.nextAuditDue ? <p className={overdue ? 'mt-2 text-xs font-semibold text-red-700' : 'mt-2 text-xs text-gray-500'}>{dueLabel}</p> : null}
         </div>
-        <div className="relative">
+        <div className="flex items-center gap-1">
+          {process.serverBacked ? (
+            <button
+              type="button"
+              title="Share process"
+              aria-label="Share process"
+              onClick={() => setMembersOpen(true)}
+              className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              <Share2 size={18} />
+            </button>
+          ) : null}
+          <div className="relative">
           <button
             type="button"
             title="Process actions"
@@ -123,6 +140,7 @@ export function ProcessCard({ process }: { process: AuditProcess }) {
               </button>
             </div>
           ) : null}
+          </div>
         </div>
       </div>
       <div className="mt-5 text-sm text-gray-600 dark:text-gray-300">{fileCount} files - {versionCount} versions</div>
@@ -146,6 +164,14 @@ export function ProcessCard({ process }: { process: AuditProcess }) {
         <Link to={`/compare`} className="rounded-lg border border-gray-300 px-4 py-2 text-sm hover:border-brand hover:text-brand dark:border-gray-700 dark:hover:bg-gray-800">Compare</Link>
       </div>
       {editOpen ? <EditProcessModal process={process} onClose={() => setEditOpen(false)} /> : null}
+      {membersOpen && process.serverBacked ? (
+        <MembersPanel
+          processIdOrCode={process.displayCode ?? process.id}
+          currentUserCode={currentUser?.displayCode}
+          canManage={canManageMembers}
+          onClose={() => setMembersOpen(false)}
+        />
+      ) : null}
     </article>
   );
 }

--- a/apps/web/src/components/dashboard/ProcessCard.tsx
+++ b/apps/web/src/components/dashboard/ProcessCard.tsx
@@ -9,6 +9,7 @@ import type { AuditProcess } from '../../lib/types';
 import { selectHasUnsavedAudit, selectLatestAuditResult } from '../../store/selectors';
 import { processDashboardPath } from '../../lib/processRoutes';
 import { useAppStore } from '../../store/useAppStore';
+import { useEffectiveAccess } from '../../hooks/useEffectiveAccess';
 import { useCurrentUser } from '../auth/authContext';
 import { Button } from '../shared/Button';
 import { MembersPanel } from '../workspace/MembersPanel';
@@ -29,7 +30,8 @@ export function ProcessCard({ process }: { process: AuditProcess }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
-  const canManageMembers = currentUser?.role === 'admin';
+  const accessGate = useEffectiveAccess(process.serverBacked ? process.displayCode ?? process.id : null);
+  const canManageMembers = process.serverBacked ? accessGate.isOwner : false;
   const latest = selectLatestAuditResult(process);
   const counts = severityCounts(process);
   const total = Math.max(1, counts.High + counts.Medium + counts.Low);

--- a/apps/web/src/components/dashboard/__tests__/ProcessCard.share.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/ProcessCard.share.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProcessCard } from '../ProcessCard';
 import { ConfirmProvider } from '../../shared/ConfirmProvider';
 import type { AuditProcess, AuditVersion, WorkbookFile } from '../../../lib/types';
+import type { AccessGate } from '../../../hooks/useEffectiveAccess';
 
 vi.mock('react-hot-toast', () => ({
   default: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
@@ -19,8 +20,25 @@ vi.mock('../../auth/authContext', () => ({
     displayCode: 'USR-1',
     email: 'u@example.com',
     displayName: 'User',
-    role: 'admin' as const,
+    role: 'auditor' as const,
   }),
+}));
+
+const accessGateMock = vi.fn<() => AccessGate>(() => ({
+  loading: false,
+  error: false,
+  permission: 'owner',
+  scopes: [],
+  isOwner: true,
+  canViewFunction: () => true,
+  canEditFunction: () => true,
+  canViewEscalations: true,
+  canEditEscalations: true,
+  canEditAllFunctions: true,
+}));
+
+vi.mock('../../../hooks/useEffectiveAccess', () => ({
+  useEffectiveAccess: (...args: unknown[]) => accessGateMock(...(args as [])),
 }));
 
 vi.mock('../../../lib/api/membersApi', () => ({
@@ -84,6 +102,18 @@ function renderCard(process: AuditProcess) {
 describe('ProcessCard — share entrypoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    accessGateMock.mockImplementation((): AccessGate => ({
+      loading: false,
+      error: false,
+      permission: 'owner',
+      scopes: [],
+      isOwner: true,
+      canViewFunction: () => true,
+      canEditFunction: () => true,
+      canViewEscalations: true,
+      canEditEscalations: true,
+      canEditAllFunctions: true,
+    }));
     vi.mocked(useAppStore).mockImplementation((selector) =>
       selector({
         deleteProcess: vi.fn(),
@@ -113,5 +143,24 @@ describe('ProcessCard — share entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: /share process/i }));
     expect(await screen.findByLabelText(/all access/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/scoped/i)).toBeInTheDocument();
+  });
+
+  it('non-owners can still open the members modal but only in view mode', async () => {
+    accessGateMock.mockImplementation((): AccessGate => ({
+      loading: false,
+      error: false,
+      permission: 'viewer',
+      scopes: [],
+      isOwner: false,
+      canViewFunction: () => true,
+      canEditFunction: () => false,
+      canViewEscalations: false,
+      canEditEscalations: false,
+      canEditAllFunctions: false,
+    }));
+    renderCard(makeProcess());
+    fireEvent.click(screen.getByRole('button', { name: /share process/i }));
+    expect(await screen.findByRole('heading', { name: /members/i })).toBeInTheDocument();
+    expect(screen.getByText(/you can see who's on this process/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/dashboard/__tests__/ProcessCard.share.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/ProcessCard.share.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProcessCard } from '../ProcessCard';
+import { ConfirmProvider } from '../../shared/ConfirmProvider';
+import type { AuditProcess, AuditVersion, WorkbookFile } from '../../../lib/types';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: vi.fn(),
+}));
+
+vi.mock('../../auth/authContext', () => ({
+  useCurrentUser: () => ({
+    id: 'u1',
+    displayCode: 'USR-1',
+    email: 'u@example.com',
+    displayName: 'User',
+    role: 'admin' as const,
+  }),
+}));
+
+vi.mock('../../../lib/api/membersApi', () => ({
+  listMembers: vi.fn().mockResolvedValue([]),
+  addMember: vi.fn(),
+  updateMember: vi.fn(),
+  removeMember: vi.fn(),
+}));
+
+import { useAppStore } from '../../../store/useAppStore';
+
+const policy = {
+  highEffortThreshold: 900,
+  mediumEffortMin: 400,
+  mediumEffortMax: 800,
+  lowEffortMin: 1,
+  lowEffortMax: 399,
+  lowEffortEnabled: false,
+  zeroEffortEnabled: true,
+  missingEffortEnabled: true,
+  missingManagerEnabled: true,
+  inPlanningEffortEnabled: true,
+  onHoldEffortEnabled: true,
+  onHoldEffortThreshold: 200,
+  updatedAt: '2026-04-16T00:00:00.000Z',
+};
+
+function makeProcess(overrides: Partial<AuditProcess> = {}): AuditProcess {
+  return {
+    id: 'p-card',
+    displayCode: 'PRC-CARD',
+    name: 'Card test process',
+    description: '',
+    serverBacked: true,
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    nextAuditDue: null,
+    files: [] as WorkbookFile[],
+    activeFileId: null,
+    versions: [] as AuditVersion[],
+    auditPolicy: policy,
+    notificationTracking: {},
+    comments: {},
+    corrections: {},
+    acknowledgments: {},
+    savedTemplates: {},
+    ...overrides,
+  };
+}
+
+function renderCard(process: AuditProcess) {
+  return render(
+    <ConfirmProvider>
+      <MemoryRouter>
+        <ProcessCard process={process} />
+      </MemoryRouter>
+    </ConfirmProvider>,
+  );
+}
+
+describe('ProcessCard — share entrypoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAppStore).mockImplementation((selector) =>
+      selector({
+        deleteProcess: vi.fn(),
+        updateProcess: vi.fn(),
+      } as never),
+    );
+  });
+
+  it('renders an accessible share button on a server-backed process card', () => {
+    renderCard(makeProcess());
+    expect(screen.getByRole('button', { name: /share process/i })).toBeInTheDocument();
+  });
+
+  it('does not render the share button on a local-only (non-serverBacked) process card', () => {
+    renderCard(makeProcess({ serverBacked: false }));
+    expect(screen.queryByRole('button', { name: /share process/i })).toBeNull();
+  });
+
+  it('clicking share opens the members modal for the selected process', async () => {
+    renderCard(makeProcess());
+    fireEvent.click(screen.getByRole('button', { name: /share process/i }));
+    expect(await screen.findByRole('heading', { name: /members/i })).toBeInTheDocument();
+  });
+
+  it('opened modal exposes scoped access options (smoke)', async () => {
+    renderCard(makeProcess());
+    fireEvent.click(screen.getByRole('button', { name: /share process/i }));
+    expect(await screen.findByLabelText(/all access/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/scoped/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/escalations/Composer.tsx
+++ b/apps/web/src/components/escalations/Composer.tsx
@@ -71,13 +71,50 @@ export function Composer({
   const [cc, setCc] = useState<string[]>([]);
   const [ccInput, setCcInput] = useState('');
   const [removedEngines, setRemovedEngines] = useState<Set<string>>(new Set());
-  const [resolvedPreview, setResolvedPreview] = useState<{ subject: string; body: string } | null>(null);
+  const [resolvedPreview, setResolvedPreview] = useState<{
+    subject: string;
+    body: string;
+    bodyHtml?: string;
+  } | null>(null);
   const [dirtyWarn, setDirtyWarn] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [authorNote, setAuthorNote] = useState('');
   const [deadlineAt, setDeadlineAt] = useState<string>(() =>
     toDateInputValue(addBusinessDays(new Date(), 5)),
   );
+  const [projectLinks, setProjectLinks] = useState<Record<string, string>>({});
+  const [projectLinksOpen, setProjectLinksOpen] = useState(false);
+
+  // Unique project IDs across all engine findings — these are the rows the
+  // auditor can attach a project link to. Order matches the engine-iteration
+  // order of `findingsByEngine` so the inputs appear in a stable sequence.
+  const uniqueProjectIds = useMemo(() => {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const fid of FUNCTION_IDS) {
+      for (const f of row.findingsByEngine[fid] ?? []) {
+        const id = f.projectNo?.trim();
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        ordered.push(id);
+      }
+    }
+    return ordered;
+  }, [row.findingsByEngine]);
+
+  // Only forward links that look like real URLs. Empty / partial entries
+  // are stripped so the server never sees them and the preview column
+  // stays hidden until at least one valid link has been entered.
+  const cleanProjectLinks = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const [pid, url] of Object.entries(projectLinks)) {
+      const trimmed = url.trim();
+      if (!trimmed) continue;
+      if (!/^https?:\/\//i.test(trimmed)) continue;
+      out[pid] = trimmed;
+    }
+    return out;
+  }, [projectLinks]);
 
   const outlookCount = row.outlookCount ?? 0;
   const teamsCount = row.teamsCount ?? 0;
@@ -142,6 +179,7 @@ export function Composer({
       removedEngineIds: [...removedEngines],
       authorNote,
       deadlineAt: deadlineAt || null,
+      projectLinks: cleanProjectLinks,
     };
     if (templateId) previewBody.templateId = templateId;
     void previewCompose(trackingRef, previewBody)
@@ -160,7 +198,7 @@ export function Composer({
     return () => {
       cancelled = true;
     };
-  }, [viewMode, trackingRef, templateId, subject, body, cc, removedEngines, authorNote, deadlineAt]);
+  }, [viewMode, trackingRef, templateId, subject, body, cc, removedEngines, authorNote, deadlineAt, cleanProjectLinks]);
 
   const draftMut = useMutation({
     mutationFn: (payload: ComposeDraftPayload) => saveComposeDraft(trackingRef!, payload),
@@ -191,6 +229,7 @@ export function Composer({
         channel,
         authorNote,
         deadlineAt: deadlineAt || null,
+        projectLinks: cleanProjectLinks,
         sources: FUNCTION_IDS.filter(
           (id) => (row.countsByEngine[id] ?? 0) > 0 && !removedEngines.has(id),
         ) as string[],
@@ -230,7 +269,7 @@ export function Composer({
   const dirtyRef = useRef(false);
   useEffect(() => {
     dirtyRef.current = true;
-  }, [subject, body, cc, removedEngines, templateId, authorNote, deadlineAt]);
+  }, [subject, body, cc, removedEngines, templateId, authorNote, deadlineAt, cleanProjectLinks]);
   const latestPayloadRef = useRef<ComposeDraftPayload>({
     subject,
     body,
@@ -238,6 +277,7 @@ export function Composer({
     removedEngineIds: [...removedEngines],
     authorNote,
     deadlineAt: deadlineAt || null,
+    projectLinks: cleanProjectLinks,
     ...(templateId ? { templateId } : {}),
   });
   useEffect(() => {
@@ -248,9 +288,10 @@ export function Composer({
       removedEngineIds: [...removedEngines],
       authorNote,
       deadlineAt: deadlineAt || null,
+      projectLinks: cleanProjectLinks,
       ...(templateId ? { templateId } : {}),
     };
-  }, [subject, body, cc, removedEngines, templateId, authorNote, deadlineAt]);
+  }, [subject, body, cc, removedEngines, templateId, authorNote, deadlineAt, cleanProjectLinks]);
   useAutosaveOnLeave(async () => {
     if (readOnly || !trackingRef || !dirtyRef.current) return;
     if (!latestPayloadRef.current.body?.trim() && !latestPayloadRef.current.subject?.trim()) return;
@@ -322,6 +363,7 @@ export function Composer({
     removedEngineIds: [...removedEngines],
     authorNote,
     deadlineAt: deadlineAt || null,
+    projectLinks: cleanProjectLinks,
     ...(templateId ? { templateId } : {}),
   };
 
@@ -431,6 +473,55 @@ export function Composer({
         </div>
       </div>
 
+      {uniqueProjectIds.length > 0 ? (
+        <div className="rounded border border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={() => setProjectLinksOpen((v) => !v)}
+            className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-medium text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+            aria-expanded={projectLinksOpen}
+          >
+            <span>
+              Project links
+              <span className="ml-1 text-gray-400">
+                ({Object.keys(cleanProjectLinks).length}/{uniqueProjectIds.length})
+              </span>
+              <span className="ml-2 font-normal text-gray-500">
+                Optional — paste a URL per project to include it in the email.
+              </span>
+            </span>
+            <span className="text-gray-400">{projectLinksOpen ? '▾' : '▸'}</span>
+          </button>
+          {projectLinksOpen ? (
+            <div className="space-y-2 border-t border-gray-100 px-3 py-2 dark:border-gray-800">
+              {uniqueProjectIds.map((pid) => (
+                <div key={pid} className="grid grid-cols-[7rem,1fr] items-center gap-2">
+                  <label
+                    className="truncate text-xs font-medium text-gray-600 dark:text-gray-300"
+                    title={pid}
+                  >
+                    {pid}
+                  </label>
+                  <input
+                    type="url"
+                    disabled={readOnly}
+                    value={projectLinks[pid] ?? ''}
+                    onChange={(e) =>
+                      setProjectLinks((prev) => ({ ...prev, [pid]: e.target.value }))
+                    }
+                    placeholder="https://bcs.example.com/project/…"
+                    className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900"
+                  />
+                </div>
+              ))}
+              <p className="pt-1 text-[11px] text-gray-500">
+                Only valid http(s) URLs render in the preview. Leave blank to skip a project.
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div>
         <div className="text-xs font-medium text-gray-500">Findings by engine</div>
         <div className="mt-1 space-y-1">
@@ -496,6 +587,8 @@ export function Composer({
           <PreviewPane
             subject={resolvedPreview?.subject ?? (previewLoading ? 'Loading…' : subject)}
             body={resolvedPreview?.body ?? (previewLoading ? 'Loading…' : body)}
+            {...(resolvedPreview?.bodyHtml ? { bodyHtml: resolvedPreview.bodyHtml } : {})}
+            deadlineAt={deadlineAt || null}
           />
         </div>
       )}

--- a/apps/web/src/components/escalations/PreviewPane.tsx
+++ b/apps/web/src/components/escalations/PreviewPane.tsx
@@ -1,26 +1,48 @@
 export function PreviewPane({
   subject,
   body,
+  bodyHtml,
   deadlineAt,
 }: {
   subject: string;
   body: string;
+  /** HTML rendering of the body — preferred over plain text when present. */
+  bodyHtml?: string;
   deadlineAt?: string | null;
 }) {
+  const hasHtml = Boolean(bodyHtml && bodyHtml.trim().length > 0);
   return (
-    <div className="rounded border border-gray-200 bg-white p-3 text-sm dark:border-gray-700 dark:bg-gray-900">
-      <div className="text-xs font-medium text-gray-500">Subject</div>
-      <div className="mt-1 font-medium text-gray-900 dark:text-white">{subject || '(empty)'}</div>
+    <div className="rounded border border-gray-200 bg-white p-4 text-sm shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Subject</div>
+      <div className="mt-1 text-base font-semibold text-gray-900 dark:text-white">
+        {subject || '(empty)'}
+      </div>
       {deadlineAt ? (
         <>
-          <div className="mt-3 text-xs font-medium text-gray-500">Due date</div>
+          <div className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+            Due date
+          </div>
           <div className="mt-1 text-gray-900 dark:text-white">
             {new Date(deadlineAt).toLocaleDateString()}
           </div>
         </>
       ) : null}
-      <div className="mt-3 text-xs font-medium text-gray-500">Body</div>
-      <pre className="mt-1 whitespace-pre-wrap font-sans text-gray-800 dark:text-gray-200">{body || '(empty)'}</pre>
+      <div className="mt-4 border-t border-gray-200 pt-3 text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:border-gray-800">
+        Body
+      </div>
+      {hasHtml ? (
+        <div
+          className="email-preview mt-2 rounded border border-gray-100 bg-white p-3 text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100"
+          // The HTML is generated server-side by tracking-compose.service —
+          // every dynamic field is escaped before it goes into the markup,
+          // so this is safe to render as-is.
+          dangerouslySetInnerHTML={{ __html: bodyHtml! }}
+        />
+      ) : (
+        <pre className="mt-2 whitespace-pre-wrap font-sans text-gray-800 dark:text-gray-200">
+          {body || '(empty)'}
+        </pre>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/workspace/AuditResultsTab.tsx
+++ b/apps/web/src/components/workspace/AuditResultsTab.tsx
@@ -135,12 +135,19 @@ export function AuditResultsTab({
   file,
   mappingSource,
   onMappingSourceChange,
+  canEdit = true,
+  readOnlyReason,
 }: {
   process: AuditProcess;
   file?: WorkbookFile | undefined;
   mappingSource?: MappingSourceInput | undefined;
   onMappingSourceChange?: (src: MappingSourceInput | undefined) => void;
+  /** When false, Run/Re-run/comment/correction/acknowledgment are disabled. Defaults to true. */
+  canEdit?: boolean;
+  /** Tooltip shown on disabled mutating controls. */
+  readOnlyReason?: string | undefined;
 }) {
+  const editTooltip = !canEdit ? readOnlyReason : undefined;
   // The Zustand `currentAuditResult` is only populated by an interactive
   // run from this same browser session — it gets cleared whenever the user
   // navigates between processes or functions (see useAppStore lines 321,
@@ -450,7 +457,8 @@ export function AuditResultsTab({
                     },
                   );
                 }}
-                disabled={!hasSelected || !mappingSourceOk}
+                disabled={!hasSelected || !mappingSourceOk || !canEdit}
+                title={editTooltip}
                 className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white disabled:opacity-40"
               >
                 Run Audit
@@ -497,7 +505,8 @@ export function AuditResultsTab({
                       },
                     );
                   }}
-                  disabled={!hasSelected || !mappingSourceOk}
+                  disabled={!hasSelected || !mappingSourceOk || !canEdit}
+                  title={editTooltip}
                   className="rounded-lg bg-amber-600 px-3 py-2 text-xs font-semibold text-white hover:bg-amber-700 disabled:opacity-40"
                 >
                   Re-run audit
@@ -584,6 +593,8 @@ export function AuditResultsTab({
                             comments={selectIssueComments(process, issue)}
                             onAdd={(body) => addIssueComment(process.id, auditIssueKey(issue), body)}
                             onDelete={(commentId) => deleteIssueComment(process.id, auditIssueKey(issue), commentId)}
+                            canEdit={canEdit}
+                            readOnlyReason={editTooltip}
                           />
                           <div className="mt-4">
                             <div className="mb-2 text-xs font-semibold text-gray-500">Auditor decision</div>
@@ -596,11 +607,13 @@ export function AuditResultsTab({
                                   <button
                                     key={statusOption}
                                     type="button"
+                                    disabled={!canEdit}
+                                    title={editTooltip}
                                     onClick={(event) => {
                                       event.stopPropagation();
                                       setIssueAcknowledgment(process.id, auditIssueKey(issue), statusOption);
                                     }}
-                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium ${
+                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50 ${
                                       active
                                         ? 'border-brand bg-brand-subtle text-brand'
                                         : 'border-gray-300 text-gray-600 hover:border-gray-400 dark:border-gray-600 dark:text-gray-300'
@@ -617,6 +630,8 @@ export function AuditResultsTab({
                             correction={selectIssueCorrection(process, issue)}
                             onSave={(correction) => saveIssueCorrection(process.id, auditIssueKey(issue), correction)}
                             onClear={() => clearIssueCorrection(process.id, auditIssueKey(issue))}
+                            canEdit={canEdit}
+                            readOnlyReason={editTooltip}
                           />
                         </td>
                       </tr>
@@ -640,7 +655,7 @@ function Step({ done, children }: { done: boolean; children: React.ReactNode }) 
   return <div className="flex items-center gap-2"><Icon size={16} className={done ? 'text-green-600' : 'text-gray-400'} />{children}</div>;
 }
 
-function IssueCorrectionEditor({ issue, correction, onSave, onClear }: { issue: AuditIssue; correction?: IssueCorrection | undefined; onSave: (correction: Omit<IssueCorrection, 'issueKey' | 'processId' | 'updatedAt'>) => void; onClear: () => void }) {
+function IssueCorrectionEditor({ issue, correction, onSave, onClear, canEdit = true, readOnlyReason }: { issue: AuditIssue; correction?: IssueCorrection | undefined; onSave: (correction: Omit<IssueCorrection, 'issueKey' | 'processId' | 'updatedAt'>) => void; onClear: () => void; canEdit?: boolean; readOnlyReason?: string | undefined }) {
   const [effort, setEffort] = useState(String(correction?.effort ?? issue.effort));
   const [projectState, setProjectState] = useState(correction?.projectState ?? issue.projectState);
   const [projectManager, setProjectManager] = useState(correction?.projectManager ?? issue.projectManager);
@@ -648,34 +663,36 @@ function IssueCorrectionEditor({ issue, correction, onSave, onClear }: { issue: 
 
   function submit(event: FormEvent) {
     event.preventDefault();
+    if (!canEdit) return;
     onSave({ effort: Number(effort) || 0, projectState: projectState.trim(), projectManager: projectManager.trim(), note });
   }
 
   return (
-    <section className="mt-4 border-t border-gray-200 pt-4 dark:border-gray-700">
+    <section className="mt-4 border-t border-gray-200 pt-4 dark:border-gray-700" title={canEdit ? undefined : readOnlyReason}>
       <div className="flex items-center justify-between gap-3">
         <h4 className="font-semibold">Inline correction</h4>
         {correction ? <span className="text-xs text-gray-500">Updated {new Date(correction.updatedAt).toLocaleString()}</span> : null}
       </div>
       <form onSubmit={submit} className="mt-3 grid gap-3 md:grid-cols-4">
-        <label className="text-xs text-gray-500">Effort<input value={effort} onChange={(event) => setEffort(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label>
-        <label className="text-xs text-gray-500">State<input value={projectState} onChange={(event) => setProjectState(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label>
-        <label className="text-xs text-gray-500">Manager<input value={projectManager} onChange={(event) => setProjectManager(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label>
-        <label className="text-xs text-gray-500">Note<input value={note} onChange={(event) => setNote(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label>
+        <label className="text-xs text-gray-500">Effort<input value={effort} disabled={!canEdit} onChange={(event) => setEffort(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-900" /></label>
+        <label className="text-xs text-gray-500">State<input value={projectState} disabled={!canEdit} onChange={(event) => setProjectState(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-900" /></label>
+        <label className="text-xs text-gray-500">Manager<input value={projectManager} disabled={!canEdit} onChange={(event) => setProjectManager(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-900" /></label>
+        <label className="text-xs text-gray-500">Note<input value={note} disabled={!canEdit} onChange={(event) => setNote(event.target.value)} className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-900" /></label>
         <div className="flex gap-2 md:col-span-4">
-          <Button type="submit" size="sm">Save correction</Button>
-          {correction ? <Button variant="secondary" size="sm" onClick={onClear}>Clear correction</Button> : null}
+          <Button type="submit" size="sm" disabled={!canEdit} title={canEdit ? undefined : readOnlyReason}>Save correction</Button>
+          {correction ? <Button variant="secondary" size="sm" onClick={onClear} disabled={!canEdit} title={canEdit ? undefined : readOnlyReason}>Clear correction</Button> : null}
         </div>
       </form>
     </section>
   );
 }
 
-function IssueComments({ comments, onAdd, onDelete }: { comments: IssueComment[]; onAdd: (body: string) => void; onDelete: (commentId: string) => void }) {
+function IssueComments({ comments, onAdd, onDelete, canEdit = true, readOnlyReason }: { comments: IssueComment[]; onAdd: (body: string) => void; onDelete: (commentId: string) => void; canEdit?: boolean; readOnlyReason?: string | undefined }) {
   const [body, setBody] = useState('');
 
   function submit(event: FormEvent) {
     event.preventDefault();
+    if (!canEdit) return;
     onAdd(body);
     setBody('');
   }
@@ -694,15 +711,30 @@ function IssueComments({ comments, onAdd, onDelete }: { comments: IssueComment[]
                 <div className="text-xs font-semibold text-gray-500">{comment.author} - {new Date(comment.createdAt).toLocaleString()}</div>
                 <p className="mt-1 text-sm text-gray-900 dark:text-gray-100">{comment.body}</p>
               </div>
-              <button type="button" onClick={() => onDelete(comment.id)} className="text-xs text-gray-400 hover:text-red-600">Delete</button>
+              <button
+                type="button"
+                onClick={() => onDelete(comment.id)}
+                disabled={!canEdit}
+                title={canEdit ? undefined : readOnlyReason}
+                className="text-xs text-gray-400 hover:text-red-600 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:text-gray-300"
+              >
+                Delete
+              </button>
             </div>
           </div>
         ))}
         {!comments.length ? <div className="text-sm text-gray-500">No notes yet. Capture PM feedback, approval context, or follow-up details here.</div> : null}
       </div>
       <form onSubmit={submit} className="mt-3 flex flex-col gap-2 sm:flex-row">
-        <input value={body} onChange={(event) => setBody(event.target.value)} placeholder="Add audit note..." className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" />
-        <Button type="submit" size="sm" disabled={!body.trim()}>Add note</Button>
+        <input
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder={canEdit ? 'Add audit note...' : 'Read-only — comments disabled'}
+          disabled={!canEdit}
+          title={canEdit ? undefined : readOnlyReason}
+          className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-900"
+        />
+        <Button type="submit" size="sm" disabled={!canEdit || !body.trim()} title={canEdit ? undefined : readOnlyReason}>Add note</Button>
       </form>
     </section>
   );

--- a/apps/web/src/components/workspace/FilesSidebar.tsx
+++ b/apps/web/src/components/workspace/FilesSidebar.tsx
@@ -13,9 +13,13 @@ import { SheetList } from './SheetList';
 interface Props {
   process: AuditProcess;
   functionId?: FunctionId;
+  /** When false, upload + delete are disabled with a tooltip explaining why. Defaults to true (backward compat). */
+  canEdit?: boolean;
+  /** Tooltip text shown on disabled mutating controls. */
+  readOnlyReason?: string | undefined;
 }
 
-export function FilesSidebar({ process, functionId }: Props) {
+export function FilesSidebar({ process, functionId, canEdit = true, readOnlyReason }: Props) {
   const confirm = useConfirm();
   const uploadFile = useAppStore((state) => state.uploadFile);
   const saveFileDraft = useAppStore((state) => state.saveFileDraft);
@@ -25,8 +29,10 @@ export function FilesSidebar({ process, functionId }: Props) {
   const uploads = useAppStore((state) => state.uploads);
   const scopedFid: FunctionId = functionId ?? DEFAULT_FUNCTION_ID;
   const activeFile = process.files.find((file) => file.id === process.activeFileId) ?? process.files[0];
+  const tooltip = !canEdit ? readOnlyReason : undefined;
 
   async function upload(files: FileList | null) {
+    if (!canEdit) return;
     if (!files?.length) return;
     for (const file of Array.from(files)) {
       try {
@@ -61,6 +67,7 @@ export function FilesSidebar({ process, functionId }: Props) {
   }
 
   async function confirmDelete(file: WorkbookFile) {
+    if (!canEdit) return;
     const ok = await confirm({
       title: `Delete ${file.name}?`,
       description: 'This removes the document and its audit data from this browser.',
@@ -77,15 +84,51 @@ export function FilesSidebar({ process, functionId }: Props) {
       <section className="p-4">
         <div className="flex items-center justify-between">
           <h2 className="text-sm font-semibold">Documents</h2>
-          <label className="inline-flex cursor-pointer items-center gap-1 rounded-lg bg-brand px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-hover">
+          <label
+            aria-disabled={!canEdit}
+            title={tooltip}
+            className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium text-white ${
+              canEdit
+                ? 'cursor-pointer bg-brand hover:bg-brand-hover'
+                : 'cursor-not-allowed bg-gray-300 dark:bg-gray-700'
+            }`}
+          >
             <Upload size={14} />
             Upload
-            <input type="file" multiple accept=".xlsx,.xlsm" onChange={(event) => { void upload(event.target.files); }} className="hidden" />
+            <input
+              type="file"
+              multiple
+              accept=".xlsx,.xlsm"
+              disabled={!canEdit}
+              onChange={(event) => { void upload(event.target.files); }}
+              className="hidden"
+            />
           </label>
         </div>
-        <label onDragOver={(event) => event.preventDefault()} onDrop={(event) => { event.preventDefault(); void upload(event.dataTransfer.files); }} className="mt-3 flex cursor-pointer flex-col items-center rounded-lg border border-dashed border-gray-300 bg-white p-4 text-center text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700">
-          Drag documents here or pick multiple files
-          <input type="file" multiple accept=".xlsx,.xlsm" onChange={(event) => { void upload(event.target.files); }} className="hidden" />
+        <label
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            if (!canEdit) return;
+            void upload(event.dataTransfer.files);
+          }}
+          aria-disabled={!canEdit}
+          title={tooltip}
+          className={`mt-3 flex flex-col items-center rounded-lg border border-dashed border-gray-300 p-4 text-center text-xs ${
+            canEdit
+              ? 'cursor-pointer bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700'
+              : 'cursor-not-allowed bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-900'
+          }`}
+        >
+          {canEdit ? 'Drag documents here or pick multiple files' : 'Read-only — upload disabled'}
+          <input
+            type="file"
+            multiple
+            accept=".xlsx,.xlsm"
+            disabled={!canEdit}
+            onChange={(event) => { void upload(event.target.files); }}
+            className="hidden"
+          />
         </label>
         <div className="mt-4 space-y-2">
           {Object.entries(uploads).map(([key, item]) => (
@@ -101,6 +144,8 @@ export function FilesSidebar({ process, functionId }: Props) {
               file={file}
               isActive={file.id === process.activeFileId}
               serverBacked={Boolean(process.serverBacked)}
+              canDelete={canEdit}
+              deleteTooltip={tooltip}
               onSelect={() => setActiveFile(process.id, file.id)}
               onView={() => onView(file)}
               onDownload={() => void onDownload(file)}
@@ -118,6 +163,8 @@ function DocumentCard({
   file,
   isActive,
   serverBacked,
+  canDelete,
+  deleteTooltip,
   onSelect,
   onView,
   onDownload,
@@ -126,6 +173,8 @@ function DocumentCard({
   file: WorkbookFile;
   isActive: boolean;
   serverBacked: boolean;
+  canDelete: boolean;
+  deleteTooltip?: string | undefined;
   onSelect: () => void;
   onView: () => void;
   onDownload: () => void;
@@ -196,12 +245,17 @@ function DocumentCard({
         <button
           type="button"
           aria-label={`Delete ${file.name}`}
-          title="Delete document"
+          title={canDelete ? 'Delete document' : deleteTooltip}
+          disabled={!canDelete}
           onClick={(event) => {
             event.stopPropagation();
             onDelete();
           }}
-          className="rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
+          className={`rounded-md p-1 ${
+            canDelete
+              ? 'text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30'
+              : 'cursor-not-allowed text-gray-300 dark:text-gray-600'
+          }`}
         >
           <Trash2 size={14} />
         </button>

--- a/apps/web/src/components/workspace/FilesSidebar.tsx
+++ b/apps/web/src/components/workspace/FilesSidebar.tsx
@@ -154,7 +154,7 @@ export function FilesSidebar({ process, functionId, canEdit = true, readOnlyReas
           ))}
         </div>
       </section>
-      {activeFile ? <SheetList process={process} file={activeFile} /> : null}
+      {activeFile ? <SheetList process={process} file={activeFile} canEdit={canEdit} readOnlyReason={readOnlyReason} /> : null}
     </div>
   );
 }

--- a/apps/web/src/components/workspace/MembersPanel.tsx
+++ b/apps/web/src/components/workspace/MembersPanel.tsx
@@ -1,23 +1,192 @@
-import { UserPlus, X } from 'lucide-react';
-import { useEffect, useState, type FormEvent } from 'react';
+import { Pencil, UserPlus, X } from 'lucide-react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import toast from 'react-hot-toast';
-import { addMember, listMembers, removeMember, type ProcessMemberRow } from '../../lib/api/membersApi';
+import { FUNCTION_REGISTRY, getFunctionLabel, type FunctionId } from '@ses/domain';
+import {
+  addMember,
+  listMembers,
+  removeMember,
+  updateMember,
+  type AccessMode,
+  type AddMemberInput,
+  type MemberScopeRow,
+  type ProcessMemberRow,
+  type ScopeAccessLevel,
+  type UpdateMemberInput,
+} from '../../lib/api/membersApi';
 import { Button } from '../shared/Button';
 import { useConfirm } from '../shared/ConfirmProvider';
 import { Skeleton } from '../shared/Skeleton';
 
 type Permission = 'viewer' | 'editor' | 'owner';
 const PERMISSIONS: Permission[] = ['viewer', 'editor', 'owner'];
+const ACCESS_LEVELS: ScopeAccessLevel[] = ['viewer', 'editor'];
+const ESCALATION_KEY = '__escalation-center__';
+const ALL_FUNCTIONS_KEY = '__all-functions__';
+
+type ScopeKey = FunctionId | typeof ESCALATION_KEY | typeof ALL_FUNCTIONS_KEY;
+
+interface ScopeEditorState {
+  selected: Record<ScopeKey, ScopeAccessLevel | undefined>;
+}
+
+function emptyScopeState(): ScopeEditorState {
+  return { selected: {} as Record<ScopeKey, ScopeAccessLevel | undefined> };
+}
+
+function stateFromRows(rows: MemberScopeRow[]): ScopeEditorState {
+  const out = emptyScopeState();
+  for (const row of rows) {
+    if (row.scopeType === 'all-functions') {
+      out.selected[ALL_FUNCTIONS_KEY] = row.accessLevel;
+    } else if (row.scopeType === 'escalation-center') {
+      out.selected[ESCALATION_KEY] = row.accessLevel;
+    } else if (row.scopeType === 'function' && row.functionId) {
+      out.selected[row.functionId as FunctionId] = row.accessLevel;
+    }
+  }
+  return out;
+}
+
+function stateToRows(state: ScopeEditorState): MemberScopeRow[] {
+  const rows: MemberScopeRow[] = [];
+  for (const [key, level] of Object.entries(state.selected)) {
+    if (!level) continue;
+    if (key === ALL_FUNCTIONS_KEY) {
+      rows.push({ scopeType: 'all-functions', functionId: null, accessLevel: level });
+    } else if (key === ESCALATION_KEY) {
+      rows.push({ scopeType: 'escalation-center', functionId: null, accessLevel: level });
+    } else {
+      rows.push({ scopeType: 'function', functionId: key, accessLevel: level });
+    }
+  }
+  return rows;
+}
+
+function ScopeEditor({
+  state,
+  onChange,
+  disabled = false,
+}: {
+  state: ScopeEditorState;
+  onChange: (next: ScopeEditorState) => void;
+  disabled?: boolean;
+}) {
+  const allOn = !!state.selected[ALL_FUNCTIONS_KEY];
+
+  function toggle(key: ScopeKey, level: ScopeAccessLevel | undefined) {
+    const next: ScopeEditorState = { selected: { ...state.selected } };
+    if (level === undefined) {
+      delete next.selected[key];
+    } else {
+      next.selected[key] = level;
+    }
+    onChange(next);
+  }
+
+  return (
+    <div className="space-y-2 rounded border border-gray-200 bg-gray-50 p-2 text-xs dark:border-gray-700 dark:bg-gray-800/40">
+      <ScopeRow
+        label="All functions"
+        checked={allOn}
+        level={state.selected[ALL_FUNCTIONS_KEY]}
+        onChange={(lvl) => toggle(ALL_FUNCTIONS_KEY, lvl)}
+        disabled={disabled}
+      />
+      <div className="ml-2 border-l border-dashed border-gray-300 pl-2 dark:border-gray-700">
+        {allOn ? (
+          <p className="py-1 text-[11px] italic text-gray-500">
+            "All functions" supersedes the per-function selections below.
+          </p>
+        ) : null}
+        {FUNCTION_REGISTRY.map((fn) => (
+          <ScopeRow
+            key={fn.id}
+            label={fn.label}
+            checked={!!state.selected[fn.id as FunctionId]}
+            level={state.selected[fn.id as FunctionId]}
+            onChange={(lvl) => toggle(fn.id as FunctionId, lvl)}
+            disabled={disabled || allOn}
+          />
+        ))}
+      </div>
+      <ScopeRow
+        label="Escalation Center"
+        checked={!!state.selected[ESCALATION_KEY]}
+        level={state.selected[ESCALATION_KEY]}
+        onChange={(lvl) => toggle(ESCALATION_KEY, lvl)}
+        disabled={disabled}
+      />
+    </div>
+  );
+}
+
+function ScopeRow({
+  label,
+  checked,
+  level,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  checked: boolean;
+  level: ScopeAccessLevel | undefined;
+  onChange: (next: ScopeAccessLevel | undefined) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label className={`flex items-center gap-2 py-0.5 ${disabled ? 'opacity-50' : ''}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked ? level ?? 'viewer' : undefined)}
+      />
+      <span className="flex-1">{label}</span>
+      <select
+        value={level ?? 'viewer'}
+        disabled={disabled || !checked}
+        onChange={(e) => onChange(e.target.value as ScopeAccessLevel)}
+        className="rounded border border-gray-300 bg-white px-1.5 py-0.5 text-[11px] dark:border-gray-700 dark:bg-gray-900"
+      >
+        {ACCESS_LEVELS.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function ScopeBadges({ scopes }: { scopes: MemberScopeRow[] }) {
+  if (!scopes.length) return null;
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {scopes.map((s, i) => {
+        let label: string;
+        if (s.scopeType === 'all-functions') label = 'All functions';
+        else if (s.scopeType === 'escalation-center') label = 'Escalation Center';
+        else label = s.functionId ? getFunctionLabel(s.functionId as FunctionId) : 'function';
+        return (
+          <span
+            key={`${s.scopeType}:${s.functionId ?? ''}:${i}`}
+            className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-700 dark:bg-blue-900/30 dark:text-blue-200"
+          >
+            {label} · {s.accessLevel}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
 
 /**
  * Drawer-style panel for managing the members of a single process.
  *
- * - Owners and admins see everyone + add/remove controls.
- * - Editors/viewers see the list but no controls (server enforces auth so UI
- *   is just cosmetic; a malicious client can't bypass).
- *
- * Note: the permission dropdown submits a re-add with the new permission, which
- * the backend treats as idempotent upsert.
+ * Members can be invited unrestricted (legacy behavior, gets the global
+ * permission process-wide) or scoped (per-function and/or escalation-center
+ * access levels). Server enforces both layers; UI just collects the intent.
  */
 export function MembersPanel({
   processIdOrCode,
@@ -35,6 +204,13 @@ export function MembersPanel({
   const [busy, setBusy] = useState(false);
   const [email, setEmail] = useState('');
   const [permission, setPermission] = useState<Permission>('editor');
+  const [accessMode, setAccessMode] = useState<AccessMode>('unrestricted');
+  const [inviteScopes, setInviteScopes] = useState<ScopeEditorState>(emptyScopeState());
+  const [editingMemberId, setEditingMemberId] = useState<string | null>(null);
+  const [editScopes, setEditScopes] = useState<ScopeEditorState>(emptyScopeState());
+  const [editAccessMode, setEditAccessMode] = useState<AccessMode>('unrestricted');
+
+  const showInviteScopes = canManage && permission !== 'owner' && accessMode === 'scoped';
 
   async function refresh() {
     try {
@@ -55,9 +231,23 @@ export function MembersPanel({
     if (!email.trim()) return;
     setBusy(true);
     try {
-      const result = await addMember(processIdOrCode, { email: email.trim(), permission });
+      const isOwner = permission === 'owner';
+      const scoped = !isOwner && accessMode === 'scoped';
+      const scopes = scoped ? stateToRows(inviteScopes) : undefined;
+      if (scoped && (!scopes || scopes.length === 0)) {
+        throw new Error('Pick at least one scope or switch to "All access".');
+      }
+      const payload: AddMemberInput = {
+        email: email.trim(),
+        permission,
+        accessMode: isOwner ? 'unrestricted' : accessMode,
+      };
+      if (scopes) payload.scopes = scopes;
+      const result = await addMember(processIdOrCode, payload);
       toast.success(result.changed ? `Added ${email.trim()}` : `${email.trim()} already a member (unchanged)`);
       setEmail('');
+      setAccessMode('unrestricted');
+      setInviteScopes(emptyScopeState());
       await refresh();
     } catch (err) {
       toast.error((err as Error).message);
@@ -90,7 +280,7 @@ export function MembersPanel({
     if (row.permission === nextPerm) return;
     setBusy(true);
     try {
-      await addMember(processIdOrCode, { email: row.email, permission: nextPerm });
+      await updateMember(processIdOrCode, row.displayCode, { permission: nextPerm });
       toast.success(`${row.displayName} is now ${nextPerm}`);
       await refresh();
     } catch (err) {
@@ -99,6 +289,35 @@ export function MembersPanel({
       setBusy(false);
     }
   }
+
+  function startEdit(row: ProcessMemberRow) {
+    setEditingMemberId(row.id);
+    setEditScopes(stateFromRows(row.scopes));
+    setEditAccessMode(row.scopes.length > 0 ? 'scoped' : 'unrestricted');
+  }
+
+  async function saveEditScopes(row: ProcessMemberRow) {
+    setBusy(true);
+    try {
+      const scoped = editAccessMode === 'scoped';
+      const scopes = scoped ? stateToRows(editScopes) : [];
+      if (scoped && scopes.length === 0) {
+        throw new Error('Pick at least one scope or switch to "All access".');
+      }
+      const payload: UpdateMemberInput = { accessMode: editAccessMode };
+      if (scoped) payload.scopes = scopes;
+      await updateMember(processIdOrCode, row.displayCode, payload);
+      toast.success(`Updated access for ${row.displayName}`);
+      setEditingMemberId(null);
+      await refresh();
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const memberList = useMemo(() => members ?? [], [members]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-end bg-black/30" onClick={onClose}>
@@ -145,6 +364,34 @@ export function MembersPanel({
                 Add
               </Button>
             </div>
+            {permission !== 'owner' ? (
+              <div className="mt-3 space-y-2">
+                <div className="flex items-center gap-3 text-xs">
+                  <span className="font-semibold uppercase tracking-wide text-gray-500">Access</span>
+                  <label className="flex items-center gap-1">
+                    <input
+                      type="radio"
+                      name="invite-access-mode"
+                      checked={accessMode === 'unrestricted'}
+                      onChange={() => setAccessMode('unrestricted')}
+                    />
+                    All access
+                  </label>
+                  <label className="flex items-center gap-1">
+                    <input
+                      type="radio"
+                      name="invite-access-mode"
+                      checked={accessMode === 'scoped'}
+                      onChange={() => setAccessMode('scoped')}
+                    />
+                    Scoped
+                  </label>
+                </div>
+                {showInviteScopes ? (
+                  <ScopeEditor state={inviteScopes} onChange={setInviteScopes} />
+                ) : null}
+              </div>
+            ) : null}
             <p className="mt-2 text-[11px] text-gray-500">
               The user must already have an account. For this dev environment the seeded users are{' '}
               <code>admin@ses.local</code> and <code>auditor@ses.local</code>.
@@ -164,56 +411,108 @@ export function MembersPanel({
           </div>
         ) : (
           <ul className="space-y-2">
-            {members.map((row) => {
+            {memberList.map((row) => {
               const isSelf = row.userCode === currentUserCode;
+              const isEditing = editingMemberId === row.id;
               return (
                 <li
                   key={row.id}
-                  className="flex items-center gap-3 rounded-lg border border-gray-200 p-3 text-sm dark:border-gray-700"
+                  className="rounded-lg border border-gray-200 p-3 text-sm dark:border-gray-700"
                 >
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">
-                      {row.displayName} {isSelf ? <span className="text-xs text-gray-400">(you)</span> : null}
+                  <div className="flex items-center gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-medium">
+                        {row.displayName} {isSelf ? <span className="text-xs text-gray-400">(you)</span> : null}
+                      </div>
+                      <div className="truncate text-xs text-gray-500">{row.email}</div>
+                      <div className="mt-0.5 text-[10px] uppercase tracking-wide text-gray-400">
+                        {row.userCode} · {row.globalRole}
+                      </div>
+                      <ScopeBadges scopes={row.scopes} />
                     </div>
-                    <div className="truncate text-xs text-gray-500">{row.email}</div>
-                    <div className="mt-0.5 text-[10px] uppercase tracking-wide text-gray-400">
-                      {row.userCode} · {row.globalRole}
-                    </div>
+                    {canManage ? (
+                      <select
+                        value={row.permission}
+                        onChange={(e) => void changePermission(row, e.target.value as Permission)}
+                        disabled={busy || isSelf}
+                        className="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800"
+                        title={isSelf ? 'You cannot change your own permission' : ''}
+                      >
+                        {PERMISSIONS.map((p) => (
+                          <option key={p} value={p}>
+                            {p}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                        {row.permission}
+                      </span>
+                    )}
+                    {canManage && row.permission !== 'owner' ? (
+                      <button
+                        type="button"
+                        onClick={() => (isEditing ? setEditingMemberId(null) : startEdit(row))}
+                        disabled={busy}
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-40 dark:hover:bg-gray-800"
+                        title="Edit access"
+                        aria-label="Edit access"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                    ) : null}
+                    {canManage && !isSelf ? (
+                      <button
+                        type="button"
+                        onClick={() => void kick(row)}
+                        disabled={busy}
+                        className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-40 dark:hover:bg-red-900/30"
+                        title="Remove"
+                      >
+                        <X size={14} />
+                      </button>
+                    ) : null}
                   </div>
-                  {canManage ? (
-                    <select
-                      value={row.permission}
-                      onChange={(e) => void changePermission(row, e.target.value as Permission)}
-                      disabled={busy || isSelf}
-                      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800"
-                      title={isSelf ? 'You cannot change your own permission' : ''}
-                    >
-                      {PERMISSIONS.map((p) => (
-                        <option key={p} value={p}>
-                          {p}
-                        </option>
-                      ))}
-                    </select>
-                  ) : (
-                    <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                      {row.permission}
-                    </span>
-                  )}
-                  {canManage && !isSelf ? (
-                    <button
-                      type="button"
-                      onClick={() => void kick(row)}
-                      disabled={busy}
-                      className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-40 dark:hover:bg-red-900/30"
-                      title="Remove"
-                    >
-                      <X size={14} />
-                    </button>
+                  {isEditing ? (
+                    <div className="mt-3 space-y-2 border-t border-dashed border-gray-200 pt-3 dark:border-gray-700">
+                      <div className="flex items-center gap-3 text-xs">
+                        <span className="font-semibold uppercase tracking-wide text-gray-500">Access</span>
+                        <label className="flex items-center gap-1">
+                          <input
+                            type="radio"
+                            name={`edit-access-${row.id}`}
+                            checked={editAccessMode === 'unrestricted'}
+                            onChange={() => setEditAccessMode('unrestricted')}
+                          />
+                          All access
+                        </label>
+                        <label className="flex items-center gap-1">
+                          <input
+                            type="radio"
+                            name={`edit-access-${row.id}`}
+                            checked={editAccessMode === 'scoped'}
+                            onChange={() => setEditAccessMode('scoped')}
+                          />
+                          Scoped
+                        </label>
+                      </div>
+                      {editAccessMode === 'scoped' ? (
+                        <ScopeEditor state={editScopes} onChange={setEditScopes} />
+                      ) : null}
+                      <div className="flex justify-end gap-2">
+                        <Button type="button" variant="ghost" onClick={() => setEditingMemberId(null)} disabled={busy}>
+                          Cancel
+                        </Button>
+                        <Button type="button" onClick={() => void saveEditScopes(row)} disabled={busy}>
+                          Save
+                        </Button>
+                      </div>
+                    </div>
                   ) : null}
                 </li>
               );
             })}
-            {!members.length ? (
+            {!memberList.length ? (
               <li className="rounded border border-dashed border-gray-300 p-4 text-center text-xs text-gray-400 dark:border-gray-700">
                 No members yet.
               </li>

--- a/apps/web/src/components/workspace/PreviewTab.tsx
+++ b/apps/web/src/components/workspace/PreviewTab.tsx
@@ -1,14 +1,48 @@
 import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import type { AuditProcess, AuditResult, WorkbookFile } from '../../lib/types';
+import { fetchSheetPreviewFromApi } from '../../lib/api/filesApi';
 import { EmptyState } from '../shared/EmptyState';
 import { StatusBadge } from '../shared/StatusBadge';
 
 export function PreviewTab({ process, file, result }: { process: AuditProcess; file?: WorkbookFile | undefined; result: AuditResult | null }) {
   const [sheetName, setSheetName] = useState(file?.sheets[0]?.name ?? '');
   const activeSheet = useMemo(() => file?.sheets.find((sheet) => sheet.name === sheetName) ?? file?.sheets[0], [file, sheetName]);
-  const rows = activeSheet ? (file?.rawData[activeSheet.name] ?? []) : [];
+  const hasLocalRows = Boolean(activeSheet && file && (file.rawData[activeSheet.name]?.length ?? 0) > 0);
+  const previewQ = useQuery({
+    queryKey: ['sheet-preview', file?.id, activeSheet?.id, result?.id],
+    enabled: Boolean(
+      process.serverBacked
+      && file
+      && activeSheet
+      && !hasLocalRows,
+    ),
+    queryFn: () => fetchSheetPreviewFromApi(
+      (file as WorkbookFile & { displayCode?: string }).displayCode ?? file!.id,
+      (activeSheet as { displayCode?: string }).displayCode ?? activeSheet!.name,
+      {
+        page: 1,
+        pageSize: 100,
+        ...(result?.id ? { runIdOrCode: result.id } : {}),
+      },
+    ),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const rows = activeSheet
+    ? (hasLocalRows
+      ? (file?.rawData[activeSheet.name] ?? [])
+      : [
+          previewQ.data?.headers ?? [],
+          ...(previewQ.data?.rows.map((row) => row.values) ?? []),
+        ])
+    : [];
   const headerRowIndex = activeSheet?.headerRowIndex ?? 0;
-  const headers = activeSheet?.originalHeaders?.length ? activeSheet.originalHeaders : rows[headerRowIndex] ?? [];
+  const headers = activeSheet?.originalHeaders?.length
+    ? activeSheet.originalHeaders
+    : previewQ.data?.headers?.length
+      ? previewQ.data.headers
+      : rows[headerRowIndex] ?? [];
   const validSheetCount = file?.sheets.filter((sheet) => sheet.status === 'valid').length ?? 0;
   const skippedSheetCount = file ? file.sheets.length - validSheetCount : 0;
   const selectedSheetCount = file?.sheets.filter((sheet) => sheet.status === 'valid' && sheet.isSelected).length ?? 0;
@@ -65,6 +99,8 @@ export function PreviewTab({ process, file, result }: { process: AuditProcess; f
         </div>
       ) : null}
       <div className="overflow-auto rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        {previewQ.isLoading ? <div className="border-b border-gray-200 px-4 py-3 text-sm text-gray-500 dark:border-gray-700">Loading preview…</div> : null}
+        {previewQ.isError ? <div className="border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">Preview could not be loaded for this shared file.</div> : null}
         <table className="min-w-full border-collapse text-left text-sm">
           <thead className="sticky top-0 bg-gray-100 dark:bg-gray-700">
             <tr>{headers.map((header, index) => <th key={index} scope="col" className="whitespace-nowrap border-b border-gray-200 px-3 py-2 font-semibold dark:border-gray-600">{String(header)}</th>)}</tr>

--- a/apps/web/src/components/workspace/SheetList.tsx
+++ b/apps/web/src/components/workspace/SheetList.tsx
@@ -5,7 +5,17 @@ import { useAppStore } from '../../store/useAppStore';
 import { Badge } from '../shared/Badge';
 import { StatusBadge } from '../shared/StatusBadge';
 
-export function SheetList({ process, file }: { process: AuditProcess; file: WorkbookFile }) {
+export function SheetList({
+  process,
+  file,
+  canEdit = true,
+  readOnlyReason,
+}: {
+  process: AuditProcess;
+  file: WorkbookFile;
+  canEdit?: boolean;
+  readOnlyReason?: string | undefined;
+}) {
   const [scope, setScope] = useState<'all' | 'selected'>('all');
   const toggleSheet = useAppStore((state) => state.toggleSheet);
   const selectAllValidSheets = useAppStore((state) => state.selectAllValidSheets);
@@ -15,6 +25,7 @@ export function SheetList({ process, file }: { process: AuditProcess; file: Work
   const selected = valid.filter((sheet) => sheet.isSelected).length;
 
   function changeScope(value: 'all' | 'selected') {
+    if (!canEdit) return;
     setScope(value);
     if (value === 'all') selectAllValidSheets(process.id, file.id);
   }
@@ -26,7 +37,7 @@ export function SheetList({ process, file }: { process: AuditProcess; file: Work
         <p className="text-xs text-gray-500">{file.isAudited ? `${selected} audited, ${skipped} skipped` : `${selected} selected, ${skipped} skipped`}</p>
       </div>
       <label className="text-xs font-medium text-gray-500">Scope</label>
-      <select value={scope} onChange={(event) => changeScope(event.target.value as 'all' | 'selected')} className="mt-1 w-full rounded-lg border border-gray-300 px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-800">
+      <select value={scope} disabled={!canEdit} title={!canEdit ? readOnlyReason : undefined} onChange={(event) => changeScope(event.target.value as 'all' | 'selected')} className="mt-1 w-full rounded-lg border border-gray-300 px-2 py-2 text-sm disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 dark:border-gray-700 dark:bg-gray-800">
         <option value="all">Audit all valid sheets</option>
         <option value="selected">Audit selected sheets</option>
       </select>
@@ -36,7 +47,7 @@ export function SheetList({ process, file }: { process: AuditProcess; file: Work
           return (
             <div key={sheet.name} className={`rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800 ${disabled ? 'opacity-50' : ''}`}>
               <div className="flex items-start gap-2">
-                {scope === 'selected' ? <input type="checkbox" disabled={disabled} checked={sheet.isSelected} onChange={() => toggleSheet(process.id, file.id, sheet.name)} className="mt-1" /> : null}
+                {scope === 'selected' ? <input type="checkbox" title={!canEdit ? readOnlyReason : undefined} disabled={disabled || !canEdit} checked={sheet.isSelected} onChange={() => toggleSheet(process.id, file.id, sheet.name)} className="mt-1" /> : null}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="truncate text-sm font-medium">{sheet.name}</span>
@@ -55,8 +66,8 @@ export function SheetList({ process, file }: { process: AuditProcess; file: Work
       </div>
       {scope === 'selected' ? (
         <div className="mt-3 flex gap-2">
-          <button onClick={() => selectAllValidSheets(process.id, file.id)} className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs hover:bg-gray-50 dark:border-gray-700">Select Valid</button>
-          <button onClick={() => clearSheetSelection(process.id, file.id)} className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs hover:bg-gray-50 dark:border-gray-700">Clear All</button>
+          <button type="button" title={!canEdit ? readOnlyReason : undefined} disabled={!canEdit} onClick={() => selectAllValidSheets(process.id, file.id)} className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700">Select Valid</button>
+          <button type="button" title={!canEdit ? readOnlyReason : undefined} disabled={!canEdit} onClick={() => clearSheetSelection(process.id, file.id)} className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700">Clear All</button>
         </div>
       ) : null}
     </section>

--- a/apps/web/src/components/workspace/__tests__/MembersPanel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/MembersPanel.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConfirmProvider } from '../../shared/ConfirmProvider';
+import { MembersPanel } from '../MembersPanel';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
+}));
+
+vi.mock('../../../lib/api/membersApi', () => ({
+  listMembers: vi.fn(),
+  addMember: vi.fn(),
+  updateMember: vi.fn(),
+  removeMember: vi.fn(),
+}));
+
+import * as membersApi from '../../../lib/api/membersApi';
+
+function renderPanel(opts?: { canManage?: boolean }) {
+  return render(
+    <ConfirmProvider>
+      <MembersPanel
+        processIdOrCode="P-1"
+        currentUserCode="U-CURRENT"
+        canManage={opts?.canManage ?? true}
+        onClose={() => {}}
+      />
+    </ConfirmProvider>,
+  );
+}
+
+describe('MembersPanel — invite scope flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(membersApi.listMembers).mockResolvedValue([]);
+    vi.mocked(membersApi.addMember).mockResolvedValue({ id: 'm1', displayCode: 'M-1', changed: true });
+  });
+
+  it('toggling Scoped reveals the scope editor and submits a scoped payload', async () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByPlaceholderText('email@company.com'), {
+      target: { value: 'a@b.test' },
+    });
+    fireEvent.click(screen.getByLabelText(/Scoped/i));
+    // Tick the Master Data checkbox (its label text comes from FUNCTION_REGISTRY).
+    const masterDataLabel = await screen.findByText('Master Data');
+    const masterDataRow = masterDataLabel.closest('label');
+    expect(masterDataRow).not.toBeNull();
+    const masterDataCheckbox = within(masterDataRow as HTMLElement).getByRole('checkbox');
+    fireEvent.click(masterDataCheckbox);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add/ }));
+
+    await waitFor(() => expect(vi.mocked(membersApi.addMember)).toHaveBeenCalled());
+    const [, body] = vi.mocked(membersApi.addMember).mock.calls[0]!;
+    expect(body.email).toBe('a@b.test');
+    expect(body.permission).toBe('editor');
+    expect(body.accessMode).toBe('scoped');
+    expect(body.scopes).toEqual([
+      { scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' },
+    ]);
+  });
+
+  it('selecting permission=owner hides the scope editor and submits without scopes', async () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByPlaceholderText('email@company.com'), {
+      target: { value: 'owner@b.test' },
+    });
+    const permissionSelect = screen.getByDisplayValue('editor') as HTMLSelectElement;
+    fireEvent.change(permissionSelect, { target: { value: 'owner' } });
+    // Wait for React's controlled-select to actually swap the displayed value.
+    await waitFor(() => expect(permissionSelect.value).toBe('owner'));
+
+    // The scope toggle UI should disappear once owner is selected.
+    expect(screen.queryByLabelText(/Scoped/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => expect(vi.mocked(membersApi.addMember)).toHaveBeenCalled());
+    const [, body] = vi.mocked(membersApi.addMember).mock.calls[0]!;
+    expect(body.permission).toBe('owner');
+    expect(body.accessMode).toBe('unrestricted');
+    expect(body.scopes).toBeUndefined();
+  });
+});
+
+describe('MembersPanel — scope badges + edit panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(membersApi.listMembers).mockResolvedValue([
+      {
+        id: 'm-1',
+        displayCode: 'M-1',
+        userId: 'u-1',
+        userCode: 'U-1',
+        email: 'scoped@b.test',
+        displayName: 'Scoped User',
+        globalRole: 'auditor',
+        permission: 'viewer',
+        addedAt: new Date().toISOString(),
+        scopes: [
+          { scopeType: 'function', functionId: 'master-data', accessLevel: 'viewer' },
+          { scopeType: 'escalation-center', functionId: null, accessLevel: 'viewer' },
+        ],
+      },
+    ]);
+    vi.mocked(membersApi.updateMember).mockResolvedValue({ id: 'm-1', displayCode: 'M-1', changed: true });
+  });
+
+  it('renders scope badges and PATCHes when the inline edit panel is saved', async () => {
+    renderPanel();
+
+    expect(await screen.findByText(/Master Data · viewer/)).toBeInTheDocument();
+    expect(screen.getByText(/Escalation Center · viewer/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit access/ }));
+    // Save with the existing scoped state — should still PATCH.
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => expect(vi.mocked(membersApi.updateMember)).toHaveBeenCalled());
+    const [, memberCode, body] = vi.mocked(membersApi.updateMember).mock.calls[0]!;
+    expect(memberCode).toBe('M-1');
+    expect(body.accessMode).toBe('scoped');
+    expect(body.scopes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ scopeType: 'function', functionId: 'master-data' }),
+        expect.objectContaining({ scopeType: 'escalation-center' }),
+      ]),
+    );
+  });
+});

--- a/apps/web/src/components/workspace/__tests__/PreviewTab.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/PreviewTab.test.tsx
@@ -1,0 +1,100 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PreviewTab } from '../PreviewTab';
+import type { AuditProcess, WorkbookFile } from '../../../lib/types';
+
+const fetchSheetPreviewFromApi = vi.fn();
+
+vi.mock('../../../lib/api/filesApi', () => ({
+  fetchSheetPreviewFromApi: (...args: unknown[]) => fetchSheetPreviewFromApi(...args),
+}));
+
+function renderWithQuery(ui: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const file: WorkbookFile = {
+  id: 'file-1',
+  displayCode: 'FIL-1',
+  name: 'shared.xlsx',
+  uploadedAt: '2026-04-10T00:00:00.000Z',
+  lastAuditedAt: '2026-04-10T00:00:00.000Z',
+  isAudited: true,
+  functionId: 'master-data',
+  rawData: {},
+  sheets: [
+    {
+      id: 'sheet-1',
+      displayCode: 'SHT-1',
+      name: 'Effort Data',
+      status: 'valid',
+      rowCount: 1,
+      isSelected: true,
+      headerRowIndex: 0,
+      originalHeaders: [],
+      normalizedHeaders: [],
+    },
+  ],
+};
+
+const process: AuditProcess = {
+  id: 'process-1',
+  displayCode: 'PRC-1',
+  name: 'Shared process',
+  description: '',
+  serverBacked: true,
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-01T00:00:00.000Z',
+  nextAuditDue: null,
+  files: [file],
+  activeFileId: file.id,
+  versions: [],
+  auditPolicy: {
+    highEffortThreshold: 900,
+    mediumEffortMin: 400,
+    mediumEffortMax: 800,
+    lowEffortMin: 1,
+    lowEffortMax: 399,
+    lowEffortEnabled: false,
+    zeroEffortEnabled: true,
+    missingEffortEnabled: true,
+    missingManagerEnabled: true,
+    inPlanningEffortEnabled: true,
+    onHoldEffortEnabled: true,
+    onHoldEffortThreshold: 200,
+    updatedAt: '2026-04-10T00:00:00.000Z',
+  },
+  notificationTracking: {},
+  comments: {},
+  corrections: {},
+  acknowledgments: {},
+  savedTemplates: {},
+};
+
+afterEach(() => {
+  fetchSheetPreviewFromApi.mockReset();
+});
+
+describe('PreviewTab', () => {
+  it('loads preview rows from the API when a shared server-backed file has no local rawData', async () => {
+    fetchSheetPreviewFromApi.mockResolvedValue({
+      fileId: 'file-1',
+      fileCode: 'FIL-1',
+      sheetName: 'Effort Data',
+      sheetCode: 'SHT-1',
+      page: 1,
+      pageSize: 100,
+      totalRows: 1,
+      headerRowIndex: 0,
+      headers: ['Project No.', 'Project'],
+      rows: [{ rowIndex: 1, values: ['90032101', 'Digital Core SAP S4'] }],
+    });
+
+    renderWithQuery(<PreviewTab process={process} file={file} result={null} />);
+
+    await waitFor(() => expect(fetchSheetPreviewFromApi).toHaveBeenCalledWith('FIL-1', 'SHT-1', expect.any(Object)));
+    expect(await screen.findByText('Digital Core SAP S4')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useEffectiveAccess.test.ts
+++ b/apps/web/src/hooks/__tests__/useEffectiveAccess.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { computeAccess } from '../useEffectiveAccess';
+import type { EffectiveAccess } from '../../lib/api/processAccessApi';
+
+// Locks parity with apps/api/src/common/access-scope.service.ts:resolve. If a
+// case here changes, the server resolver must move with it (and vice versa).
+describe('computeAccess', () => {
+  const fid = 'master-data';
+  const otherFid = 'over-planning';
+
+  describe('owner bypass', () => {
+    it('owner is allowed regardless of scopes/action/kind', () => {
+      const access: EffectiveAccess = { permission: 'owner', scopes: [] };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(true);
+      expect(computeAccess(access, { kind: 'escalation-center', action: 'edit' })).toBe(true);
+      expect(computeAccess(access, { kind: 'all-functions', action: 'edit' })).toBe(true);
+    });
+  });
+
+  describe('legacy fallback (no scope rows)', () => {
+    it('editor passes view + edit', () => {
+      const access: EffectiveAccess = { permission: 'editor', scopes: [] };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'view' })).toBe(true);
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(true);
+    });
+
+    it('viewer passes view but not edit', () => {
+      const access: EffectiveAccess = { permission: 'viewer', scopes: [] };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'view' })).toBe(true);
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(false);
+    });
+  });
+
+  describe('function scope', () => {
+    it('function-viewer can view that function but not edit', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'function', functionId: fid, accessLevel: 'viewer' }],
+      };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'view' })).toBe(true);
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(false);
+    });
+
+    it('function-editor can edit that function only', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'function', functionId: fid, accessLevel: 'editor' }],
+      };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(true);
+      expect(computeAccess(access, { kind: 'function', functionId: otherFid, action: 'view' })).toBe(false);
+    });
+
+    it('all-functions:editor unlocks every function', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'all-functions', functionId: null, accessLevel: 'editor' }],
+      };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(true);
+      expect(computeAccess(access, { kind: 'function', functionId: otherFid, action: 'edit' })).toBe(true);
+    });
+
+    it('most permissive matching scope wins (function:viewer + all-functions:editor → editor)', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [
+          { scopeType: 'function', functionId: fid, accessLevel: 'viewer' },
+          { scopeType: 'all-functions', functionId: null, accessLevel: 'editor' },
+        ],
+      };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'edit' })).toBe(true);
+    });
+  });
+
+  describe('escalation-center scope', () => {
+    it('escalation-viewer can view escalations but not edit', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'escalation-center', functionId: null, accessLevel: 'viewer' }],
+      };
+      expect(computeAccess(access, { kind: 'escalation-center', action: 'view' })).toBe(true);
+      expect(computeAccess(access, { kind: 'escalation-center', action: 'edit' })).toBe(false);
+    });
+
+    it('escalation-only scope denies function access', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'escalation-center', functionId: null, accessLevel: 'editor' }],
+      };
+      expect(computeAccess(access, { kind: 'function', functionId: fid, action: 'view' })).toBe(false);
+    });
+  });
+
+  describe('all-functions kind (process-wide non-function routes)', () => {
+    it('view is allowed if any scope row exists', () => {
+      const access: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'function', functionId: fid, accessLevel: 'viewer' }],
+      };
+      expect(computeAccess(access, { kind: 'all-functions', action: 'view' })).toBe(true);
+    });
+
+    it('edit requires an all-functions row', () => {
+      const onlyFunction: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'function', functionId: fid, accessLevel: 'editor' }],
+      };
+      expect(computeAccess(onlyFunction, { kind: 'all-functions', action: 'edit' })).toBe(false);
+
+      const withAll: EffectiveAccess = {
+        permission: 'editor',
+        scopes: [{ scopeType: 'all-functions', functionId: null, accessLevel: 'editor' }],
+      };
+      expect(computeAccess(withAll, { kind: 'all-functions', action: 'edit' })).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/hooks/useEffectiveAccess.ts
+++ b/apps/web/src/hooks/useEffectiveAccess.ts
@@ -1,0 +1,124 @@
+import { useQuery } from '@tanstack/react-query';
+import type { FunctionId } from '@ses/domain';
+import { getMyAccess, type EffectiveAccess, type ProcessPermission } from '../lib/api/processAccessApi';
+import type { MemberScopeRow, ScopeAccessLevel } from '../lib/api/membersApi';
+
+/**
+ * Pure resolver that mirrors `AccessScopeService.resolve` on the API. It
+ * MUST stay in lock-step with that file — see access-scope.service.ts:96.
+ *
+ * Resolution:
+ *   1. owner => allow.
+ *   2. zero scope rows => fall back to ProcessMember.permission (legacy).
+ *   3. otherwise match by kind:
+ *      - 'function': exact function row + any 'all-functions' row.
+ *      - 'escalation-center': exact escalation row only.
+ *      - 'all-functions' (process-wide non-function routes): view if any
+ *        scope row exists; edit requires an 'all-functions' row.
+ */
+const accessRank: Record<ScopeAccessLevel, number> = { viewer: 1, editor: 2 };
+const baseRank: Record<ProcessPermission, number> = { viewer: 1, editor: 2, owner: 3 };
+
+type Kind = 'all-functions' | 'function' | 'escalation-center';
+type Action = 'view' | 'edit';
+
+export function computeAccess(
+  access: EffectiveAccess,
+  ctx: { kind: Kind; functionId?: string; action: Action },
+): boolean {
+  if (access.permission === 'owner') return true;
+  const required = ctx.action === 'view' ? 1 : 2;
+
+  if (access.scopes.length === 0) {
+    return baseRank[access.permission] >= required;
+  }
+
+  const candidates: ScopeAccessLevel[] = [];
+
+  if (ctx.kind === 'function') {
+    if (!ctx.functionId) return false;
+    const exact = access.scopes.find(
+      (s) => s.scopeType === 'function' && s.functionId === ctx.functionId,
+    );
+    if (exact) candidates.push(exact.accessLevel);
+    const all = access.scopes.find((s) => s.scopeType === 'all-functions');
+    if (all) candidates.push(all.accessLevel);
+  } else if (ctx.kind === 'escalation-center') {
+    const esc = access.scopes.find((s) => s.scopeType === 'escalation-center');
+    if (esc) candidates.push(esc.accessLevel);
+  } else {
+    if (ctx.action === 'view') return true;
+    const all = access.scopes.find((s) => s.scopeType === 'all-functions');
+    if (all) candidates.push(all.accessLevel);
+  }
+
+  if (candidates.length === 0) return false;
+  const best = Math.max(...candidates.map((c) => accessRank[c]));
+  return best >= required;
+}
+
+export interface AccessGate {
+  loading: boolean;
+  /** True when we couldn't load access (e.g., not a member, or network) — caller should treat as no access. */
+  error: boolean;
+  permission: ProcessPermission | null;
+  scopes: MemberScopeRow[];
+  isOwner: boolean;
+  canViewFunction(fid: FunctionId | string | null | undefined): boolean;
+  canEditFunction(fid: FunctionId | string | null | undefined): boolean;
+  canViewEscalations: boolean;
+  canEditEscalations: boolean;
+  canEditAllFunctions: boolean;
+}
+
+/**
+ * Hook returning the current user's effective access for a process plus
+ * predicates the workspace UI uses to disable mutating controls. Falls back
+ * to a deny-all gate while loading or when not a member.
+ */
+export function useEffectiveAccess(processIdOrCode: string | null | undefined): AccessGate {
+  const enabled = Boolean(processIdOrCode);
+  const q = useQuery({
+    queryKey: ['process-access', processIdOrCode],
+    queryFn: () => getMyAccess(processIdOrCode as string),
+    enabled,
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const access = q.data ?? null;
+
+  if (!access) {
+    const isLoading = enabled && q.isLoading;
+    return {
+      loading: isLoading,
+      error: enabled && !q.isLoading && !q.isFetching,
+      permission: null,
+      scopes: [],
+      isOwner: false,
+      canViewFunction: () => false,
+      canEditFunction: () => false,
+      canViewEscalations: false,
+      canEditEscalations: false,
+      canEditAllFunctions: false,
+    };
+  }
+
+  const fnGate = (action: Action) => (fid: FunctionId | string | null | undefined) => {
+    if (!fid) return false;
+    return computeAccess(access, { kind: 'function', functionId: String(fid), action });
+  };
+
+  return {
+    loading: false,
+    error: false,
+    permission: access.permission,
+    scopes: access.scopes,
+    isOwner: access.permission === 'owner',
+    canViewFunction: fnGate('view'),
+    canEditFunction: fnGate('edit'),
+    canViewEscalations: computeAccess(access, { kind: 'escalation-center', action: 'view' }),
+    canEditEscalations: computeAccess(access, { kind: 'escalation-center', action: 'edit' }),
+    canEditAllFunctions: computeAccess(access, { kind: 'all-functions', action: 'edit' }),
+  };
+}

--- a/apps/web/src/lib/api/filesApi.ts
+++ b/apps/web/src/lib/api/filesApi.ts
@@ -65,6 +65,46 @@ export async function listFilesOnApi(
   return (await res.json()) as ApiFileSummary[];
 }
 
+export interface ApiSheetPreview {
+  fileId: string;
+  fileCode: string;
+  sheetName: string;
+  sheetCode: string;
+  page: number;
+  pageSize: number;
+  totalRows: number;
+  headerRowIndex: number;
+  headers: string[];
+  rows: Array<{
+    rowIndex: number;
+    values: string[];
+    issue?: {
+      id: string;
+      displayCode: string;
+      severity: string;
+      issueKey: string;
+    };
+  }>;
+}
+
+export async function fetchSheetPreviewFromApi(
+  fileIdOrCode: string,
+  sheetIdOrCode: string,
+  opts?: { page?: number; pageSize?: number; runIdOrCode?: string },
+): Promise<ApiSheetPreview> {
+  const params = new URLSearchParams();
+  if (opts?.page) params.set('page', String(opts.page));
+  if (opts?.pageSize) params.set('pageSize', String(opts.pageSize));
+  if (opts?.runIdOrCode) params.set('run', opts.runIdOrCode);
+  const query = params.size > 0 ? `?${params.toString()}` : '';
+  const res = await fetch(
+    `/api/v1/files/${encodeURIComponent(fileIdOrCode)}/sheets/${encodeURIComponent(sheetIdOrCode)}/preview${query}`,
+    { credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to load sheet preview');
+  return (await res.json()) as ApiSheetPreview;
+}
+
 export async function deleteFileOnApi(fileIdOrCode: string): Promise<void> {
   const res = await fetch(`/api/v1/files/${encodeURIComponent(fileIdOrCode)}`, {
     method: 'DELETE',

--- a/apps/web/src/lib/api/membersApi.ts
+++ b/apps/web/src/lib/api/membersApi.ts
@@ -1,5 +1,15 @@
 import { JSON_HEADERS, parseApiError } from './client';
 
+export type ScopeAccessLevel = 'viewer' | 'editor';
+export type ScopeType = 'all-functions' | 'function' | 'escalation-center';
+export type AccessMode = 'unrestricted' | 'scoped';
+
+export interface MemberScopeRow {
+  scopeType: ScopeType;
+  functionId: string | null;
+  accessLevel: ScopeAccessLevel;
+}
+
 export interface ProcessMemberRow {
   id: string;
   displayCode: string;
@@ -10,6 +20,21 @@ export interface ProcessMemberRow {
   globalRole: string;
   permission: 'viewer' | 'editor' | 'owner';
   addedAt: string;
+  scopes: MemberScopeRow[];
+}
+
+export interface AddMemberInput {
+  email?: string;
+  userCode?: string;
+  permission?: 'viewer' | 'editor' | 'owner';
+  accessMode?: AccessMode;
+  scopes?: MemberScopeRow[];
+}
+
+export interface UpdateMemberInput {
+  permission?: 'viewer' | 'editor' | 'owner';
+  accessMode?: AccessMode;
+  scopes?: MemberScopeRow[];
 }
 
 export async function listMembers(processIdOrCode: string): Promise<ProcessMemberRow[]> {
@@ -17,12 +42,13 @@ export async function listMembers(processIdOrCode: string): Promise<ProcessMembe
     credentials: 'include',
   });
   if (!res.ok) throw await parseApiError(res, 'Failed to load members');
-  return (await res.json()) as ProcessMemberRow[];
+  const rows = (await res.json()) as Array<Omit<ProcessMemberRow, 'scopes'> & { scopes?: MemberScopeRow[] }>;
+  return rows.map((row) => ({ ...row, scopes: row.scopes ?? [] }));
 }
 
 export async function addMember(
   processIdOrCode: string,
-  body: { email?: string; userCode?: string; permission?: 'viewer' | 'editor' | 'owner' },
+  body: AddMemberInput,
 ): Promise<{ id: string; displayCode: string; changed: boolean }> {
   const res = await fetch(`/api/v1/processes/${encodeURIComponent(processIdOrCode)}/members`, {
     method: 'POST',
@@ -31,6 +57,24 @@ export async function addMember(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await parseApiError(res, 'Failed to add member');
+  return (await res.json()) as { id: string; displayCode: string; changed: boolean };
+}
+
+export async function updateMember(
+  processIdOrCode: string,
+  memberIdOrCode: string,
+  body: UpdateMemberInput,
+): Promise<{ id: string; displayCode: string; changed: boolean }> {
+  const res = await fetch(
+    `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/members/${encodeURIComponent(memberIdOrCode)}`,
+    {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to update member');
   return (await res.json()) as { id: string; displayCode: string; changed: boolean };
 }
 

--- a/apps/web/src/lib/api/processAccessApi.ts
+++ b/apps/web/src/lib/api/processAccessApi.ts
@@ -1,0 +1,19 @@
+import { parseApiError } from './client';
+import type { MemberScopeRow } from './membersApi';
+
+export type ProcessPermission = 'viewer' | 'editor' | 'owner';
+
+export interface EffectiveAccess {
+  permission: ProcessPermission;
+  scopes: MemberScopeRow[];
+}
+
+export async function getMyAccess(processIdOrCode: string): Promise<EffectiveAccess> {
+  const res = await fetch(
+    `/api/v1/processes/${encodeURIComponent(processIdOrCode)}/me/access`,
+    { credentials: 'include' },
+  );
+  if (!res.ok) throw await parseApiError(res, 'Failed to load access');
+  const json = (await res.json()) as { permission: ProcessPermission; scopes?: MemberScopeRow[] };
+  return { permission: json.permission, scopes: json.scopes ?? [] };
+}

--- a/apps/web/src/lib/api/trackingComposeApi.ts
+++ b/apps/web/src/lib/api/trackingComposeApi.ts
@@ -13,6 +13,8 @@ export type ComposeDraftPayload = {
   authorNote?: string;
   /** Issue #75: ISO-8601 date for the {{dueDate}} slot. */
   deadlineAt?: string | null;
+  /** Map of projectNo → URL the auditor pasted in the Composer. */
+  projectLinks?: Record<string, string>;
 };
 
 /**
@@ -25,6 +27,8 @@ export interface SendComposeResult {
   channel: 'email' | 'teams' | 'both';
   subject: string;
   body: string;
+  /** HTML rendering of the body — used by the Composer preview, not by mailto. */
+  bodyHtml?: string;
   to: string;
   cc: string[];
 }
@@ -45,7 +49,7 @@ export async function previewCompose(trackingIdOrCode: string, body: Partial<Com
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await parseApiError(res, 'Preview failed');
-  return (await res.json()) as { subject: string; body: string };
+  return (await res.json()) as { subject: string; body: string; bodyHtml?: string };
 }
 
 export async function saveComposeDraft(trackingIdOrCode: string, body: ComposeDraftPayload) {

--- a/apps/web/src/pages/Workspace.tsx
+++ b/apps/web/src/pages/Workspace.tsx
@@ -1,11 +1,10 @@
 import { Link, Navigate, useBlocker, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowDownToLine, History, Play, Save, Users } from 'lucide-react';
+import { ArrowDownToLine, History, Play, Save } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { DEFAULT_FUNCTION_ID, getFunctionLabel, isFunctionId, isValidEmail, type FunctionId } from '@ses/domain';
 import { FilesSidebar } from '../components/workspace/FilesSidebar';
-import { MembersPanel } from '../components/workspace/MembersPanel';
 import { WorkspaceShell } from '../components/workspace/WorkspaceShell';
 import { TabPanel } from '../components/workspace/TabPanel';
 import { PreviewTab } from '../components/workspace/PreviewTab';
@@ -28,6 +27,9 @@ import { useRealtime } from '../realtime/useRealtime';
 import { onRealtimeEvent } from '../realtime/socket';
 import { directorySuggestions } from '../lib/api/directoryApi';
 import { ResolutionDrawer } from '../components/directory/ResolutionDrawer';
+import { useEffectiveAccess } from '../hooks/useEffectiveAccess';
+
+const READ_ONLY_TOOLTIP = 'Read-only access — ask an admin for editor scope.';
 
 const AnalyticsTab = lazy(() => import('../components/workspace/AnalyticsTab').then((module) => ({ default: module.AnalyticsTab })));
 const VersionHistoryTab = lazy(() =>
@@ -73,7 +75,6 @@ export function Workspace() {
   const currentUser = useCurrentUser();
   const managerDirectoryOn = currentUser?.managerDirectoryEnabled !== false;
   const tabFromUrl = searchParams.get('tab');
-  const [membersOpen, setMembersOpen] = useState(false);
   const [resolutionOpen, setResolutionOpen] = useState(false);
   const [versionModalOpen, setVersionModalOpen] = useState(false);
   // Blocker handed off when the user picks "Save as new version" from the
@@ -212,8 +213,16 @@ export function Workspace() {
   }
   const mappingSourceValid =
     !MAPPING_ENABLED_FUNCTIONS.has(activeFile?.functionId ?? '') || isMappingSourceValid(mappingSource);
-  const canRun = Boolean(process && activeFile && selectedSheets > 0 && !isAuditRunning && mappingSourceValid);
-  const canSave = Boolean(process && latestResult && !isAuditRunning);
+  const accessGate = useEffectiveAccess(process?.serverBacked ? process.displayCode ?? process.id : null);
+  // For local-only (non-serverBacked) processes there's no membership row to
+  // consult — the user is the local owner of their browser session, so allow.
+  const canEditThisFunction = process?.serverBacked
+    ? accessGate.canEditFunction(activeFile?.functionId ?? functionId)
+    : true;
+  const featureCanRun = Boolean(process && activeFile && selectedSheets > 0 && !isAuditRunning && mappingSourceValid);
+  const featureCanSave = Boolean(process && latestResult && !isAuditRunning);
+  const canRun = featureCanRun && canEditThisFunction;
+  const canSave = featureCanSave && canEditThisFunction;
   const canDownload = Boolean(process && activeFile && latestResult && hasSavedVersion && !isAuditRunning);
 
   const onRunAudit = useCallback(async () => {
@@ -275,7 +284,6 @@ export function Workspace() {
     );
   }, [activeFile, latestResult, process]);
 
-  const onOpenMembers = useCallback(() => setMembersOpen(true), []);
   const onOpenVersionHistory = useCallback(() => {
     if (!process) return;
     void navigate(versionComparePath(process.displayCode ?? process.id, functionId));
@@ -286,12 +294,16 @@ export function Workspace() {
   const headerConfig = useMemo(() => {
     if (!process) return { breadcrumbs: [] };
     const saveLabel = headVersion ? `Save to ${headVersionName}` : 'Save';
-    const saveTooltip = !latestResult
+    const saveTooltip = !canEditThisFunction
+      ? READ_ONLY_TOOLTIP
+      : !latestResult
       ? 'Run audit first to save.'
       : headVersion
       ? `Update ${headVersionName} in place with the latest findings. Use the caret to create a new named version.`
       : 'Save the current audit findings as V1.';
-    const runTooltip = !activeFile
+    const runTooltip = !canEditThisFunction
+      ? READ_ONLY_TOOLTIP
+      : !activeFile
       ? 'Upload a file first'
       : selectedSheets === 0
       ? 'Select at least one valid sheet'
@@ -326,9 +338,6 @@ export function Workspace() {
         onClick: onDownload,
         disabled: !canDownload,
       });
-    }
-    if (process.serverBacked) {
-      overflow.push({ id: 'members', label: 'Members', icon: Users, onClick: onOpenMembers });
     }
     if (hasSavedVersion) {
       overflow.push({ id: 'versions', label: 'Version history', icon: History, onClick: onOpenVersionHistory });
@@ -385,6 +394,7 @@ export function Workspace() {
     latestResult,
     correctionCount,
     canRun,
+    canEditThisFunction,
     mappingSourceValid,
     canSave,
     canDownload,
@@ -396,7 +406,6 @@ export function Workspace() {
     onSaveAsNew,
     onDownload,
     onDownloadCorrected,
-    onOpenMembers,
     onOpenVersionHistory,
     leaveGuard,
   ]);
@@ -412,10 +421,9 @@ export function Workspace() {
   if (!process) return <Navigate to="/" replace />;
   const scopedProcess = { ...process, files: functionFiles };
   const draft = fileDrafts[`${process.id}:${functionId}`];
-  const canManageMembers = currentUser?.role === 'admin';
 
   return (
-    <AppShell process={process} sidebar={<FilesSidebar process={scopedProcess} functionId={functionId} />}>
+    <AppShell process={process} sidebar={<FilesSidebar process={scopedProcess} functionId={functionId} canEdit={canEditThisFunction} readOnlyReason={READ_ONLY_TOOLTIP} />}>
       <DraftRestoreBanner
         draft={draft}
         currentFile={activeFile}
@@ -459,6 +467,8 @@ export function Workspace() {
               file={activeFile}
               mappingSource={mappingSource}
               onMappingSourceChange={setMappingSource}
+              canEdit={canEditThisFunction}
+              readOnlyReason={READ_ONLY_TOOLTIP}
             />
           </TabPanel>
         ) : null}
@@ -489,14 +499,6 @@ export function Workspace() {
           </TabPanel>
         ) : null}
       </WorkspaceShell>
-      {membersOpen && process.serverBacked ? (
-        <MembersPanel
-          processIdOrCode={process.displayCode ?? process.id}
-          currentUserCode={currentUser?.displayCode}
-          canManage={canManageMembers}
-          onClose={() => setMembersOpen(false)}
-        />
-      ) : null}
       {managerDirectoryOn && resolutionOpen && rawManagerNames.length > 0 ? (
         <ResolutionDrawer
           open={resolutionOpen}

--- a/apps/web/src/pages/__tests__/Workspace.test.tsx
+++ b/apps/web/src/pages/__tests__/Workspace.test.tsx
@@ -42,7 +42,19 @@ const file: WorkbookFile = {
   lastAuditedAt: null,
   isAudited: false,
   functionId: 'over-planning',
-  sheets: [],
+  sheets: [
+    {
+      id: 's-ws',
+      displayCode: 'SHT-WS',
+      name: 'Sheet 1',
+      status: 'valid',
+      rowCount: 3,
+      isSelected: true,
+      headerRowIndex: 0,
+      originalHeaders: [],
+      normalizedHeaders: [],
+    },
+  ],
   rawData: {},
 };
 
@@ -190,6 +202,7 @@ describe('Workspace', () => {
     const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
     expect(fileInput).not.toBeNull();
     expect(fileInput!.disabled).toBe(true);
+    expect(screen.getByRole('combobox')).toBeDisabled();
   });
 
   it('keeps FilesSidebar Upload enabled when the user has editor scope (default mock)', () => {

--- a/apps/web/src/pages/__tests__/Workspace.test.tsx
+++ b/apps/web/src/pages/__tests__/Workspace.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Workspace } from '../Workspace';
 import { ConfirmProvider } from '../../components/shared/ConfirmProvider';
 import type { AuditProcess, AuditVersion, WorkbookFile } from '../../lib/types';
@@ -88,9 +88,48 @@ vi.mock('../../lib/api/directoryApi', () => ({
   directorySuggestions: vi.fn().mockResolvedValue({ results: {} }),
 }));
 
+type GateMock = {
+  loading: boolean;
+  error: boolean;
+  permission: 'viewer' | 'editor' | 'owner';
+  scopes: Array<{ scopeType: string; functionId: string | null; accessLevel: string }>;
+  isOwner: boolean;
+  canViewFunction: (fid: string | null | undefined) => boolean;
+  canEditFunction: (fid: string | null | undefined) => boolean;
+  canViewEscalations: boolean;
+  canEditEscalations: boolean;
+  canEditAllFunctions: boolean;
+};
+
+const defaultGate: GateMock = {
+  loading: false,
+  error: false,
+  permission: 'editor',
+  scopes: [],
+  isOwner: false,
+  canViewFunction: () => true,
+  canEditFunction: () => true,
+  canViewEscalations: true,
+  canEditEscalations: true,
+  canEditAllFunctions: true,
+};
+
+const accessGateMock = vi.fn(() => defaultGate);
+
+vi.mock('../../hooks/useEffectiveAccess', () => ({
+  useEffectiveAccess: (...args: unknown[]) => accessGateMock(...(args as [])),
+}));
+
 import { useAppStore } from '../../store/useAppStore';
 
 describe('Workspace', () => {
+  beforeEach(() => {
+    accessGateMock.mockImplementation(() => defaultGate);
+  });
+  afterEach(() => {
+    accessGateMock.mockReset();
+  });
+
   const baseStore = {
     processes: [mockProcess],
     hydrateProcesses: vi.fn().mockResolvedValue(undefined),
@@ -120,6 +159,45 @@ describe('Workspace', () => {
     vi.mocked(useAppStore).mockImplementation((selector) => selector({ ...baseStore } as never));
     renderWorkspaceAt('/processes/p-ws/over-planning');
     expect(screen.getByText('hydrated.xlsx')).toBeInTheDocument();
+  });
+
+  it('does not expose a members-share trigger anywhere in the workspace', () => {
+    vi.mocked(useAppStore).mockImplementation((selector) => selector({ ...baseStore } as never));
+    renderWorkspaceAt('/processes/p-ws/over-planning');
+    // Members management has been migrated to the dashboard process card.
+    expect(screen.queryByRole('button', { name: /^members$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /share process/i })).toBeNull();
+  });
+
+  it('disables FilesSidebar Upload when the user has function-viewer scope', () => {
+    const viewerGate: GateMock = {
+      loading: false,
+      error: false,
+      permission: 'editor',
+      scopes: [{ scopeType: 'function', functionId: 'over-planning', accessLevel: 'viewer' }],
+      isOwner: false,
+      canViewFunction: () => true,
+      canEditFunction: () => false,
+      canViewEscalations: false,
+      canEditEscalations: false,
+      canEditAllFunctions: false,
+    };
+    accessGateMock.mockImplementation(() => viewerGate);
+    vi.mocked(useAppStore).mockImplementation((selector) => selector({ ...baseStore } as never));
+    renderWorkspaceAt('/processes/p-ws/over-planning');
+    // The Upload <input> on the sidebar should be disabled, and the wrapping
+    // label should advertise read-only via aria-disabled.
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    expect(fileInput!.disabled).toBe(true);
+  });
+
+  it('keeps FilesSidebar Upload enabled when the user has editor scope (default mock)', () => {
+    vi.mocked(useAppStore).mockImplementation((selector) => selector({ ...baseStore } as never));
+    renderWorkspaceAt('/processes/p-ws/over-planning');
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    expect(fileInput!.disabled).toBe(false);
   });
 
   it('shows the draft restore banner when draft metadata is newer than the active file', () => {

--- a/apps/web/src/realtime/__tests__/useRealtime.test.ts
+++ b/apps/web/src/realtime/__tests__/useRealtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleEnvelope } from '../useRealtime';
+import { useAppStore } from '../../store/useAppStore';
+
+vi.mock('../../store/useAppStore', () => ({
+  useAppStore: {
+    getState: vi.fn(),
+  },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+describe('handleEnvelope', () => {
+  it('forces a latest-result refresh for the file mentioned by audit.completed', () => {
+    const hydrateLatestAuditResult = vi.fn();
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      processes: [
+        {
+          id: 'process-1',
+          displayCode: 'PRC-1',
+          files: [{ id: 'file-1', displayCode: 'FIL-1' }],
+          activeFileId: 'file-1',
+        },
+      ],
+      hydrateLatestAuditResult,
+    } as never);
+
+    handleEnvelope(
+      {
+        event: 'audit.completed',
+        processCode: 'PRC-1',
+        payload: { runCode: 'RUN-1', fileCode: 'FIL-1' },
+        actor: { code: 'USR-2', displayName: 'Other User' },
+      } as never,
+      'USR-1',
+      vi.fn(),
+      vi.fn(),
+      { current: undefined },
+    );
+
+    expect(hydrateLatestAuditResult).toHaveBeenCalledWith('process-1', 'file-1', { force: true });
+  });
+});

--- a/apps/web/src/realtime/useRealtime.ts
+++ b/apps/web/src/realtime/useRealtime.ts
@@ -104,7 +104,7 @@ export function useRealtime(
   return { members, connected, move };
 }
 
-function handleEnvelope(
+export function handleEnvelope(
   envelope: RealtimeEnvelope,
   selfCode: string | undefined,
   setMembers: React.Dispatch<React.SetStateAction<PresenceMember[]>>,
@@ -144,22 +144,25 @@ function handleEnvelope(
     case 'audit.completed': {
       if (isSelf) return;
       const actor = envelope.actor?.displayName ?? 'Someone';
-      const code =
-        (envelope.payload as { runCode?: string } | undefined)?.runCode ?? '';
+      const payload = envelope.payload as {
+        runCode?: string;
+        fileId?: string;
+        fileCode?: string;
+      } | undefined;
+      const code = payload?.runCode ?? '';
       toast(`${actor} ran an audit ${code}`.trim(), { icon: '🔎' });
-      // Refresh the active workspace file's audit result so viewers/editors
-      // viewing this process see the new findings without a manual reload.
-      // We don't have fileId on the payload, so we refresh whichever file the
-      // workspace is currently focused on for this process — if no workspace
-      // is open or the active file belongs to a different process, this is
-      // a cheap no-op (hydrate uses processId+fileId and matches the store).
+      // Refresh the exact file the other user ran so scoped viewers/editors
+      // see fresh findings immediately instead of staying pinned to a cached
+      // in-session result from before the rerun.
       const state = useAppStore.getState();
       const proc = state.processes.find(
         (p) => p.id === envelope.processCode || p.displayCode === envelope.processCode,
       );
-      const activeFileId = proc?.activeFileId;
-      if (proc && activeFileId) {
-        void state.hydrateLatestAuditResult(proc.id, activeFileId);
+      const targetFileId =
+        proc?.files.find((f) => f.id === payload?.fileId || f.displayCode === payload?.fileCode)?.id
+        ?? proc?.activeFileId;
+      if (proc && targetFileId) {
+        void state.hydrateLatestAuditResult(proc.id, targetFileId, { force: true });
       }
       return;
     }

--- a/apps/web/src/realtime/useRealtime.ts
+++ b/apps/web/src/realtime/useRealtime.ts
@@ -147,6 +147,20 @@ function handleEnvelope(
       const code =
         (envelope.payload as { runCode?: string } | undefined)?.runCode ?? '';
       toast(`${actor} ran an audit ${code}`.trim(), { icon: '🔎' });
+      // Refresh the active workspace file's audit result so viewers/editors
+      // viewing this process see the new findings without a manual reload.
+      // We don't have fileId on the payload, so we refresh whichever file the
+      // workspace is currently focused on for this process — if no workspace
+      // is open or the active file belongs to a different process, this is
+      // a cheap no-op (hydrate uses processId+fileId and matches the store).
+      const state = useAppStore.getState();
+      const proc = state.processes.find(
+        (p) => p.id === envelope.processCode || p.displayCode === envelope.processCode,
+      );
+      const activeFileId = proc?.activeFileId;
+      if (proc && activeFileId) {
+        void state.hydrateLatestAuditResult(proc.id, activeFileId);
+      }
       return;
     }
     case 'tracking.updated': {

--- a/apps/web/src/store/useAppStore.ts
+++ b/apps/web/src/store/useAppStore.ts
@@ -101,7 +101,7 @@ type AppStore = {
   // arrives on the Audit Results tab from a deep link (Escalation Center
   // "Open evidence", a bookmarked URL, a hard refresh, etc.) and the
   // in-session result was wiped by a navigation.
-  hydrateLatestAuditResult: (processId: string, fileId: string) => Promise<void>;
+  hydrateLatestAuditResult: (processId: string, fileId: string, opts?: { force?: boolean }) => Promise<void>;
   saveVersion: (processId: string, details: { versionName: string; notes: string }) => AuditProcess | undefined;
   // Overwrite the head version's result with the current audit run, preserving
   // the version name / notes / createdAt. Creates V1 if no version exists.
@@ -746,7 +746,7 @@ export const useAppStore = create<AppStore>()(
         set({ isAuditRunning: false, auditProgressText: '', auditRunKey: null });
       },
 
-      hydrateLatestAuditResult: async (processId, fileId) => {
+      hydrateLatestAuditResult: async (processId, fileId, opts) => {
         const process = get().processes.find((item) => item.id === processId || item.displayCode === processId);
         const file = process?.files.find((item) => item.id === fileId);
         if (!process || !file) return;
@@ -761,7 +761,7 @@ export const useAppStore = create<AppStore>()(
         // need to re-fetch — keep what runAudit produced (it has live
         // post-audit hooks like directory resolution applied).
         const existing = get().currentAuditResult;
-        if (existing && existing.fileId === fileId) return;
+        if (!opts?.force && existing && existing.fileId === fileId) return;
 
         try {
           const apiResult = await fetchLatestAuditRunForFile(processRef, fileDisplayCode);

--- a/packages/domain/src/findingsByEngine.ts
+++ b/packages/domain/src/findingsByEngine.ts
@@ -6,7 +6,45 @@ export type EngineFindingLine = {
   severity: string;
   ruleName: string;
   notes: string;
+  /** Optional issue identifier (e.g. tracking issue key). */
+  issueKey?: string;
+  /** Optional task name from the source row. */
+  taskName?: string;
+  /** Optional employee/resource name from the source row. */
+  employeeName?: string;
+  /** Optional country / region label. */
+  country?: string;
+  /** Engine-specific rich context — see EngineFindingDetail for fields. */
+  detail?: EngineFindingDetail;
 };
+
+/**
+ * Per-engine context stripped from `AuditIssue` rows so the email builder
+ * can emit a column set that actually explains the finding. Different
+ * engines surface different columns: e.g. master-data needs the missing
+ * field name, over-planning wants the offending months and threshold,
+ * function-rate / internal-cost-rate want the zero-month count.
+ */
+export interface EngineFindingDetail {
+  ruleCode: string;
+  ruleName: string;
+  ruleCategory: string;
+  severity: string;
+  reason: string | null;
+  thresholdLabel: string | null;
+  recommendedAction: string | null;
+  sheetName: string | null;
+  projectManager: string | null;
+  projectState: string | null;
+  effort: number | null;
+  /** Joined month labels (e.g. "Mar-2026, Apr-2026") for over-planning / rate engines. */
+  affectedMonths: string | null;
+  zeroMonthCount: number | null;
+  /** Master-data: the missing field's human label (e.g. "Project Industry"). */
+  missingFieldLabel: string | null;
+  /** Auditor-supplied URL for the project (e.g. BCS deep link). */
+  projectLink: string | null;
+}
 
 export function buildFindingsByEngineMarkdown(lines: EngineFindingLine[]): string {
   if (!lines.length) return '_No open findings._';
@@ -28,4 +66,246 @@ export function buildFindingsByEngineMarkdown(lines: EngineFindingLine[]): strin
     parts.push('');
   }
   return parts.join('\n').trim();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+type ColumnSpec<T> = {
+  header: string;
+  read: (row: T) => string;
+};
+
+const HTML_TABLE_STYLE =
+  'border-collapse:collapse;width:100%;font-family:Arial,Helvetica,sans-serif;border:1.5px solid #334155;table-layout:fixed;';
+const HTML_HEAD_STYLE =
+  'border:1px solid #334155;padding:8px 10px;font-size:12px;font-weight:700;background:#1e293b;color:#ffffff;text-align:left;letter-spacing:0.02em;';
+const HTML_CELL_STYLE =
+  'border:1px solid #cbd5e1;padding:8px 10px;font-size:13px;color:#0f172a;vertical-align:top;word-wrap:break-word;overflow-wrap:break-word;';
+const HTML_CELL_STYLE_ALT = HTML_CELL_STYLE + 'background:#f8fafc;';
+
+function dash(value: string | null | undefined): string {
+  const trimmed = (value ?? '').toString().trim();
+  return trimmed.length === 0 ? '—' : trimmed;
+}
+
+function clamp(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, Math.max(1, max - 1)).trimEnd() + '…';
+}
+
+/**
+ * Engine → column map. Each engine surfaces only the columns that explain
+ * its findings; values are clamped so wide free-text fields can't blow up
+ * the layout. `width` is a CSS percentage so the HTML grid stays even when
+ * the data is uneven. The optional `Project Link` column is appended only
+ * when at least one finding in the engine has a link supplied — otherwise
+ * the column is dropped so the table doesn't carry empty space.
+ */
+type EngineColumn = ColumnSpec<EngineFindingLine> & {
+  width: string;
+  /** Marks the column as a hyperlink in the HTML renderer. */
+  isLink?: boolean;
+};
+
+const PROJECT_LINK_COLUMN: EngineColumn = {
+  header: 'Project Link',
+  width: '20%',
+  isLink: true,
+  read: (r) => r.detail?.projectLink?.trim() || '',
+};
+
+function columnsForEngine(engineKey: string, hasProjectLink: boolean): EngineColumn[] {
+  const linkCol = hasProjectLink ? [PROJECT_LINK_COLUMN] : [];
+  switch (engineKey) {
+    case 'master-data':
+      return [
+        { header: '#', width: '4%', read: () => '' },
+        { header: 'Project ID', width: '14%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '26%' : '34%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'Missing Field', width: hasProjectLink ? '24%' : '32%', read: (r) => dash(r.detail?.missingFieldLabel ?? r.detail?.ruleName) },
+        { header: 'Severity', width: hasProjectLink ? '12%' : '16%', read: (r) => dash(r.detail?.severity) },
+        ...linkCol,
+      ];
+    case 'over-planning':
+      return [
+        { header: '#', width: '4%', read: () => '' },
+        { header: 'Project ID', width: '14%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '22%' : '28%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'Issue', width: hasProjectLink ? '15%' : '18%', read: (r) => dash(r.detail?.ruleName) },
+        { header: 'Affected Month(s)', width: hasProjectLink ? '15%' : '18%', read: (r) => dash(r.detail?.affectedMonths) },
+        { header: 'Effort / Threshold', width: hasProjectLink ? '12%' : '14%', read: (r) => dash(r.detail?.thresholdLabel ?? (r.detail?.effort != null ? `${r.detail.effort}` : '')) },
+        { header: 'Severity', width: '8%', read: (r) => dash(r.detail?.severity) },
+        ...linkCol,
+      ];
+    case 'missing-plan':
+      return [
+        { header: '#', width: '4%', read: () => '' },
+        { header: 'Project ID', width: '14%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '24%' : '32%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'State', width: hasProjectLink ? '14%' : '18%', read: (r) => dash(r.detail?.projectState) },
+        { header: 'Issue', width: hasProjectLink ? '24%' : '32%', read: (r) => dash(r.detail?.ruleName) },
+        ...linkCol,
+      ];
+    case 'function-rate':
+      return [
+        { header: '#', width: '4%', read: () => '' },
+        { header: 'Project ID', width: '12%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '16%' : '22%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'Resource', width: '14%', read: (r) => dash(r.detail?.projectManager) },
+        { header: 'Issue', width: hasProjectLink ? '12%' : '13%', read: (r) => dash(r.detail?.ruleName) },
+        { header: 'Affected Month(s)', width: hasProjectLink ? '14%' : '17%', read: (r) => dash(r.detail?.affectedMonths) },
+        { header: 'Zero Months', width: '11%', read: (r) => dash(r.detail?.zeroMonthCount != null ? String(r.detail.zeroMonthCount) : '') },
+        { header: 'Severity', width: hasProjectLink ? '7%' : '10%', read: (r) => dash(r.detail?.severity) },
+        ...linkCol,
+      ];
+    case 'internal-cost-rate':
+      return [
+        { header: '#', width: '4%', read: () => '' },
+        { header: 'Project ID', width: '12%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '16%' : '22%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'Resource', width: '14%', read: (r) => dash(r.detail?.projectManager) },
+        { header: 'Issue', width: hasProjectLink ? '12%' : '13%', read: (r) => dash(r.detail?.ruleName) },
+        { header: 'Affected Month(s)', width: hasProjectLink ? '14%' : '17%', read: (r) => dash(r.detail?.affectedMonths) },
+        { header: 'Zero Months', width: '11%', read: (r) => dash(r.detail?.zeroMonthCount != null ? String(r.detail.zeroMonthCount) : '') },
+        { header: 'Severity', width: hasProjectLink ? '7%' : '10%', read: (r) => dash(r.detail?.severity) },
+        ...linkCol,
+      ];
+    default:
+      return [
+        { header: '#', width: '5%', read: () => '' },
+        { header: 'Project ID', width: '15%', read: (r) => dash(r.projectNo) },
+        { header: 'Project Name', width: hasProjectLink ? '20%' : '25%', read: (r) => clamp(dash(r.projectName), 60) },
+        { header: 'Issue', width: '20%', read: (r) => dash(r.detail?.ruleName ?? r.ruleName) },
+        { header: 'Severity', width: '10%', read: (r) => dash(r.detail?.severity ?? r.severity) },
+        { header: 'Notes', width: hasProjectLink ? '15%' : '25%', read: (r) => clamp(dash(r.detail?.reason ?? r.notes), 80) },
+        ...linkCol,
+      ];
+  }
+}
+
+function shortDescriptionForEngine(engineKey: string): string {
+  switch (engineKey) {
+    case 'master-data':
+      return 'Required master-data fields are missing or contain placeholder values for the projects below. Please update the records so audits can complete.';
+    case 'over-planning':
+      return 'The following projects show monthly effort above the configured planning threshold. Please review and confirm or correct the planning entries.';
+    case 'missing-plan':
+      return 'The following projects have no planned effort recorded. Please add a plan or confirm the project should be inactive.';
+    case 'function-rate':
+      return 'External function rates are missing or recorded as zero for the months shown below. Please update the rate sheet.';
+    case 'internal-cost-rate':
+      return 'Internal cost rates are missing or recorded as zero for the months shown below. Please confirm or update the cost entries.';
+    default:
+      return 'Open findings for the projects listed below need attention.';
+  }
+}
+
+/**
+ * Render the findings as a styled HTML table grouped by engine, with each
+ * engine getting the columns that actually explain its findings (set in
+ * `columnsForEngine`). Inline styles are deliberately verbose so the
+ * markup survives the trip through Outlook / Gmail / Teams web (none of
+ * them honour <style> blocks reliably).
+ */
+export function buildFindingsByEngineHtmlTable(lines: EngineFindingLine[]): string {
+  if (!lines.length) {
+    return '<p style="margin:0;color:#475569;font-style:italic;">No open findings.</p>';
+  }
+  const byEngine = new Map<string, { label: string; rows: EngineFindingLine[] }>();
+  for (const line of lines) {
+    const key = line.engineKey;
+    if (!byEngine.has(key)) byEngine.set(key, { label: line.engineLabel, rows: [] });
+    byEngine.get(key)!.rows.push(line);
+  }
+
+  const blocks: string[] = [];
+  for (const [engineKey, { label, rows }] of byEngine) {
+    const hasProjectLink = rows.some((r) => Boolean(r.detail?.projectLink?.trim()));
+    const columns = columnsForEngine(engineKey, hasProjectLink);
+    const description = shortDescriptionForEngine(engineKey);
+    const colgroup =
+      `<colgroup>` +
+      columns.map((c) => `<col style="width:${c.width};">`).join('') +
+      `</colgroup>`;
+    const headerCells = columns
+      .map((c) => `<th style="${HTML_HEAD_STYLE}">${escapeHtml(c.header)}</th>`)
+      .join('');
+    const bodyRows = rows
+      .map((r, idx) => {
+        const cellStyle = idx % 2 === 0 ? HTML_CELL_STYLE : HTML_CELL_STYLE_ALT;
+        const cells = columns
+          .map((c, cIdx) => {
+            if (cIdx === 0) {
+              return `<td style="${cellStyle}">${idx + 1}</td>`;
+            }
+            const value = c.read(r);
+            if (c.isLink) {
+              const url = value.trim();
+              if (!url) return `<td style="${cellStyle}">—</td>`;
+              const safeUrl = escapeHtml(url);
+              return (
+                `<td style="${cellStyle}">` +
+                `<a href="${safeUrl}" style="color:#1d4ed8;text-decoration:underline;word-break:break-all;" target="_blank" rel="noopener noreferrer">Open project</a>` +
+                `</td>`
+              );
+            }
+            return `<td style="${cellStyle}">${escapeHtml(value)}</td>`;
+          })
+          .join('');
+        return `<tr>${cells}</tr>`;
+      })
+      .join('');
+    blocks.push(
+      `<div style="margin:0 0 22px 0;">` +
+        `<div style="font-size:14px;font-weight:700;color:#0f172a;margin:0 0 4px 0;">` +
+        `${escapeHtml(label)} <span style="color:#64748b;font-weight:400;">(${rows.length} finding${rows.length === 1 ? '' : 's'})</span>` +
+        `</div>` +
+        `<div style="font-size:12px;color:#475569;margin:0 0 10px 0;line-height:1.45;">${escapeHtml(description)}</div>` +
+        `<table cellpadding="0" cellspacing="0" border="1" style="${HTML_TABLE_STYLE}">` +
+        colgroup +
+        `<thead><tr>${headerCells}</tr></thead>` +
+        `<tbody>${bodyRows}</tbody>` +
+        `</table></div>`,
+    );
+  }
+  return blocks.join('');
+}
+
+/**
+ * Plain-text version, used by the mailto / Teams handoff. ASCII pipe
+ * tables are unreliable across mail clients (proportional fonts mangle
+ * them), so we emit a clean numbered breakdown per finding instead.
+ */
+export function buildFindingsByEngineTextTable(lines: EngineFindingLine[]): string {
+  if (!lines.length) return 'No open findings.';
+  const byEngine = new Map<string, { label: string; rows: EngineFindingLine[] }>();
+  for (const line of lines) {
+    const key = line.engineKey;
+    if (!byEngine.has(key)) byEngine.set(key, { label: line.engineLabel, rows: [] });
+    byEngine.get(key)!.rows.push(line);
+  }
+  const blocks: string[] = [];
+  for (const [engineKey, { label, rows }] of byEngine) {
+    const hasProjectLink = rows.some((r) => Boolean(r.detail?.projectLink?.trim()));
+    const columns = columnsForEngine(engineKey, hasProjectLink).filter((c) => c.header !== '#');
+    blocks.push(`${label} (${rows.length})`);
+    blocks.push(shortDescriptionForEngine(engineKey));
+    blocks.push('');
+    rows.forEach((r, idx) => {
+      blocks.push(`${idx + 1}. ${dash(r.projectNo)} — ${dash(r.projectName)}`);
+      for (const c of columns.slice(2)) {
+        const v = c.read(r);
+        if (v && v !== '—') blocks.push(`   ${c.header}: ${v}`);
+      }
+      blocks.push('');
+    });
+  }
+  return blocks.join('\n').trim();
 }


### PR DESCRIPTION
Render escalation Compose preview as a structured per-engine email

The Compose tab in the Escalation Center showed "(empty)" for Subject
and Body whenever no template was selected, and the only finding context
the manager ever saw was a markdown bullet list of project numbers.
Auditors had to hand-edit every email before sending. This commit
replaces the preview with a fully resolved, professionally formatted
email driven by the row's findings.

## What the manager now sees
- A real subject line (e.g. `Action Required — {processName}: Open
  Findings (6)`) instead of `Escalation`.
- Greeting + Quality Governance intro paragraph + signature block.
- One styled HTML table per engine with full borders, dark header band,
  zebra rows, fixed column widths, and engine-specific columns:
  - **Master Data** — Project ID · Project Name · Missing Field ·
    Severity · *(optional Project Link)*
  - **Over Planning** — Project ID · Project Name · Issue · Affected
    Month(s) · Effort / Threshold · Severity · *(optional Project Link)*
  - **Missing Plan** — Project ID · Project Name · State · Issue ·
    *(optional Project Link)*
  - **Function Rate / Internal Cost Rate** — Project ID · Project Name ·
    Resource · Issue · Affected Month(s) · Zero Months · Severity ·
    *(optional Project Link)*
- A short one-liner under each engine header explaining what's being
  asked (e.g. "External function rates are missing or recorded as zero
  for the months shown below…").
- Plain-text body for the mailto: / Teams handoff is now a clean
  numbered breakdown per finding (no more pipe-character ASCII tables
  that proportional fonts mangle).

## What the auditor gets in the Composer
- New collapsible **Project links** section between the Template / Due
  Date row and the Findings list. Auto-discovers every unique
  `projectNo` across the row's engine findings and renders one
  `<input type="url">` per project, with a `(filled / total)` counter
  on the toggle.
- Project Link is the only conditional column — it appears in the
  preview / outgoing email only after at least one valid `http(s)` URL
  has been entered. Empty or non-URL entries are stripped before they
  reach the server.
- Links flow through preview, draft autosave, and send, so a refresh /
  reopen doesn't lose them.

## Architecture
- `packages/domain/src/findingsByEngine.ts`
  - New `EngineFindingDetail` carries rich per-finding context
    (`ruleName`, `severity`, `reason`, `thresholdLabel`,
    `recommendedAction`, `projectManager`, `projectState`, `effort`,
    `affectedMonths`, `zeroMonthCount`, `missingFieldLabel`,
    `projectLink`).
  - `columnsForEngine(engineKey, hasProjectLink)` is the single source
    of truth for which columns each engine renders.
  - `buildFindingsByEngineHtmlTable()` and
    `buildFindingsByEngineTextTable()` both consume that map, so HTML
    preview and plain-text body always agree on the column set.

- `apps/api/src/tracking-compose/tracking-compose.service.ts`
  - `resolveContent()` returns `{ subject, text, html, channel,
    managerEmail }`. `text` (used by mailto / Teams handoff) is
    unchanged in contract; `html` is new and used by the preview.
  - When no template / draft / override supplies a subject or body,
    falls back to bundled professional defaults instead of the old
    terse `Escalation` stub.
  - Every `issueKey` in scope is loaded once from `AuditIssue`
    (process-scoped to prevent cross-process leaks), joined to
    `AUDIT_RULES_BY_CODE` for rule names / categories, and attached to
    the engine line.
  - Wires `{dueDate}` slot (was referenced in the UI label but never
    substituted) and humanises `{slaDeadline}` / `{auditRunDate}`.
  - New `substituteHtml()` performs HTML-aware token substitution:
    literal template text is escaped and `\n → <br>`, while slot HTML
    (the findings table) is inserted verbatim.
  - `ComposeDraftPayload.projectLinks?: Record<string, string>` accepted
    from override / draft; only `http(s)` URLs survive validation.

- `apps/web/src/components/escalations/PreviewPane.tsx`
  - New optional `bodyHtml` prop. When present, renders the styled HTML
    email; otherwise falls back to `<pre>` plain text. Server escapes
    every dynamic field, so `dangerouslySetInnerHTML` is safe here.

- `apps/web/src/components/escalations/Composer.tsx` &
  `apps/web/src/lib/api/trackingComposeApi.ts`
  - Plumbed `bodyHtml` and `projectLinks` through the preview / draft /
    send / autosave-on-leave payloads and into `PreviewPane`.
  - Added the collapsible Project Links section with per-project URL
    inputs and a `(filled / total)` counter.

## Behaviour notes
- Existing seeded templates still work — the HTML renderer escapes
  literal template prose and substitutes the `{findingsByEngine}` slot
  with the rich HTML table, so any template body that previously
  substituted markdown now renders as a real grid.
- The `mailto:` and Teams deep-link handoff still uses the plain-text
  `body` (HTML in `mailto:` isn't reliable across clients), so nothing
  in the existing send pipeline changes.
- `Project Manager` column was removed from the Master Data /
  Over Planning / Missing Plan tables on auditor request. The
  `Resource` column on the rate engines is preserved — it's a distinct
  concept (the priced / costed resource, not the project manager).

## Test plan
- [x] `npm run typecheck` clean across `@ses/domain`, `@ses/api`,
      `@ses/web`.
- [x] `npm run test --workspace @ses/domain` — 148 / 148 pass.
- [ ] Open an escalation finding with mixed engines (master-data +
      over-planning + a rate engine) and confirm each engine renders
      its own columned table with correct headers.
- [ ] Verify `Project Link` column is hidden until a URL is entered,
      then appears as `Open project` for matching `projectNo` rows only.
- [ ] Click `Outlook` and confirm the prefilled mail body matches the
      plain-text version (numbered breakdown, no pipe ASCII).
- [ ] Refresh / reopen the drawer — confirm that filled project links
      persist (autosave + draft round-trip).
- [ ] Confirm the existing seeded templates still substitute correctly
      in HTML preview (table renders, surrounding prose is preserved
      and HTML-escaped).
